### PR TITLE
chore: add release verification script (pnpm verify:release)

### DIFF
--- a/deployment-checklist.md
+++ b/deployment-checklist.md
@@ -44,9 +44,13 @@ All targets ship as **Manifest V3** (`manifestVersion: 3` is forced in [wxt.conf
 
 ## Pre-submission verification
 
-- [ ] `pnpm lint` clean
-- [ ] `pnpm typecheck` clean
-- [ ] `pnpm test` passing
-- [ ] Manual smoke test in Chrome — popup, options, switching on a Russian-defaulting site
-- [ ] Manual smoke test in Firefox build
-- [ ] Verify zip contents do not include sourcemaps or `.env` files
+Automated checks — run `pnpm verify:release` to do all four in one go:
+
+- [ ] `pnpm validate` clean (typecheck + lint + test + publint)
+- [ ] Chrome and Firefox zips produced under `apps/extension/.output/`
+- [ ] Zip contents do not include sourcemaps, `.env`, `.DS_Store`, or `node_modules/`
+
+Manual — required after the script is green:
+
+- [ ] Smoke test in Chrome — load `.output/chrome-mv3/` unpacked, exercise popup, change a setting in options, visit a Russian-defaulting Ukrainian site, confirm switch
+- [ ] Smoke test in Firefox — same flow against `.output/firefox-mv3/`

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "format:check": "prettier --check .",
     "publint": "pnpm --workspace-concurrency=1 --filter @movar/shared --filter @movar/rules --filter @movar/lang-detect exec publint",
     "validate": "pnpm typecheck && pnpm lint && pnpm test && pnpm publint",
+    "verify:release": "bash scripts/verify-release.sh",
     "metrics": "mkdir -p .metrics; fallow --format markdown --score --save-snapshot > .metrics/fallow.md; fallow --format json --score > .metrics/fallow.json; tsx scripts/fallow-targets.mts",
     "metrics:audit": "fallow audit --base origin/main",
     "metrics:targets": "tsx scripts/fallow-targets.mts",

--- a/scripts/verify-release.sh
+++ b/scripts/verify-release.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+#
+# Pre-submission verification suite.
+#
+# Run from the repo root before submitting Movar to any extension store.
+# Performs every check that doesn't need a browser. Fails fast on the
+# first error — the store reviewers will too.
+#
+# Exit codes:
+#   0 — all checks passed; safe to upload the produced zips
+#   1 — at least one check failed; details in the output above
+#
+# Manual smoke testing in Chrome and Firefox is NOT covered here and
+# must be done by hand once this script is green. See:
+#   apps/extension/store-assets/README.md
+#   deployment-checklist.md
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+step() {
+  printf "\n==> %s\n" "$1"
+}
+
+ok() {
+  printf "    \033[32m✓\033[0m %s\n" "$1"
+}
+
+fail() {
+  printf "    \033[31m✗\033[0m %s\n" "$1"
+  exit 1
+}
+
+step "1/4 validate (typecheck + lint + test + publint)"
+pnpm validate
+ok "validate clean"
+
+step "2/4 build chrome zip"
+pnpm --filter @movar/extension zip
+chrome_zip=$(ls -t apps/extension/.output/*-chrome.zip 2>/dev/null | head -n 1)
+[ -n "$chrome_zip" ] || fail "no chrome zip produced under apps/extension/.output/"
+ok "produced $chrome_zip"
+
+step "3/4 build firefox zip"
+pnpm --filter @movar/extension zip:firefox
+firefox_zip=$(ls -t apps/extension/.output/*-firefox.zip 2>/dev/null | head -n 1)
+[ -n "$firefox_zip" ] || fail "no firefox zip produced under apps/extension/.output/"
+ok "produced $firefox_zip"
+
+step "4/4 inspect zip contents"
+inspect_zip() {
+  local zip="$1"
+  local label="$2"
+  printf "    inspecting %s\n" "$label"
+  local contents
+  contents=$(unzip -l "$zip")
+
+  local leaks=()
+  echo "$contents" | grep -qE '\.map$' && leaks+=("sourcemap (.map)")
+  echo "$contents" | grep -qE '(^|/)\.env(\.|$)' && leaks+=(".env file")
+  echo "$contents" | grep -q '\.DS_Store' && leaks+=(".DS_Store")
+  echo "$contents" | grep -q 'node_modules/' && leaks+=("node_modules/")
+
+  if [ "${#leaks[@]}" -gt 0 ]; then
+    for leak in "${leaks[@]}"; do
+      printf "    \033[31m✗\033[0m %s contains %s\n" "$label" "$leak"
+    done
+    exit 1
+  fi
+  ok "$label clean (no sourcemaps, .env, .DS_Store, or node_modules)"
+}
+
+inspect_zip "$chrome_zip" "chrome zip"
+inspect_zip "$firefox_zip" "firefox zip"
+
+printf "\n\033[32m●\033[0m All automated checks passed.\n"
+printf "  Next: manual smoke test per deployment-checklist.md §Pre-submission verification.\n"


### PR DESCRIPTION
## Summary
Ticket #10 of the v1 release punch list.

[scripts/verify-release.sh](scripts/verify-release.sh) bundles every pre-submission check that doesn't need a browser into one command. Run it from the repo root, get a green/red result.

### What it does (in order, fail-fast)
1. `pnpm validate` — typecheck + lint + test + publint
2. Build the Chrome zip via `wxt zip`
3. Build the Firefox zip via `wxt zip -b firefox`
4. Inspect each zip for sourcemaps (`*.map`), `.env`, `.DS_Store`, `node_modules/`

Coloured ✓/✗ markers so the first failure jumps out in scrollback.

### Discoverability
Wired up as `pnpm verify:release` at the root. [deployment-checklist.md](deployment-checklist.md) now points at the script instead of listing each command separately; the only remaining manual checkbox is the Chrome + Firefox smoke test against the produced zips.

### Verified
Ran against current main — all four steps pass. Output:
```
==> 1/4 validate (typecheck + lint + test + publint)
    ✓ validate clean
==> 2/4 build chrome zip
    ✓ produced apps/extension/.output/movarextension-1.0.0-chrome.zip
==> 3/4 build firefox zip
    ✓ produced apps/extension/.output/movarextension-1.0.0-firefox.zip
==> 4/4 inspect zip contents
    ✓ chrome zip clean (no sourcemaps, .env, .DS_Store, or node_modules)
    ✓ firefox zip clean (no sourcemaps, .env, .DS_Store, or node_modules)

● All automated checks passed.
```

### When to run
Rerun **after the v1 PR train merges** (movar#2–#10 in this branch sequence) and **before clicking submit** on any store dashboard. If the script fails, do not upload.

## Test plan
- [ ] After all v1 PRs land, run `pnpm verify:release` from a clean checkout, confirm exit 0
- [ ] Load both produced zips into a fresh Chrome and Firefox profile, smoke-test per the checklist

🤖 Generated with [Claude Code](https://claude.com/claude-code)