### PR TITLE
feat(marketing): add Ukrainian translation (uk locale, /uk/ paths)

### DIFF
--- a/apps/marketing/src/components/DownloadButtons.astro
+++ b/apps/marketing/src/components/DownloadButtons.astro
@@ -10,32 +10,25 @@
  * generated HTML to confirm the right link landed.
  */
 
+import { strings, type Locale } from '../i18n';
+
+interface Props {
+  lang?: Locale;
+}
+
+const { lang = 'en' } = Astro.props;
+const t = strings[lang].download;
+
 interface Store {
   id: 'chrome' | 'edge' | 'firefox';
-  label: string;
   href: string;
   liveAt: string | null;
 }
 
 const stores: Store[] = [
-  {
-    id: 'chrome',
-    label: 'Add to Chrome',
-    href: '#',
-    liveAt: null, // TODO: paste Chrome Web Store URL on first publish
-  },
-  {
-    id: 'edge',
-    label: 'Add to Edge',
-    href: '#',
-    liveAt: null, // TODO: paste Edge Add-ons URL on first publish
-  },
-  {
-    id: 'firefox',
-    label: 'Add to Firefox',
-    href: '#',
-    liveAt: null, // TODO: paste Firefox AMO URL on first publish
-  },
+  { id: 'chrome', href: '#', liveAt: null }, // TODO: paste Chrome Web Store URL on first publish
+  { id: 'edge', href: '#', liveAt: null }, // TODO: paste Edge Add-ons URL on first publish
+  { id: 'firefox', href: '#', liveAt: null }, // TODO: paste Firefox AMO URL on first publish
 ];
 ---
 
@@ -56,10 +49,10 @@ const stores: Store[] = [
           'aria-disabled:cursor-not-allowed aria-disabled:opacity-60',
         ]}
       >
-        <span>{store.label}</span>
+        <span>{t.add[store.id]}</span>
         {store.liveAt === null && (
           <span class="rounded-md bg-surface-2 px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide text-ink-soft group-data-[primary=true]:bg-accent-deep group-data-[primary=true]:text-accent-on">
-            Soon
+            {t.soon}
           </span>
         )}
       </a>

--- a/apps/marketing/src/components/Features.astro
+++ b/apps/marketing/src/components/Features.astro
@@ -1,45 +1,26 @@
 ---
