### PR TITLE
feat(marketing): add named-site examples section

### DIFF
--- a/apps/extension/src/entrypoints/options/App.tsx
+++ b/apps/extension/src/entrypoints/options/App.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState, type FormEvent } from 'react';
 import { browser } from 'wxt/browser';
 import {
   defaultSettings,
@@ -6,10 +6,26 @@ import {
   type LanguageCode,
   type MovarSettings,
 } from '@movar/shared';
-import { getSettings } from '../../lib/settings';
+import { getSettings, setSettings as persistSettings } from '../../lib/settings';
 import { BrandMark } from '../../components/BrandMark';
 
 const version = browser.runtime.getManifest().version;
+
+/**
+ * Catalog of languages users can pick from in either list. Mirrors the
+ * "Preferred-language options" list in apps/extension/STORE-LISTING.md —
+ * keep them in sync when adding support for a new language.
+ */
+const SUPPORTED_LANGUAGES: readonly LanguageCode[] = [
+  'uk',
+  'en',
+  'de',
+  'fr',
+  'es',
+  'it',
+  'pl',
+  'ru',
+];
 
 function displayLanguage(code: LanguageCode, locale?: string): string {
   try {
@@ -24,14 +40,96 @@ function flagLetter(code: LanguageCode): string {
   return displayLanguage(code, code).charAt(0).toUpperCase();
 }
 
+/** Strip protocol, path, and port from whatever the user typed. */
+function normaliseDomain(input: string): string {
+  return input
+    .trim()
+    .toLowerCase()
+    .replace(/^https?:\/\//, '')
+    .replace(/^www\./, '')
+    .replace(/[/:].*$/, '');
+}
+
+const DOMAIN_PATTERN = /^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)+$/i;
+
 export function App() {
   const [settings, setSettings] = useState<MovarSettings>(defaultSettings);
+  const [domainDraft, setDomainDraft] = useState('');
+  const [domainError, setDomainError] = useState<string | null>(null);
 
   useEffect(() => {
     void (async () => {
       setSettings(await getSettings());
     })();
   }, []);
+
+  const update = (next: MovarSettings): void => {
+    setSettings(next);
+    void persistSettings(next);
+  };
+
+  const priorityAddable = useMemo(
+    () => SUPPORTED_LANGUAGES.filter((c) => !settings.priority.includes(c)),
+    [settings.priority],
+  );
+
+  const blockedAddable = useMemo(
+    () => SUPPORTED_LANGUAGES.filter((c) => !settings.blocked.includes(c)),
+    [settings.blocked],
+  );
+
+  const movePriority = (from: number, to: number): void => {
+    if (to < 0 || to >= settings.priority.length) return;
+    const next = [...settings.priority];
+    const [item] = next.splice(from, 1);
+    if (item === undefined) return;
+    next.splice(to, 0, item);
+    update({ ...settings, priority: next });
+  };
+
+  const removePriority = (code: LanguageCode): void => {
+    if (settings.priority.length <= 1) return;
+    update({ ...settings, priority: settings.priority.filter((c) => c !== code) });
+  };
+
+  const addPriority = (code: LanguageCode): void => {
+    if (!code || settings.priority.includes(code)) return;
+    update({ ...settings, priority: [...settings.priority, code] });
+  };
+
+  const removeBlocked = (code: LanguageCode): void => {
+    update({ ...settings, blocked: settings.blocked.filter((c) => c !== code) });
+  };
+
+  const addBlocked = (code: LanguageCode): void => {
+    if (!code || settings.blocked.includes(code)) return;
+    update({ ...settings, blocked: [...settings.blocked, code] });
+  };
+
+  const addDomain = (event: FormEvent<HTMLFormElement>): void => {
+    event.preventDefault();
+    const domain = normaliseDomain(domainDraft);
+    if (!domain) return;
+    if (!DOMAIN_PATTERN.test(domain)) {
+      setDomainError('Enter a domain like example.com');
+      return;
+    }
+    if (settings.allowlist.includes(domain)) {
+      setDomainError('Already on the list');
+      return;
+    }
+    update({ ...settings, allowlist: [...settings.allowlist, domain] });
+    setDomainDraft('');
+    setDomainError(null);
+  };
+
+  const removeDomain = (domain: string): void => {
+    update({ ...settings, allowlist: settings.allowlist.filter((d) => d !== domain) });
+  };
+
+  const toggleContentModification = (): void => {
+    update({ ...settings, contentModification: !settings.contentModification });
+  };
 
   return (
     <main className="bg-bg text-ink-strong min-h-screen px-6 py-10 font-sans">
@@ -54,54 +152,220 @@ export function App() {
         </header>
 
         <div className="grid grid-cols-[1fr_240px] gap-14 px-7 py-9">
-          <section>
-            <h3 className="font-display text-ink-strong mb-1.5 text-[22px] font-bold tracking-tight">
-              Language priority
-            </h3>
-            <p className="text-ink-soft mb-6 text-sm">
-              Movar will request each site in this order; the first available wins.
-            </p>
+          <div className="space-y-10">
+            <section>
+              <h3 className="font-display text-ink-strong mb-1.5 text-[22px] font-bold tracking-tight">
+                Language priority
+              </h3>
+              <p className="text-ink-soft mb-6 text-sm">
+                Movar will request each site in this order; the first available wins.
+              </p>
 
-            <ol className="flex max-w-md flex-col gap-2">
-              {settings.priority.map((code, i) => {
-                const primary = i === 0;
-                return (
-                  <li
-                    key={code}
-                    className={`flex items-center gap-3 rounded-lg border px-3.5 py-3 ${
-                      primary ? 'border-accent/30 bg-accent-surface' : 'border-border bg-surface-2'
-                    }`}
-                  >
-                    <div className="text-ink-faint w-4 font-mono text-[11px]">{i + 1}</div>
-                    <div
-                      className={`font-display flex size-[22px] items-center justify-center rounded-full text-[10.5px] font-bold ${
-                        primary ? 'bg-accent text-accent-on' : 'bg-surface-3 text-ink-strong'
+              <ol className="flex max-w-md flex-col gap-2">
+                {settings.priority.map((code, i) => {
+                  const primary = i === 0;
+                  const lastIndex = settings.priority.length - 1;
+                  return (
+                    <li
+                      key={code}
+                      className={`flex items-center gap-3 rounded-lg border px-3.5 py-3 ${
+                        primary
+                          ? 'border-accent/30 bg-accent-surface'
+                          : 'border-border bg-surface-2'
                       }`}
                     >
-                      {flagLetter(code)}
-                    </div>
-                    <div className="text-ink-strong flex-1 text-sm font-medium">
-                      {displayLanguage(code, code)}
-                      <span className="text-ink-soft ml-1.5 text-[13px] font-normal">
-                        {displayLanguage(code, 'en')}
+                      <div className="text-ink-faint w-4 font-mono text-[11px]">{i + 1}</div>
+                      <div
+                        className={`font-display flex size-[22px] items-center justify-center rounded-full text-[10.5px] font-bold ${
+                          primary ? 'bg-accent text-accent-on' : 'bg-surface-3 text-ink-strong'
+                        }`}
+                      >
+                        {flagLetter(code)}
+                      </div>
+                      <div className="text-ink-strong flex-1 text-sm font-medium">
+                        {displayLanguage(code, code)}
+                        <span className="text-ink-soft ml-1.5 text-[13px] font-normal">
+                          {displayLanguage(code, 'en')}
+                        </span>
+                      </div>
+                      <div className="border-border bg-surface text-ink-soft rounded border px-1.5 py-0.5 font-mono text-[11px]">
+                        {code}
+                      </div>
+                      <div className="flex items-center gap-1">
+                        <IconButton
+                          label={`Move ${displayLanguage(code, 'en')} up`}
+                          disabled={i === 0}
+                          onClick={() => {
+                            movePriority(i, i - 1);
+                          }}
+                        >
+                          ↑
+                        </IconButton>
+                        <IconButton
+                          label={`Move ${displayLanguage(code, 'en')} down`}
+                          disabled={i === lastIndex}
+                          onClick={() => {
+                            movePriority(i, i + 1);
+                          }}
+                        >
+                          ↓
+                        </IconButton>
+                        <IconButton
+                          label={`Remove ${displayLanguage(code, 'en')}`}
+                          disabled={settings.priority.length <= 1}
+                          onClick={() => {
+                            removePriority(code);
+                          }}
+                        >
+                          ×
+                        </IconButton>
+                      </div>
+                    </li>
+                  );
+                })}
+              </ol>
+
+              {priorityAddable.length > 0 ? (
+                <AddLanguagePicker
+                  label="Add language"
+                  options={priorityAddable}
+                  onAdd={addPriority}
+                />
+              ) : null}
+            </section>
+
+            <section>
+              <h3 className="font-display text-ink-strong mb-1.5 text-[22px] font-bold tracking-tight">
+                Blocked languages
+              </h3>
+              <p className="text-ink-soft mb-6 text-sm">
+                Movar will switch away from any page served in these languages.
+              </p>
+
+              {settings.blocked.length === 0 ? (
+                <p className="text-ink-faint mb-4 text-sm italic">No languages are blocked.</p>
+              ) : (
+                <ul className="mb-4 flex max-w-md flex-wrap gap-2">
+                  {settings.blocked.map((code) => (
+                    <li
+                      key={code}
+                      className="border-border bg-surface-2 text-ink-strong flex items-center gap-2 rounded-lg border px-3 py-1.5 text-[13px] font-medium"
+                    >
+                      <span>
+                        {displayLanguage(code, code)}
+                        <span className="text-ink-soft ml-1.5 text-[12px] font-normal">
+                          ({displayLanguage(code, 'en')})
+                        </span>
                       </span>
-                    </div>
-                    <div className="border-border bg-surface text-ink-soft rounded border px-1.5 py-0.5 font-mono text-[11px]">
-                      {code}
-                    </div>
-                  </li>
-                );
-              })}
-            </ol>
-          </section>
+                      <IconButton
+                        label={`Unblock ${displayLanguage(code, 'en')}`}
+                        onClick={() => {
+                          removeBlocked(code);
+                        }}
+                      >
+                        ×
+                      </IconButton>
+                    </li>
+                  ))}
+                </ul>
+              )}
+
+              {blockedAddable.length > 0 ? (
+                <AddLanguagePicker
+                  label="Block another"
+                  options={blockedAddable}
+                  onAdd={addBlocked}
+                />
+              ) : null}
+            </section>
+
+            <section>
+              <h3 className="font-display text-ink-strong mb-1.5 text-[22px] font-bold tracking-tight">
+                Exempt sites
+              </h3>
+              <p className="text-ink-soft mb-6 text-sm">Movar takes no action on these domains.</p>
+
+              {settings.allowlist.length === 0 ? (
+                <p className="text-ink-faint mb-4 text-sm italic">No sites are exempt.</p>
+              ) : (
+                <ul className="mb-4 flex max-w-md flex-wrap gap-2">
+                  {settings.allowlist.map((domain) => (
+                    <li
+                      key={domain}
+                      className="border-border bg-surface-2 text-ink-strong flex items-center gap-2 rounded-lg border px-3 py-1.5 font-mono text-[12.5px]"
+                    >
+                      <span>{domain}</span>
+                      <IconButton
+                        label={`Remove ${domain}`}
+                        onClick={() => {
+                          removeDomain(domain);
+                        }}
+                      >
+                        ×
+                      </IconButton>
+                    </li>
+                  ))}
+                </ul>
+              )}
+
+              <form onSubmit={addDomain} className="flex max-w-md gap-2">
+                <input
+                  type="text"
+                  value={domainDraft}
+                  onChange={(e) => {
+                    setDomainDraft(e.target.value);
+                    setDomainError(null);
+                  }}
+                  placeholder="example.com"
+                  aria-label="Domain to exempt"
+                  className="border-border bg-surface text-ink-strong placeholder:text-ink-faint focus:border-accent flex-1 rounded-lg border px-3 py-2 font-mono text-[13px] outline-none"
+                />
+                <button
+                  type="submit"
+                  className="bg-ink-strong text-bg hover:bg-ink rounded-lg px-4 py-2 text-[13px] font-medium transition-colors"
+                >
+                  Add
+                </button>
+              </form>
+              {domainError ? <p className="text-accent mt-2 text-[12.5px]">{domainError}</p> : null}
+            </section>
+
+            <section>
+              <h3 className="font-display text-ink-strong mb-1.5 text-[22px] font-bold tracking-tight">
+                Page content
+              </h3>
+              <p className="text-ink-soft mb-4 text-sm">
+                When on, Movar also hides blocked-language entries from on-site language pickers and
+                blurs content cards (e.g. YouTube videos) in a blocked language. Off by default;
+                turn on if you want a tidier page.
+              </p>
+
+              <label className="flex max-w-md cursor-pointer items-start gap-3">
+                <input
+                  type="checkbox"
+                  checked={settings.contentModification}
+                  onChange={toggleContentModification}
+                  className="accent-accent mt-0.5 size-4"
+                />
+                <span className="text-ink text-[13px] leading-relaxed">
+                  Allow Movar to modify page content on visited sites.
+                </span>
+              </label>
+            </section>
+          </div>
 
           <aside className="border-border text-ink-soft border-l pt-1 pl-4 text-[12.5px] leading-[1.6]">
             <b className="text-ink-strong mb-1 block text-[13px] font-semibold">
               How priority works
             </b>
             Movar negotiates each request with the site&apos;s available languages. If a site offers
-            Ukrainian, it serves Ukrainian. If only English, English. If only Russian, Movar strips
-            the page from results entirely.
+            Ukrainian, it serves Ukrainian. If only English, English. If only Russian, Movar tries
+            to switch you away.
+            <b className="text-ink-strong mt-4 mb-1 block text-[13px] font-semibold">
+              Blocked vs exempt
+            </b>
+            <em>Blocked</em> languages trigger an automatic switch away.
+            <em> Exempt</em> sites are ignored entirely — Movar does nothing on them.
           </aside>
         </div>
       </div>
@@ -112,5 +376,70 @@ export function App() {
         </a>
       </footer>
     </main>
+  );
+}
+
+interface IconButtonProps {
+  label: string;
+  onClick: () => void;
+  disabled?: boolean;
+  children: React.ReactNode;
+}
+
+function IconButton({ label, onClick, disabled = false, children }: IconButtonProps) {
+  return (
+    <button
+      type="button"
+      aria-label={label}
+      onClick={onClick}
+      disabled={disabled}
+      className="text-ink-soft hover:text-ink-strong hover:bg-surface-3 disabled:text-ink-faint flex size-7 items-center justify-center rounded-md font-mono text-[14px] transition-colors disabled:cursor-not-allowed disabled:hover:bg-transparent"
+    >
+      {children}
+    </button>
+  );
+}
+
+interface AddLanguagePickerProps {
+  label: string;
+  options: readonly LanguageCode[];
+  onAdd: (code: LanguageCode) => void;
+}
+
+function AddLanguagePicker({ label, options, onAdd }: AddLanguagePickerProps) {
+  const [draft, setDraft] = useState('');
+
+  const handleAdd = (): void => {
+    if (!draft) return;
+    onAdd(draft);
+    setDraft('');
+  };
+
+  return (
+    <div className="mt-4 flex max-w-md items-center gap-2">
+      <select
+        value={draft}
+        onChange={(e) => {
+          setDraft(e.target.value);
+        }}
+        aria-label={label}
+        className="border-border bg-surface text-ink-strong focus:border-accent flex-1 rounded-lg border px-3 py-2 text-[13px] outline-none"
+      >
+        <option value="">{label}…</option>
+        {options.map((code) => (
+          <option key={code} value={code}>
+            {displayLanguage(code, 'en')} ({code})
+          </option>
+        ))}
+      </select>
+      <button
+        type="button"
+        onClick={handleAdd}
+        disabled={!draft}
+        className="bg-ink-strong text-bg hover:bg-ink disabled:bg-surface-3 disabled:text-ink-faint rounded-lg px-4 py-2 text-[13px] font-medium transition-colors disabled:cursor-not-allowed"
+      >
+        Add
+      </button>
+    </div>
   );
 }

--- a/apps/marketing/src/components/Examples.astro
+++ b/apps/marketing/src/components/Examples.astro
@@ -1,0 +1,82 @@
+---
+interface Example {
+  site: string;
+  scenario: string;
+  without: string;
+  withMovar: string;
+  technique: string;
+}
+
+const examples: Example[] = [
+  {
+    site: 'google.com.ua',
+    scenario: 'Cyrillic query like "політика" or "новини"',
+    without:
+      'Top results are Russian-language articles. Google sees Cyrillic text and falls back to the larger Russian corpus.',
+    withMovar:
+      'Movar appends hl=uk and lr=lang_uk to /search requests so Google pins the result language. Ukrainian articles return.',
+    technique: 'URL parameter rewrite',
+  },
+  {
+    site: 'youtube.com',
+    scenario: 'Cyrillic search such as "новини" or "інтерв’ю"',
+    without:
+      'Recommendations and search results lean Russian. The interface picks up your browser locale but the recommendation engine does not.',
+    withMovar:
+      'Movar adds hl=uk and gl=UA so YouTube treats you as a Ukrainian-locale viewer for both interface and ranking.',
+    technique: 'URL parameter rewrite',
+  },
+  {
+    site: 'electrica-shop.com.ua',
+    scenario: 'Open any product page from a Ukrainian search result',
+    without:
+      'The site defaults to its Russian version at the root path even though it has a full Ukrainian version under /ua/.',
+    withMovar:
+      'Movar sets the site’s own lang cookie to "ua" and follows the page’s hreflang link to the Ukrainian counterpart. You stay in Ukrainian for the whole session.',
+    technique: 'Cookie + hreflang follow',
+  },
+];
+---
+
+<section id="examples" class="border-t border-border bg-bg px-6 py-20">
+  <div class="mx-auto max-w-5xl">
+    <h2 class="font-display text-3xl font-extrabold tracking-tight text-ink-strong sm:text-4xl">
+      What you&apos;ll actually notice
+    </h2>
+    <p class="mt-3 max-w-2xl text-ink-soft">
+      Three sites where Movar changes what reaches your screen. Same mechanism applies to
+      every Google ccTLD, Bing, DuckDuckGo, and a growing list of bilingual sites.
+    </p>
+
+    <div class="mt-10 space-y-6">
+      {
+        examples.map((example) => (
+          <article class="rounded-2xl border border-border bg-surface p-6 shadow-sm sm:p-8">
+            <div class="flex flex-wrap items-baseline justify-between gap-3">
+              <h3 class="font-display text-xl font-bold text-ink-strong">{example.site}</h3>
+              <span class="rounded-full border border-border bg-bg px-3 py-1 font-mono text-[11px] tracking-wide text-ink-soft uppercase">
+                {example.technique}
+              </span>
+            </div>
+            <p class="mt-2 text-sm text-ink-soft italic">{example.scenario}</p>
+
+            <div class="mt-5 grid gap-4 sm:grid-cols-2">
+              <div class="rounded-xl border border-border bg-bg p-4">
+                <div class="font-mono text-[10.5px] tracking-[0.1em] text-ink-faint uppercase">
+                  Without Movar
+                </div>
+                <p class="mt-2 text-sm leading-relaxed text-ink">{example.without}</p>
+              </div>
+              <div class="rounded-xl border border-accent/30 bg-accent-surface p-4">
+                <div class="font-mono text-[10.5px] tracking-[0.1em] text-accent uppercase">
+                  With Movar
+                </div>
+                <p class="mt-2 text-sm leading-relaxed text-ink-strong">{example.withMovar}</p>
+              </div>
+            </div>
+          </article>
+        ))
+      }
+    </div>
+  </div>
+</section>

--- a/apps/marketing/src/pages/index.astro
+++ b/apps/marketing/src/pages/index.astro
@@ -2,6 +2,7 @@
 import BaseLayout from '../layouts/BaseLayout.astro';
 import Header from '../components/Header.astro';
 import Hero from '../components/Hero.astro';
+import Examples from '../components/Examples.astro';
 import Features from '../components/Features.astro';
 import Footer from '../components/Footer.astro';
 ---
@@ -10,6 +11,7 @@ import Footer from '../components/Footer.astro';
   <Header />
   <main class="flex-1">
     <Hero />
+    <Examples />
     <Features />
   </main>
   <Footer />


### PR DESCRIPTION
## Summary
Ticket #6 of the v1 release punch list.

The marketing site had 4 generic feature cards and zero concrete examples — visitors had to take it on faith that the extension did anything specific. This adds an `Examples` component between Hero and Features showing three real sites, each as a side-by-side "without Movar / with Movar" card with the technique tagged.

### Examples
- **google.com.ua** — Cyrillic query → RU results without Movar; UA pinned via `hl=uk` + `lr=lang_uk` on `/search`.
- **youtube.com** — Cyrillic query → RU-leaning recommendations; UA via `hl=uk` + `gl=UA` on `/results`.
- **electrica-shop.com.ua** — RU default at root; UA available at `/ua/`; Movar sets the `lang` cookie + follows the page's hreflang to switch.

All three are real entries in `packages/rules/src/index.ts` — examples and rules should be edited together when adding ccTLDs or new sites.

### Layout
Kept the existing `Features` component. The two now play different roles:
- `Examples` (new) — "what you'll actually notice"
- `Features` (kept) — privacy & footprint claims that don't need named sites

## Test plan
- [ ] After deploy to https://movar.fyi, scroll through Hero → Examples → Features → Footer in that order
- [ ] Verify each "with Movar" claim against the actual rule in `packages/rules/src/index.ts`
- [ ] Spot-check Russian-language Cyrillic query on `google.com.ua` with/without the extension to confirm the example reflects current Google behaviour

🤖 Generated with [Claude Code](https://claude.com/claude-code)