### PR TITLE
feat: add feedback links in popup, options, and marketing footer

### DIFF
--- a/apps/extension/src/entrypoints/options/App.tsx
+++ b/apps/extension/src/entrypoints/options/App.tsx
@@ -1,6 +1,11 @@
 import { useEffect, useState } from 'react';
 import { browser } from 'wxt/browser';
-import { defaultSettings, type LanguageCode, type MovarSettings } from '@movar/shared';
+import {
+  defaultSettings,
+  FEEDBACK_URL,
+  type LanguageCode,
+  type MovarSettings,
+} from '@movar/shared';
 import { getSettings } from '../../lib/settings';
 import { BrandMark } from '../../components/BrandMark';
 
@@ -100,6 +105,12 @@ export function App() {
           </aside>
         </div>
       </div>
+
+      <footer className="text-ink-faint mx-auto mt-6 max-w-3xl px-1 text-center text-[12px]">
+        <a href={FEEDBACK_URL} className="hover:text-ink-strong transition-colors">
+          Send feedback
+        </a>
+      </footer>
     </main>
   );
 }

--- a/apps/extension/src/entrypoints/popup/App.tsx
+++ b/apps/extension/src/entrypoints/popup/App.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useState } from 'react';
 import { browser } from 'wxt/browser';
 import {
   defaultSettings,
+  FEEDBACK_URL,
   type HiddenSummary,
   type MovarSettings,
   type PauseDuration,
@@ -95,6 +96,12 @@ export function App() {
         onPause={(duration) => void handlePause(duration)}
         onResume={() => void handleResume()}
       />
+
+      <footer className="border-border text-ink-faint border-t px-[18px] py-3 text-[11.5px]">
+        <a href={FEEDBACK_URL} className="hover:text-ink-strong transition-colors">
+          Send feedback
+        </a>
+      </footer>
     </div>
   );
 }

--- a/apps/marketing/package.json
+++ b/apps/marketing/package.json
@@ -11,6 +11,7 @@
     "lint": "eslint ."
   },
   "dependencies": {
+    "@movar/shared": "workspace:*",
     "astro": "^5.0.0"
   },
   "devDependencies": {

--- a/apps/marketing/src/components/Footer.astro
+++ b/apps/marketing/src/components/Footer.astro
@@ -1,4 +1,6 @@
 ---
+import { FEEDBACK_URL } from '@movar/shared';
+
 const year = new Date().getFullYear();
 ---
 
@@ -14,6 +16,7 @@ const year = new Date().getFullYear();
     <nav class="flex items-center gap-5">
       <a href="/privacy" class="hover:text-ink-strong transition">Privacy</a>
       <a href="/#download" class="hover:text-ink-strong transition">Download</a>
+      <a href={FEEDBACK_URL} class="hover:text-ink-strong transition">Feedback</a>
     </nav>
   </div>
 </footer>

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,5 +1,8 @@
 /** Movar shared types, defaults, and constants. */
 
+/** Where users can send feedback. Used by the popup, options page, and marketing site. */
+export const FEEDBACK_URL = 'mailto:feedback@movar.fyi?subject=Movar%20feedback';
+
 /** ISO 639-1 language code, e.g. 'uk', 'en', 'ru'. */
 export type LanguageCode = string;
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -123,6 +123,9 @@ importers:
 
   apps/marketing:
     dependencies:
+      '@movar/shared':
+        specifier: workspace:*
+        version: link:../../packages/shared
       astro:
         specifier: ^5.0.0
         version: 5.18.1(@types/node@25.9.1)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.60.4)(tsx@4.22.3)(typescript@6.0.3)(yaml@2.9.0)


### PR DESCRIPTION
## Summary
Ticket #3 of the v1 release punch list.

Users have no way to send feedback today. This adds a "Send feedback" link in all three surfaces, all pointing at `mailto:feedback@movar.fyi?subject=Movar%20feedback`:

- **popup** — new footer row below pause controls
- **options page** — centred link in a footer below the main card
- **marketing site** — `Feedback` link in the existing footer nav

The URL lives in one place: `FEEDBACK_URL` in `@movar/shared`. The marketing app now depends on `@movar/shared` so all three surfaces can't drift.

## Prerequisite
- [ ] Confirm `feedback@movar.fyi` is wired up in Cloudflare Email Routing before publishing the store listings. Without that, the mailto bounces.

## Test plan
- [ ] Click "Send feedback" in the popup → opens default mail client with To and Subject populated
- [ ] Same in the options page
- [ ] Same on https://movar.fyi after deploy
- [ ] Send a test email — confirm it arrives

🤖 Generated with [Claude Code](https://claude.com/claude-code)