-interface Feature {
-  title: string;
-  body: string;
+import { strings, type Locale } from '../i18n';
+
+interface Props {
+  lang?: Locale;
 }
 
-const features: Feature[] = [
-  {
-    title: 'Fixes search results',
-    body:
-      'Google, Bing, DuckDuckGo, and YouTube get a language hint on every search, so results come back in your preferred language — no more Ukrainian queries defaulting to Russian.',
-  },
-  {
-    title: 'Detects misrouted sites',
-    body:
-      'When a Ukrainian-language site routes you to Russian on a new page, Movar notices and auto-switches you back through the site’s own language picker.',
-  },
-  {
-    title: 'Stays out of the way',
-    body:
-      'Movar only rewrites outgoing URLs and request headers — it never inspects request bodies, never injects ads, and never talks to a remote server.',
-  },
-  {
-    title: 'Nothing leaves your device',
-    body:
-      'No account, no telemetry, no analytics. Your preferences live in browser storage. Language detection runs entirely locally.',
-  },
-];
+const { lang = 'en' } = Astro.props;
+const t = strings[lang].features;
 ---
 
 <section id="how" class="border-t border-border bg-surface px-6 py-20">
   <div class="mx-auto max-w-5xl">
     <h2 class="font-display text-3xl font-extrabold tracking-tight text-ink-strong sm:text-4xl">
-      How Movar works
+      {t.sectionTitle}
     </h2>
     <p class="mt-3 max-w-2xl text-ink-soft">
-      All running silently in the background once you pick a preferred language.
+      {t.sectionLead}
     </p>
 
     <div class="mt-10 grid gap-6 sm:grid-cols-2">
       {
-        features.map((feature) => (
+        t.cards.map((feature) => (
           <article class="rounded-2xl border border-border bg-bg p-6 shadow-sm">
             <h3 class="font-display text-lg font-bold text-ink-strong">{feature.title}</h3>
             <p class="mt-2 text-sm leading-relaxed text-ink-soft">{feature.body}</p>

--- a/apps/marketing/src/components/Footer.astro
+++ b/apps/marketing/src/components/Footer.astro
@@ -1,6 +1,15 @@
 ---
 import { FEEDBACK_URL } from '@movar/shared';
+import { localeHomeHref, localePrivacyHref, strings, type Locale } from '../i18n';
 
+interface Props {
+  lang?: Locale;
+}
+
+const { lang = 'en' } = Astro.props;
+const t = strings[lang].footer;
+const privacy = localePrivacyHref(lang);
+const home = localeHomeHref(lang);
 const year = new Date().getFullYear();
 ---
 
@@ -10,13 +19,13 @@ const year = new Date().getFullYear();
       <img src="/icon.svg" alt="" width="20" height="20" class="rounded" />
       <span>
         <span class="font-display font-bold text-ink-strong">movar.fyi</span>
-        &middot; &copy; {year} Movar contributors &middot; MIT
+        &middot; &copy; {year} {t.credits}
       </span>
     </div>
     <nav class="flex items-center gap-5">
-      <a href="/privacy" class="hover:text-ink-strong transition">Privacy</a>
-      <a href="/#download" class="hover:text-ink-strong transition">Download</a>
-      <a href={FEEDBACK_URL} class="hover:text-ink-strong transition">Feedback</a>
+      <a href={privacy} class="hover:text-ink-strong transition">{t.privacy}</a>
+      <a href={`${home}#download`} class="hover:text-ink-strong transition">{t.download}</a>
+      <a href={FEEDBACK_URL} class="hover:text-ink-strong transition">{t.feedback}</a>
     </nav>
   </div>
 </footer>

--- a/apps/marketing/src/components/Header.astro
+++ b/apps/marketing/src/components/Header.astro
@@ -1,19 +1,41 @@
 ---
-// Top navigation. Sticky, low-contrast, links to in-page sections + privacy.
+import {
+  alternateLocaleHref,
+  localeHomeHref,
+  localePrivacyHref,
+  strings,
+  type Locale,
+} from '../i18n';
+
+interface Props {
+  lang?: Locale;
+}
+
+const { lang = 'en' } = Astro.props;
+const t = strings[lang];
+const home = localeHomeHref(lang);
+const privacy = localePrivacyHref(lang);
+const alternateHref = alternateLocaleHref(Astro.url.pathname, lang);
 ---
 
 <header
   class="sticky top-0 z-50 border-b border-border/60 bg-bg/85 backdrop-blur supports-[backdrop-filter]:bg-bg/70"
 >
   <div class="mx-auto flex max-w-5xl items-center justify-between px-6 py-4">
-    <a href="/" class="flex items-center gap-2.5 font-display font-bold text-ink-strong">
+    <a href={home} class="flex items-center gap-2.5 font-display font-bold text-ink-strong">
       <img src="/icon.svg" alt="" width="28" height="28" class="rounded-md" />
       <span class="text-lg tracking-tight">movar<span class="text-accent">.fyi</span></span>
     </a>
     <nav class="flex items-center gap-6 text-sm text-ink-soft">
-      <a href="/#how" class="hover:text-ink-strong transition">How it works</a>
-      <a href="/#download" class="hover:text-ink-strong transition">Download</a>
-      <a href="/privacy" class="hover:text-ink-strong transition">Privacy</a>
+      <a href={`${home}#how`} class="hover:text-ink-strong transition">{t.nav.howItWorks}</a>
+      <a href={`${home}#download`} class="hover:text-ink-strong transition">{t.nav.download}</a>
+      <a href={privacy} class="hover:text-ink-strong transition">{t.nav.privacy}</a>
+      <a
+        href={alternateHref}
+        class="border-l border-border/60 pl-6 font-mono text-[12px] hover:text-ink-strong transition"
+      >
+        {t.switcher.alternateLabel}
+      </a>
     </nav>
   </div>
 </header>

--- a/apps/marketing/src/components/Hero.astro
+++ b/apps/marketing/src/components/Hero.astro
@@ -1,5 +1,13 @@
 ---
 import DownloadButtons from './DownloadButtons.astro';
+import { strings, type Locale } from '../i18n';
+
+interface Props {
+  lang?: Locale;
+}
+
+const { lang = 'en' } = Astro.props;
+const t = strings[lang].hero;
 ---
 
 <section class="relative px-6 pt-20 pb-16 sm:pt-28 sm:pb-24">
@@ -8,27 +16,26 @@ import DownloadButtons from './DownloadButtons.astro';
       class="mb-6 inline-flex items-center gap-2 rounded-full border border-border bg-surface px-3 py-1 text-xs font-medium text-ink-soft shadow-sm"
     >
       <span class="size-1.5 rounded-full bg-accent"></span>
-      Free · MIT-licensed · Privacy-first
+      {t.badge}
     </div>
 
     <h1
       class="font-display text-5xl font-extrabold tracking-tight text-ink-strong sm:text-6xl"
     >
-      Keep the internet
-      <span class="block text-accent">in your language.</span>
+      {t.headlineLine1}
+      <span class="block text-accent">{t.headlineLine2}</span>
     </h1>
 
     <p class="mx-auto mt-6 max-w-2xl text-lg text-ink-soft sm:text-xl">
-      Movar nudges Google, Bing, DuckDuckGo, and YouTube to match your language &mdash;
-      and quietly auto-switches sites that try to serve you the wrong one. All on-device.
+      {t.subhead}
     </p>
 
     <div class="mt-10">
-      <DownloadButtons />
+      <DownloadButtons lang={lang} />
     </div>
 
     <p class="mt-4 text-xs text-ink-faint">
-      Coming soon to Chrome, Edge, and Firefox.
+      {t.comingSoon}
     </p>
   </div>
 </section>

--- a/apps/marketing/src/i18n.ts
+++ b/apps/marketing/src/i18n.ts
@@ -1,0 +1,229 @@
+/**
+ * Marketing-site i18n. Two locales: 'en' (default) and 'uk'.
+ *
+ * Components accept a `lang: Locale` prop and look up their strings in the
+ * dictionary below. Pages declare their lang by routing — /index.astro is
+ * English, /uk/index.astro is Ukrainian — and pass it down.
+ *
+ * Adding a third locale: extend the union, add a key to `strings`, update
+ * `alternateLocaleHref` to handle the third path prefix.
+ */
+
+export type Locale = 'en' | 'uk';
+
+export const locales: readonly Locale[] = ['en', 'uk'] as const;
+
+interface NavStrings {
+  howItWorks: string;
+  download: string;
+  privacy: string;
+  feedback: string;
+}
+
+interface HeroStrings {
+  badge: string;
+  headlineLine1: string;
+  headlineLine2: string;
+  subhead: string;
+  comingSoon: string;
+}
+
+interface FeatureCard {
+  title: string;
+  body: string;
+}
+
+interface FeaturesStrings {
+  sectionTitle: string;
+  sectionLead: string;
+  cards: FeatureCard[];
+}
+
+interface FooterStrings {
+  credits: string;
+  privacy: string;
+  download: string;
+  feedback: string;
+}
+
+interface DownloadStrings {
+  add: Record<'chrome' | 'edge' | 'firefox', string>;
+  soon: string;
+}
+
+interface SwitcherStrings {
+  /** Label of the OTHER locale (shown in the switcher link). */
+  alternateLabel: string;
+}
+
+interface MetaStrings {
+  /** Value of `<html lang>`. */
+  htmlLang: string;
+  /** Default <title> + meta description used by BaseLayout. */
+  defaultTitle: string;
+  defaultDescription: string;
+}
+
+export interface Strings {
+  meta: MetaStrings;
+  nav: NavStrings;
+  hero: HeroStrings;
+  features: FeaturesStrings;
+  footer: FooterStrings;
+  download: DownloadStrings;
+  switcher: SwitcherStrings;
+}
+
+const en: Strings = {
+  meta: {
+    htmlLang: 'en',
+    defaultTitle: 'Movar — keep the internet in your language',
+    defaultDescription:
+      'Keep the internet in your language. Movar nudges Google, Bing, DuckDuckGo, and YouTube to match your language.',
+  },
+  nav: {
+    howItWorks: 'How it works',
+    download: 'Download',
+    privacy: 'Privacy',
+    feedback: 'Feedback',
+  },
+  hero: {
+    badge: 'Free · MIT-licensed · Privacy-first',
+    headlineLine1: 'Keep the internet',
+    headlineLine2: 'in your language.',
+    subhead:
+      'Movar nudges Google, Bing, DuckDuckGo, and YouTube to match your language — and quietly auto-switches sites that try to serve you the wrong one. All on-device.',
+    comingSoon: 'Coming soon to Chrome, Edge, and Firefox.',
+  },
+  features: {
+    sectionTitle: 'How Movar works',
+    sectionLead: 'All running silently in the background once you pick a preferred language.',
+    cards: [
+      {
+        title: 'Fixes search results',
+        body: 'Google, Bing, DuckDuckGo, and YouTube get a language hint on every search, so results come back in your preferred language — no more Ukrainian queries defaulting to Russian.',
+      },
+      {
+        title: 'Detects misrouted sites',
+        body: "When a Ukrainian-language site routes you to Russian on a new page, Movar notices and auto-switches you back through the site's own language picker.",
+      },
+      {
+        title: 'Stays out of the way',
+        body: 'Movar only rewrites outgoing URLs and request headers — it never inspects request bodies, never injects ads, and never talks to a remote server.',
+      },
+      {
+        title: 'Nothing leaves your device',
+        body: 'No account, no telemetry, no analytics. Your preferences live in browser storage. Language detection runs entirely locally.',
+      },
+    ],
+  },
+  footer: {
+    credits: 'Movar contributors · MIT',
+    privacy: 'Privacy',
+    download: 'Download',
+    feedback: 'Feedback',
+  },
+  download: {
+    add: {
+      chrome: 'Add to Chrome',
+      edge: 'Add to Edge',
+      firefox: 'Add to Firefox',
+    },
+    soon: 'Soon',
+  },
+  switcher: {
+    alternateLabel: 'Українська',
+  },
+};
+
+const uk: Strings = {
+  meta: {
+    htmlLang: 'uk',
+    defaultTitle: 'Movar — тримайте інтернет вашою мовою',
+    defaultDescription:
+      'Тримайте інтернет вашою мовою. Movar коригує Google, Bing, DuckDuckGo та YouTube, щоб результати показувались вибраною мовою.',
+  },
+  nav: {
+    howItWorks: 'Як працює',
+    download: 'Завантажити',
+    privacy: 'Приватність',
+    feedback: 'Зворотний звʼязок',
+  },
+  hero: {
+    badge: 'Безкоштовно · Ліцензія MIT · Приватність насамперед',
+    headlineLine1: 'Тримайте інтернет',
+    headlineLine2: 'вашою мовою.',
+    subhead:
+      'Movar коригує Google, Bing, DuckDuckGo та YouTube, щоб результати поверталися вашою мовою — і тихо перемикає сайти, які підсовують не ту. Усе локально, без серверів.',
+    comingSoon: 'Незабаром у Chrome, Edge та Firefox.',
+  },
+  features: {
+    sectionTitle: 'Як працює Movar',
+    sectionLead: 'Усе виконується непомітно у фоні після того, як ви оберете бажану мову.',
+    cards: [
+      {
+        title: 'Виправляє результати пошуку',
+        body: 'Google, Bing, DuckDuckGo та YouTube отримують підказку про мову на кожен запит, тож результати повертаються вашою мовою — українські запити більше не показують російські сторінки за замовчуванням.',
+      },
+      {
+        title: 'Помічає неправильні перенаправлення',
+        body: 'Коли україномовний сайт переводить вас на російську версію на іншій сторінці, Movar це помічає й автоматично перемикає назад через рідний перемикач мов сайту.',
+      },
+      {
+        title: 'Не плутається під ногами',
+        body: 'Movar лише переписує вихідні URL та заголовки запитів — не аналізує тіла запитів, не вставляє реклами та не звертається до віддалених серверів.',
+      },
+      {
+        title: 'Нічого не покидає ваш пристрій',
+        body: 'Без облікового запису, без телеметрії, без аналітики. Ваші налаштування зберігаються у браузері. Визначення мови виконується повністю локально.',
+      },
+    ],
+  },
+  footer: {
+    credits: 'Учасники Movar · MIT',
+    privacy: 'Приватність',
+    download: 'Завантажити',
+    feedback: 'Зворотний звʼязок',
+  },
+  download: {
+    add: {
+      chrome: 'Встановити для Chrome',
+      edge: 'Встановити для Edge',
+      firefox: 'Встановити для Firefox',
+    },
+    soon: 'Скоро',
+  },
+  switcher: {
+    alternateLabel: 'English',
+  },
+};
+
+export const strings: Record<Locale, Strings> = { en, uk };
+
+/**
+ * Compute the path to the same page in the other locale. Used by the
+ * language switcher in the header.
+ *
+ *   /                    →  /uk/
+ *   /privacy             →  /uk/privacy
+ *   /uk/                 →  /
+ *   /uk/privacy          →  /privacy
+ */
+export function alternateLocaleHref(pathname: string, current: Locale): string {
+  if (current === 'en') {
+    const trimmed = pathname.replace(/\/$/, '');
+    return trimmed === '' ? '/uk/' : `/uk${trimmed}`;
+  }
+  const stripped = pathname.replace(/^\/uk/, '');
+  return stripped === '' || stripped === '/' ? '/' : stripped;
+}
+
+/** Path to the home page of a given locale. */
+export function localeHomeHref(lang: Locale): string {
+  return lang === 'uk' ? '/uk/' : '/';
+}
+
+/** Path to the privacy page of a given locale. */
+export function localePrivacyHref(lang: Locale): string {
+  return lang === 'uk' ? '/uk/privacy' : '/privacy';
+}

--- a/apps/marketing/src/layouts/BaseLayout.astro
+++ b/apps/marketing/src/layouts/BaseLayout.astro
@@ -1,42 +1,45 @@
 ---
 import '../styles/global.css';
+import { strings, type Locale } from '../i18n';
 
 interface Props {
-  title: string;
+  lang?: Locale;
+  title?: string;
   description?: string;
 }
 
-const {
-  title,
-  description = 'Keep the internet in your language. Movar nudges Google, Bing, DuckDuckGo, and YouTube to match your language.',
-} = Astro.props;
+const { lang = 'en', title, description } = Astro.props;
+const t = strings[lang];
+const resolvedTitle = title ?? t.meta.defaultTitle;
+const resolvedDescription = description ?? t.meta.defaultDescription;
 
 const canonicalURL = new URL(Astro.url.pathname, Astro.site).toString();
 ---
 
 <!doctype html>
-<html lang="en">
+<html lang={t.meta.htmlLang}>
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="generator" content={Astro.generator} />
-    <title>{title}</title>
-    <meta name="description" content={description} />
+    <title>{resolvedTitle}</title>
+    <meta name="description" content={resolvedDescription} />
     <link rel="canonical" href={canonicalURL} />
     <link rel="icon" type="image/svg+xml" href="/icon.svg" />
     <meta name="theme-color" content="#1C1917" />
 
     {/* Open Graph */}
     <meta property="og:type" content="website" />
-    <meta property="og:title" content={title} />
-    <meta property="og:description" content={description} />
+    <meta property="og:title" content={resolvedTitle} />
+    <meta property="og:description" content={resolvedDescription} />
     <meta property="og:url" content={canonicalURL} />
     <meta property="og:site_name" content="Movar" />
+    <meta property="og:locale" content={lang === 'uk' ? 'uk_UA' : 'en'} />
 
     {/* Twitter */}
     <meta name="twitter:card" content="summary" />
-    <meta name="twitter:title" content={title} />
-    <meta name="twitter:description" content={description} />
+    <meta name="twitter:title" content={resolvedTitle} />
+    <meta name="twitter:description" content={resolvedDescription} />
   </head>
   <body class="min-h-screen flex flex-col bg-bg text-ink">
     <slot />

--- a/apps/marketing/src/pages/index.astro
+++ b/apps/marketing/src/pages/index.astro
@@ -6,11 +6,11 @@ import Features from '../components/Features.astro';
 import Footer from '../components/Footer.astro';
 ---
 
-<BaseLayout title="Movar — keep the internet in your language">
-  <Header />
+<BaseLayout lang="en">
+  <Header lang="en" />
   <main class="flex-1">
-    <Hero />
-    <Features />
+    <Hero lang="en" />
+    <Features lang="en" />
   </main>
-  <Footer />
+  <Footer lang="en" />
 </BaseLayout>

--- a/apps/marketing/src/pages/privacy.astro
+++ b/apps/marketing/src/pages/privacy.astro
@@ -7,10 +7,11 @@ const lastUpdated = '27 May 2026';
 ---
 
 <BaseLayout
+  lang="en"
   title="Privacy — Movar"
   description="Movar stores everything locally. No accounts, no telemetry, no remote endpoints. Full privacy policy."
 >
-  <Header />
+  <Header lang="en" />
   <main class="flex-1 px-6 py-16">
     <article class="mx-auto max-w-3xl">
       <p class="text-xs uppercase tracking-wide text-ink-faint">Last updated · {lastUpdated}</p>
@@ -136,5 +137,5 @@ const lastUpdated = '27 May 2026';
       </section>
     </article>
   </main>
-  <Footer />
+  <Footer lang="en" />
 </BaseLayout>

--- a/apps/marketing/src/pages/uk/404.astro
+++ b/apps/marketing/src/pages/uk/404.astro
@@ -1,27 +1,27 @@
 ---
-import BaseLayout from '../layouts/BaseLayout.astro';
-import Header from '../components/Header.astro';
-import Footer from '../components/Footer.astro';
+import BaseLayout from '../../layouts/BaseLayout.astro';
+import Header from '../../components/Header.astro';
+import Footer from '../../components/Footer.astro';
 ---
 
-<BaseLayout lang="en" title="Not found — Movar" description="That page isn't here.">
-  <Header lang="en" />
+<BaseLayout lang="uk" title="Сторінку не знайдено — Movar" description="Тут нічого немає.">
+  <Header lang="uk" />
   <main class="flex flex-1 items-center justify-center px-6 py-24">
     <div class="mx-auto max-w-md text-center">
       <p class="font-mono text-sm uppercase tracking-widest text-ink-faint">404</p>
       <h1 class="mt-3 font-display text-4xl font-extrabold tracking-tight text-ink-strong sm:text-5xl">
-        Wrong page, right language.
+        Не та сторінка, але та мова.
       </h1>
       <p class="mt-4 text-ink-soft">
-        Nothing at this URL. The home page is one click away.
+        За цією адресою нічого немає. Головна сторінка за один клік.
       </p>
       <a
-        href="/"
+        href="/uk/"
         class="mt-8 inline-flex items-center justify-center rounded-xl border border-accent bg-accent px-5 py-3 text-sm font-semibold text-accent-on shadow-sm transition hover:shadow-md"
       >
-        Take me home
+        На головну
       </a>
     </div>
   </main>
-  <Footer lang="en" />
+  <Footer lang="uk" />
 </BaseLayout>

--- a/apps/marketing/src/pages/uk/index.astro
+++ b/apps/marketing/src/pages/uk/index.astro
@@ -1,0 +1,16 @@
+---
+import BaseLayout from '../../layouts/BaseLayout.astro';
+import Header from '../../components/Header.astro';
+import Hero from '../../components/Hero.astro';
+import Features from '../../components/Features.astro';
+import Footer from '../../components/Footer.astro';
+---
+
+<BaseLayout lang="uk">
+  <Header lang="uk" />
+  <main class="flex-1">
+    <Hero lang="uk" />
+    <Features lang="uk" />
+  </main>
+  <Footer lang="uk" />
+</BaseLayout>

--- a/apps/marketing/src/pages/uk/privacy.astro
+++ b/apps/marketing/src/pages/uk/privacy.astro
@@ -1,0 +1,144 @@
+---
+import BaseLayout from '../../layouts/BaseLayout.astro';
+import Header from '../../components/Header.astro';
+import Footer from '../../components/Footer.astro';
+
+const lastUpdated = '27 травня 2026';
+---
+
+<BaseLayout
+  lang="uk"
+  title="Приватність — Movar"
+  description="Movar зберігає всі дані локально. Без облікового запису, без телеметрії, без віддалених серверів."
+>
+  <Header lang="uk" />
+  <main class="flex-1 px-6 py-16">
+    <article class="mx-auto max-w-3xl">
+      <p class="text-xs uppercase tracking-wide text-ink-faint">Оновлено · {lastUpdated}</p>
+      <h1 class="mt-2 font-display text-4xl font-extrabold tracking-tight text-ink-strong sm:text-5xl">
+        Політика приватності
+      </h1>
+
+      <p class="mt-6 text-lg text-ink-soft">
+        Коротко: Movar виконується повністю на вашому пристрої. Жодні дані про ваші перегляди,
+        запити чи налаштування ніколи не покидають браузер, у якому ви встановили розширення.
+        Далі — те саме, лише з деталями.
+      </p>
+
+      <section class="mt-12 space-y-4">
+        <h2 class="font-display text-2xl font-bold text-ink-strong">Що Movar зберігає</h2>
+        <p>Movar користується вбудованими API сховища розширень браузера, щоб запамʼятати:</p>
+        <ul class="list-disc space-y-1 pl-6 text-ink-soft">
+          <li>вашу бажану мову (наприклад, українську чи англійську),</li>
+          <li>сайти, які ви виключили зі сфери дії,</li>
+          <li>чи призупинений зараз Movar,</li>
+          <li>
+            ковзний журнал з останніх 1 000 виправлень — кожен запис містить мітку часу, домен
+            сайту, застосований механізм та мову до/після. Спливне вікно показує лічильник
+            «виправлень сьогодні» та мови, приховані на поточній вкладці.
+          </li>
+        </ul>
+        <p class="text-ink-soft">
+          Налаштування зберігаються у
+          <code class="rounded bg-surface-2 px-1.5 py-0.5 text-sm">storage.sync</code>, тож
+          вбудована синхронізація браузера (Chrome Sync, Firefox Sync) може передавати їх між
+          вашими власними пристроями. Стан паузи та журнал виправлень зберігаються у
+          <code class="rounded bg-surface-2 px-1.5 py-0.5 text-sm">storage.local</code> та
+          залишаються лише на цьому пристрої. Жодні з цих даних не передаються на наш сервер —
+          бо в Movar немає сервера.
+        </p>
+      </section>
+
+      <section class="mt-12 space-y-4">
+        <h2 class="font-display text-2xl font-bold text-ink-strong">Що Movar <em>не</em> зберігає</h2>
+        <ul class="list-disc space-y-1 pl-6 text-ink-soft">
+          <li>ваші пошукові запити,</li>
+          <li>
+            історію перегляду (журнал виправлень фіксує лише <em>які домени</em> викликали
+            виправлення — без URL, шляхів чи вмісту сторінок),
+          </li>
+          <li>вміст сторінок,</li>
+          <li>будь-які ідентифікатори, що могли б відрізнити вас від іншого користувача,</li>
+          <li>жодної аналітики чи телеметрії, що передається за межі пристрою.</li>
+        </ul>
+      </section>
+
+      <section class="mt-12 space-y-4">
+        <h2 class="font-display text-2xl font-bold text-ink-strong">Дозволи та чому вони потрібні</h2>
+        <dl class="space-y-5 text-ink-soft">
+          <div>
+            <dt class="font-semibold text-ink-strong">storage</dt>
+            <dd>Зберігати перелічені вище налаштування між перезапусками браузера.</dd>
+          </div>
+          <div>
+            <dt class="font-semibold text-ink-strong">declarativeNetRequest</dt>
+            <dd>
+              Додавати параметр мови до вихідних запитів до пошукових систем (Google, Bing,
+              DuckDuckGo, YouTube), щоб результати показувались вибраною мовою. Правила статичні
+              й декларативні — розширення ніколи не бачить тіл запитів чи вмісту відповідей.
+            </dd>
+          </div>
+          <div>
+            <dt class="font-semibold text-ink-strong">alarms</dt>
+            <dd>
+              Будити фоновий скрипт, коли спливає тимчасова пауза (наприклад, «призупинити на 30
+              хвилин»), щоб Movar відновлювався самостійно.
+            </dd>
+          </div>
+          <div>
+            <dt class="font-semibold text-ink-strong">tabs</dt>
+            <dd>
+              Зчитувати URL активної вкладки, коли ви відкриваєте спливне вікно чи сторінку
+              налаштувань — щоб Movar показав, чи поточний сайт у списку винятків, і дозволив
+              перемкнути цей статус одним кліком.
+            </dd>
+          </div>
+          <div>
+            <dt class="font-semibold text-ink-strong">доступ до всіх сайтів</dt>
+            <dd>
+              Контентний скрипт застосовує мовну корекцію на сайті, який ви зараз переглядаєте.
+              Movar читає сторінку лише настільки, наскільки потрібно для визначення її мови;
+              жоден вміст сторінки нікуди не передається.
+            </dd>
+          </div>
+        </dl>
+      </section>
+
+      <section class="mt-12 space-y-4">
+        <h2 class="font-display text-2xl font-bold text-ink-strong">Треті сторони</h2>
+        <p class="text-ink-soft">
+          Movar не вбудовує жодних сторонніх скриптів, аналітики, рекламних мереж чи віддалених
+          конфігурацій. Розширення спілкується лише з сайтами, які ви самі обираєте, і лише для
+          того, щоб переписати вихідні URL у спосіб, описаний вище.
+        </p>
+      </section>
+
+      <section class="mt-12 space-y-4">
+        <h2 class="font-display text-2xl font-bold text-ink-strong">Діти</h2>
+        <p class="text-ink-soft">
+          Movar не збирає жодних даних, тож немає чого окремо розкривати щодо даних дітей.
+          Розширенням можна користуватися в будь-якому віці.
+        </p>
+      </section>
+
+      <section class="mt-12 space-y-4">
+        <h2 class="font-display text-2xl font-bold text-ink-strong">Зміни в цій політиці</h2>
+        <p class="text-ink-soft">
+          Якщо поведінка Movar колись зміниться у спосіб, що стосуватиметься даних, які торкає
+          розширення, цю сторінку буде оновлено, а дату «Оновлено» вгорі — змінено. Попередній
+          текст залишиться в історії git проєкту.
+        </p>
+      </section>
+
+      <section class="mt-12 space-y-4">
+        <h2 class="font-display text-2xl font-bold text-ink-strong">Звʼязок</h2>
+        <p class="text-ink-soft">
+          Movar — це опенсорс під ліцензією MIT. Запитання, зауваження та звіти про помилки
+          вітаються в репозиторії проєкту (посилання зʼявиться у футері, коли репозиторій стане
+          публічним).
+        </p>
+      </section>
+    </article>
+  </main>
+  <Footer lang="uk" />
+</BaseLayout>


### PR DESCRIPTION
## Summary
Ticket #8 of the v1 release punch list.

Adds a second locale to the marketing site via Astro file-based routing — no library, no runtime resolution.

### Routes
| EN          | UK              |
| ----------- | --------------- |
| `/`         | `/uk/`          |
| `/privacy`  | `/uk/privacy`   |
| `/404`      | `/uk/404`       |

### Architecture
- **`src/i18n.ts`** holds the strings dictionary (keyed by `Locale = 'en' \| 'uk'`) plus path helpers (`alternateLocaleHref`, `localeHomeHref`, `localePrivacyHref`).
- **Shared components** (`BaseLayout`, `Header`, `Hero`, `Features`, `Footer`, `DownloadButtons`) accept a `lang` prop (default `'en'`) and look up text via the dictionary.
- **Locale switcher** in `Header` renders the alternate-locale label ("Українська" on EN pages, "English" on UK pages) and links to the matching path in the other locale.
- **Privacy** is structured prose — rather than parameterise every paragraph, the UK version lives as a parallel file (`src/pages/uk/privacy.astro`). The shorter pages (hero, features, footer, 404) draw text from the dictionary.
- **`BaseLayout`** stamps the correct `<html lang>`, `og:locale`, and locale-specific default `<title>` + meta description when the page doesn't override them.

### Translation source
- Hero/Features adapted from the UK store-listing draft in `apps/extension/STORE-LISTING.md`.
- Privacy translation is my best effort — should be **sanity-checked by a Ukrainian speaker** before the marketing launch.

### Why this approach
- Astro file-based routing is what we already use; no new dependencies.
- Two locales fit comfortably in one dictionary file; a third (e.g. `pl`) is a small extension.
- Inline UK privacy means edits to the policy can happen in one file per locale, not 30 string keys.

## Test plan
- [ ] Visit https://movar.fyi → EN site renders, switcher reads "Українська"
- [ ] Click switcher → lands on `/uk/`, full Ukrainian site, switcher reads "English"
- [ ] Visit `/privacy` → switcher takes you to `/uk/privacy` and back
- [ ] Native Ukrainian speaker reviews `/uk/` and `/uk/privacy` for tone, accuracy, and legalese
- [ ] View page source: `<html lang="uk">` on UK pages, `og:locale = "uk_UA"`
- [ ] Run `pnpm --filter @movar/marketing build` — 6 pages generated

## Rebase notes
This PR touches every shared component to add the `lang` prop. Open marketing PRs will need rebasing:
- [movar#7](https://github.com/rejifald/movar/pull/7) (Examples) — add `lang` prop to `Examples.astro`, expose UK strings.
- [movar#8](https://github.com/rejifald/movar/pull/8) (BeforeAfter) — same treatment for `BeforeAfter.astro`.

Both follow-ups are mechanical: copy the pattern from `Features.astro`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)