### PR TITLE
feat(extension): split contentModification toggle from enabled, default OFF

### DIFF
--- a/apps/extension/src/entrypoints/content.ts
+++ b/apps/extension/src/entrypoints/content.ts
@@ -305,8 +305,10 @@ async function applyOnce(settings: MovarSettings): Promise<boolean> {
 
   if (await attemptLanguageSwitch(settings, rule, pageLang, target)) return true;
 
-  await filterAndRecordPickers(settings, pageLang, target);
-  await filterAndRecordContent(settings, pageLang, target);
+  if (settings.contentModification) {
+    await filterAndRecordPickers(settings, pageLang, target);
+    await filterAndRecordContent(settings, pageLang, target);
+  }
 
   return false;
 }

--- a/apps/extension/src/entrypoints/popup/App.tsx
+++ b/apps/extension/src/entrypoints/popup/App.tsx
@@ -86,9 +86,9 @@ export function App() {
         onToggleEnabled={() => void toggleEnabled()}
       />
 
-      {hidden === null ? null : (
+      {hidden !== null && settings.contentModification ? (
         <HiddenPanel hidden={hidden} onRestore={() => void handleRestore()} />
-      )}
+      ) : null}
 
       <PauseControls
         pause={pause}

--- a/apps/extension/src/lib/settings.ts
+++ b/apps/extension/src/lib/settings.ts
@@ -5,7 +5,9 @@ const SETTINGS_KEY = 'settings';
 
 export async function getSettings(): Promise<MovarSettings> {
   const stored = await browser.storage.sync.get(SETTINGS_KEY);
-  return (stored[SETTINGS_KEY] as MovarSettings | undefined) ?? defaultSettings;
+  // Merge with defaults so keys added in newer versions (e.g. contentModification)
+  // resolve to their default for installs upgraded from older schemas.
+  return { ...defaultSettings, ...(stored[SETTINGS_KEY] as Partial<MovarSettings> | undefined) };
 }
 
 export async function setSettings(next: MovarSettings): Promise<void> {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "publint": "pnpm --workspace-concurrency=1 --filter @movar/shared --filter @movar/rules --filter @movar/lang-detect exec publint",
     "validate": "pnpm typecheck && pnpm lint && pnpm test && pnpm publint",
     "metrics": "mkdir -p .metrics; fallow --format markdown --score --save-snapshot > .metrics/fallow.md; fallow --format json --score > .metrics/fallow.json; tsx scripts/fallow-targets.mts",
-    "metrics:audit": "fallow audit --base main",
+    "metrics:audit": "fallow audit --base origin/main",
     "metrics:targets": "tsx scripts/fallow-targets.mts",
     "metrics:baseline": "fallow --save-regression-baseline .fallow/regression-baseline.json",
     "metrics:check": "fallow --fail-on-regression --tolerance 0 --regression-baseline .fallow/regression-baseline.json",

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -11,10 +11,16 @@ export interface MovarSettings {
   enabled: boolean;
   /** Ordered language priority; the first available language wins. */
   priority: LanguageCode[];
-  /** Languages to strip from on-site language switchers. */
+  /** Languages to strip from on-site language switchers (only when contentModification is on). */
   blocked: LanguageCode[];
   /** Domains where Movar takes no action. */
   allowlist: string[];
+  /**
+   * Allow Movar to modify page DOM: hide blocked-language entries in
+   * on-site language pickers and blur content cards in a blocked language.
+   * Off by default — the safer baseline ships only header/URL-level switching.
+   */
+  contentModification: boolean;
 }
 
 export const defaultSettings: MovarSettings = {
@@ -22,6 +28,7 @@ export const defaultSettings: MovarSettings = {
   priority: ['uk', 'en'],
   blocked: ['ru'],
   allowlist: [],
+  contentModification: false,
 };
 
 export type CorrectionMechanism =


### PR DESCRIPTION
## Summary
Ticket #4 of the v1 release punch list.

The single `enabled` flag conflated two very different behaviours:

- **Language switching** — header rewrites (DNR) and on-site redirects (cookie/localStorage/picker click). Doesn't change page DOM.
- **Content modification** — hides blocked-language entries inside on-site language pickers and blurs content cards in a blocked language (YouTube etc.). Visibly mutates the page.

Shipping the second one on-by-default to first-time users is a credibility risk: pages can subtly change in ways the user didn't ask for. v1 should ship the safer baseline.

### Changes
- Add `contentModification: boolean` to `MovarSettings`, default `false`.
- Gate `filterAndRecordPickers` + `filterAndRecordContent` in `content.ts` on the new flag. `attemptLanguageSwitch` (URL redirects) still responds to `enabled` only.
- Hide `HiddenPanel` in the popup when `contentModification` is off so users don't see an irrelevant "On this page / Nothing hidden here" block.
- `getSettings()` now merges stored with defaults so existing installs whose stored payload pre-dates the new key resolve it to `false`. Same pattern handles any future settings additions.

DNR header rewrites in `dnr.ts` / `background.ts` are untouched — they already gated on `enabled`, which is still the right knob for them.

### Note: this branch also includes a piggy-backed CI fix
This branch was already present on origin from a prior session with one commit:

> `fix(ci): use origin/main as fallow audit base` — \`actions/checkout\` on a PR doesn't create a local \`main\` branch, so \`fallow audit --base main\` failed with \`unknown revision\`. Use \`origin/main\` instead.

It's unrelated to ticket #4 but ships in this PR. Splitting it would require a force-push.

### Follow-up
- Ticket #5 (options page editable) will expose a toggle for \`contentModification\` in the UI.

## Test plan
- [ ] Fresh install in Chrome — confirm Movar still switches a Russian-default page to UA (URL/header path), but the YouTube card-blur and picker-item-hiding don't happen
- [ ] Manually set \`contentModification: true\` via the options page (after ticket #5 lands) — confirm card-blur and picker-hide return
- [ ] Existing install with old settings — confirm \`contentModification\` reads as \`false\` and popup HiddenPanel disappears
- [ ] CI: confirm \`fallow audit\` step passes on this PR (validates the piggy-backed fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)