### PR TITLE
fix(extension): show real manifest version in options header

### DIFF
--- a/apps/extension/src/entrypoints/options/App.tsx
+++ b/apps/extension/src/entrypoints/options/App.tsx
@@ -1,7 +1,10 @@
 import { useEffect, useState } from 'react';
+import { browser } from 'wxt/browser';
 import { defaultSettings, type LanguageCode, type MovarSettings } from '@movar/shared';
 import { getSettings } from '../../lib/settings';
 import { BrandMark } from '../../components/BrandMark';
+
+const version = browser.runtime.getManifest().version;
 
 function displayLanguage(code: LanguageCode, locale?: string): string {
   try {
@@ -35,7 +38,7 @@ export function App() {
               Movar
             </span>
             <span className="text-ink-faint ml-1 font-mono text-[10.5px] font-normal tracking-wide">
-              v0.1.0
+              v{version}
             </span>
           </div>
           <nav className="flex gap-1">


### PR DESCRIPTION
## Summary
Ticket #1 of the v1 release punch list.

The options page header was hard-coded to `v0.1.0` while the manifest already reads `1.0.0`. Read the version from `browser.runtime.getManifest().version` so the header always matches the shipped manifest — no more drift on future bumps.

## Test plan
- [ ] Load the unpacked extension in Chrome, open the options page, confirm header shows `v1.0.0`
- [ ] Bump `apps/extension/package.json` version locally, rebuild, confirm header updates without touching App.tsx

🤖 Generated with [Claude Code](https://claude.com/claude-code)