### PR TITLE
chore(extension): remove Activity dashboard placeholder

### DIFF
--- a/apps/extension/src/entrypoints/options/App.tsx
+++ b/apps/extension/src/entrypoints/options/App.tsx
@@ -85,16 +85,6 @@ export function App() {
                 );
               })}
             </ol>
-
-            <h3 className="font-display text-ink-strong mt-10 mb-1.5 text-[22px] font-bold tracking-tight">
-              Activity
-            </h3>
-            <p className="text-ink-soft mb-6 text-sm">
-              Corrections over time, top offenders, breakdown by mechanism.
-            </p>
-            <div className="border-border-strong text-ink-faint rounded-lg border border-dashed px-6 py-12 text-center text-sm">
-              Usefulness dashboard (Tremor) — coming soon
-            </div>
           </section>
 
           <aside className="border-border text-ink-soft border-l pt-1 pl-4 text-[12.5px] leading-[1.6]">


### PR DESCRIPTION
## Summary
Ticket #2 of the v1 release punch list.

Drop the "Usefulness dashboard (Tremor) — coming soon" block from the options page. Advertising an unbuilt feature is a credibility drag on store-listing screenshots. The real Tremor dashboard ships in v1.1.

The popup already surfaces "corrections today" via the existing events log, so users still have a basic signal — just not a chart.

## Test plan
- [ ] Load the unpacked extension, open the options page, confirm only "Language priority" + the right-side "How priority works" aside render

🤖 Generated with [Claude Code](https://claude.com/claude-code)