### PR TITLE
chore(marketing): polish hero, features, and privacy copy

### DIFF
--- a/apps/marketing/src/components/Features.astro
+++ b/apps/marketing/src/components/Features.astro
@@ -8,17 +8,17 @@ const features: Feature[] = [
   {
     title: 'Fixes search results',
     body:
-      'Google, Bing, DuckDuckGo, and YouTube get a language hint on every query so Cyrillic searches stop surfacing Russian-language results by default.',
+      'Google, Bing, DuckDuckGo, and YouTube get a language hint on every search, so results come back in your preferred language — no more Ukrainian queries defaulting to Russian.',
   },
   {
     title: 'Detects misrouted sites',
     body:
-      'When a Ukrainian-language site serves you Russian on a new page, Movar notices and offers a one-click switch using the site’s own language picker.',
+      'When a Ukrainian-language site routes you to Russian on a new page, Movar notices and auto-switches you back through the site’s own language picker.',
   },
   {
     title: 'Stays out of the way',
     body:
-      'Static URL rewrites only — Movar never inspects request bodies, never injects ads, and never talks to a remote server.',
+      'Movar only rewrites outgoing URLs and request headers — it never inspects request bodies, never injects ads, and never talks to a remote server.',
   },
   {
     title: 'Nothing leaves your device',
@@ -34,7 +34,7 @@ const features: Feature[] = [
       How Movar works
     </h2>
     <p class="mt-3 max-w-2xl text-ink-soft">
-      Four behaviours, all running silently in the background once you pick a preferred language.
+      All running silently in the background once you pick a preferred language.
     </p>
 
     <div class="mt-10 grid gap-6 sm:grid-cols-2">

--- a/apps/marketing/src/components/Hero.astro
+++ b/apps/marketing/src/components/Hero.astro
@@ -20,7 +20,7 @@ import DownloadButtons from './DownloadButtons.astro';
 
     <p class="mx-auto mt-6 max-w-2xl text-lg text-ink-soft sm:text-xl">
       Movar nudges Google, Bing, DuckDuckGo, and YouTube to match your language &mdash;
-      automatically, on every site, without leaving your device.
+      and quietly auto-switches sites that try to serve you the wrong one. All on-device.
     </p>
 
     <div class="mt-10">
@@ -28,7 +28,7 @@ import DownloadButtons from './DownloadButtons.astro';
     </div>
 
     <p class="mt-4 text-xs text-ink-faint">
-      Available for Chrome, Edge, and Firefox.
+      Coming soon to Chrome, Edge, and Firefox.
     </p>
   </div>
 </section>

--- a/apps/marketing/src/pages/privacy.astro
+++ b/apps/marketing/src/pages/privacy.astro
@@ -26,19 +26,24 @@ const lastUpdated = '27 May 2026';
 
       <section class="mt-12 space-y-4">
         <h2 class="font-display text-2xl font-bold text-ink-strong">What Movar stores</h2>
-        <p>
-          Movar uses the browser's built-in <code class="rounded bg-surface-2 px-1.5 py-0.5 text-sm">storage.local</code> API
-          to remember:
-        </p>
+        <p>Movar uses your browser's extension-storage APIs to remember:</p>
         <ul class="list-disc space-y-1 pl-6 text-ink-soft">
           <li>your preferred language (e.g. Ukrainian, English),</li>
           <li>any sites you've exempted from corrections,</li>
           <li>whether Movar is currently paused,</li>
-          <li>a lifetime counter of how many corrections Movar has applied.</li>
+          <li>
+            a rolling log of the last 1,000 corrections — each entry holds a timestamp, the site's
+            domain, which mechanism applied, and the from/to language. The popup uses this to show
+            "corrections today" and which languages it has hidden on the current tab.
+          </li>
         </ul>
         <p class="text-ink-soft">
-          This data lives in your browser, in the same place where your bookmarks and history are
-          stored. It is never synced to any server, including ours — because there is no server.
+          Your preferences live in
+          <code class="rounded bg-surface-2 px-1.5 py-0.5 text-sm">storage.sync</code>, which means
+          your browser's own sync feature (Chrome Sync, Firefox Sync) can carry them between your
+          own devices. The pause state and the corrections log live in
+          <code class="rounded bg-surface-2 px-1.5 py-0.5 text-sm">storage.local</code> and stay on
+          this device. None of it is ever sent to a server of ours — because there is no server.
         </p>
       </section>
 
@@ -46,10 +51,13 @@ const lastUpdated = '27 May 2026';
         <h2 class="font-display text-2xl font-bold text-ink-strong">What Movar does <em>not</em> store</h2>
         <ul class="list-disc space-y-1 pl-6 text-ink-soft">
           <li>your search queries,</li>
-          <li>your browsing history,</li>
+          <li>
+            your browsing history (the corrections log records <em>which domains</em> triggered a
+            correction, never URLs, paths, or what was on the page),
+          </li>
           <li>page contents,</li>
           <li>any identifier that could distinguish you from another user,</li>
-          <li>any kind of analytics, telemetry, or usage metric.</li>
+          <li>any analytics or telemetry transmitted off-device.</li>
         </ul>
       </section>
 
@@ -70,7 +78,10 @@ const lastUpdated = '27 May 2026';
           </div>
           <div>
             <dt class="font-semibold text-ink-strong">alarms</dt>
-            <dd>Reset the daily "corrections today" counter shown in the popup.</dd>
+            <dd>
+              Wake the background script when a timed pause expires (e.g. "pause for 30 minutes")
+              so Movar can resume on its own.
+            </dd>
           </div>
           <div>
             <dt class="font-semibold text-ink-strong">tabs</dt>


### PR DESCRIPTION
## Summary
- Tighten Hero subhead; switch "Available for Chrome, Edge, and Firefox" to "Coming soon" until the v1 listings actually go live.
- Rewrite the four Features cards for clarity; drop the stale "Four behaviours" intro.
- Update the privacy page to describe the real storage layout (`storage.sync` for prefs, `storage.local` for the corrections log) and the correct purpose of the `alarms` permission.

Out-of-scope changes that have been sitting in the working tree — separated from the v1 ticket work so the per-ticket PRs stay focused.

## Test plan
- [ ] Visit https://movar.fyi after deploy and spot-check Hero, Features, and Privacy copy
- [ ] Confirm typecheck + lint already pass (lefthook ran them on commit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)