### PR TITLE
feat(marketing): add before/after layout with placeholder screenshot slots

### DIFF
--- a/apps/marketing/public/screenshots/README.md
+++ b/apps/marketing/public/screenshots/README.md
@@ -1,0 +1,16 @@
+# Marketing screenshots
+
+Drop PNG files here. The marketing site references them by exact filename.
+
+| Filename                   | What it shows                                                        | Aspect | Approx. dimensions |
+| -------------------------- | -------------------------------------------------------------------- | ------ | ------------------ |
+| `google-without-movar.png` | Cyrillic query on google.com.ua, Russian-language results dominating | 16:10  | 1280×800           |
+| `google-with-movar.png`    | Same query, Ukrainian-language results                               | 16:10  | 1280×800           |
+| `popup.png`                | Extension popup open on a real page                                  | 4:3    | 480×360            |
+| `options.png`              | Extension options page with edited priority list                     | 16:10  | 1280×800           |
+
+The `BeforeAfter.astro` component will render placeholder cards until
+`google-without-movar.png` and `google-with-movar.png` exist at this path.
+
+For store-listing screenshots (Chrome Web Store, Edge, AMO), see
+`apps/extension/store-assets/` (ticket #9).

--- a/apps/marketing/src/components/BeforeAfter.astro
+++ b/apps/marketing/src/components/BeforeAfter.astro
@@ -1,0 +1,87 @@
+---
+/**
+ * Side-by-side before/after for a single representative search.
+ *
+ * Drop the two PNGs at:
+ *   apps/marketing/public/screenshots/google-without-movar.png
+ *   apps/marketing/public/screenshots/google-with-movar.png
+ *
+ * Both 1280×800 (16:10). Until they exist the component renders dashed
+ * placeholder cards in their place.
+ */
+
+interface Comparison {
+  label: string;
+  variant: 'without' | 'with';
+  caption: string;
+  src: string;
+  alt: string;
+}
+
+const comparisons: Comparison[] = [
+  {
+    label: 'Without Movar',
+    variant: 'without',
+    caption: 'Top results lean Russian.',
+    src: '/screenshots/google-without-movar.png',
+    alt: 'Google search results for a Cyrillic query, with Russian-language pages dominating',
+  },
+  {
+    label: 'With Movar',
+    variant: 'with',
+    caption: 'Ukrainian results pinned via hl=uk + lr=lang_uk.',
+    src: '/screenshots/google-with-movar.png',
+    alt: 'Same Google search, now returning Ukrainian-language pages',
+  },
+];
+---
+
+<section id="before-after" class="border-t border-border bg-surface px-6 py-20">
+  <div class="mx-auto max-w-5xl">
+    <h2 class="font-display text-3xl font-extrabold tracking-tight text-ink-strong sm:text-4xl">
+      See it in action
+    </h2>
+    <p class="mt-3 max-w-2xl text-ink-soft">
+      Same Cyrillic query on google.com.ua, two outcomes.
+    </p>
+
+    <div class="mt-10 grid gap-6 sm:grid-cols-2">
+      {
+        comparisons.map((c) => (
+          <figure
+            class:list={[
+              'rounded-2xl border bg-bg p-3 shadow-sm',
+              c.variant === 'with' ? 'border-accent/30' : 'border-border',
+            ]}
+          >
+            <div
+              class="relative flex aspect-[16/10] items-center justify-center overflow-hidden rounded-lg border border-dashed border-border bg-surface-2"
+            >
+              <img
+                src={c.src}
+                alt={c.alt}
+                loading="lazy"
+                class="absolute inset-0 size-full object-cover"
+                onerror="this.style.display='none'"
+              />
+              <span class="text-ink-faint relative font-mono text-[11px]">
+                {c.src.split('/').pop()}
+              </span>
+            </div>
+            <figcaption class="mt-3 px-1 pb-1">
+              <div
+                class:list={[
+                  'font-mono text-[10.5px] tracking-[0.1em] uppercase',
+                  c.variant === 'with' ? 'text-accent' : 'text-ink-faint',
+                ]}
+              >
+                {c.label}
+              </div>
+              <p class="text-ink mt-1 text-sm">{c.caption}</p>
+            </figcaption>
+          </figure>
+        ))
+      }
+    </div>
+  </div>
+</section>

--- a/apps/marketing/src/pages/index.astro
+++ b/apps/marketing/src/pages/index.astro
@@ -2,6 +2,7 @@
 import BaseLayout from '../layouts/BaseLayout.astro';
 import Header from '../components/Header.astro';
 import Hero from '../components/Hero.astro';
+import BeforeAfter from '../components/BeforeAfter.astro';
 import Features from '../components/Features.astro';
 import Footer from '../components/Footer.astro';
 ---
@@ -10,6 +11,7 @@ import Footer from '../components/Footer.astro';
   <Header />
   <main class="flex-1">
     <Hero />
+    <BeforeAfter />
     <Features />
   </main>
   <Footer />


### PR DESCRIPTION
## Summary
Ticket #7 of the v1 release punch list.

The marketing site had zero visuals. Visitors had to trust the text. This adds a `BeforeAfter` component between Hero and Features with side-by-side figures for the same Cyrillic `google.com.ua` query — "without Movar" on the left, "with Movar" on the right.

### What's in this PR vs deferred to ticket #9
- ✅ **Layout, component, and screenshot folder structure** — done here.
- ✅ **Placeholder behaviour** — if a PNG is missing, the dashed-border card with the expected filename stays visible. The marketing site stays publishable through the gap.
- ⏳ **The actual PNGs** — captured under ticket #9. Drop them into [`apps/marketing/public/screenshots/`](apps/marketing/public/screenshots/) (see the [README](apps/marketing/public/screenshots/README.md) for filenames and dimensions).

### Why placeholders not real screenshots in this PR
This branch is being merged from a CLI without a browser available — I can't capture the real PNGs. Splitting the structural work from the asset capture lets the layout land + get reviewed, while the screenshots happen under the existing ticket that's already scoped for it.

## Test plan
- [ ] After merge, build + deploy: confirm BeforeAfter renders with dashed placeholders showing the filenames
- [ ] Drop the two PNGs into `apps/marketing/public/screenshots/` (when ticket #9 captures them); confirm they replace the placeholders without code change

## Likely rebase
This PR and [movar#7](https://github.com/rejifald/movar/pull/7) both modify `index.astro` to add a new component slot. Merge order:
- If movar#7 (Examples) lands first → this PR rebases to insert `<BeforeAfter />` *after* `<Examples />`.
- If this PR lands first → movar#7 rebases to insert `<Examples />` *before* `<BeforeAfter />`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)