### PR TITLE
feat(extension): make options page editable

### DIFF
--- a/apps/extension/src/entrypoints/options/AllowlistSection.tsx
+++ b/apps/extension/src/entrypoints/options/AllowlistSection.tsx
@@ -1,0 +1,87 @@
+import { useState, type FormEvent } from 'react';
+import type { MovarSettings } from '@movar/shared';
+import { DOMAIN_PATTERN, IconButton, normaliseDomain } from './shared';
+
+interface Props {
+  settings: MovarSettings;
+  onChange: (next: MovarSettings) => void;
+}
+
+export function AllowlistSection({ settings, onChange }: Props) {
+  const [draft, setDraft] = useState('');
+  const [error, setError] = useState<string | null>(null);
+
+  const remove = (domain: string): void => {
+    onChange({ ...settings, allowlist: settings.allowlist.filter((d) => d !== domain) });
+  };
+
+  const submit = (event: FormEvent<HTMLFormElement>): void => {
+    event.preventDefault();
+    const domain = normaliseDomain(draft);
+    if (!domain) return;
+    if (!DOMAIN_PATTERN.test(domain)) {
+      setError('Enter a domain like example.com');
+      return;
+    }
+    if (settings.allowlist.includes(domain)) {
+      setError('Already on the list');
+      return;
+    }
+    onChange({ ...settings, allowlist: [...settings.allowlist, domain] });
+    setDraft('');
+    setError(null);
+  };
+
+  return (
+    <section>
+      <h3 className="font-display text-ink-strong mb-1.5 text-[22px] font-bold tracking-tight">
+        Exempt sites
+      </h3>
+      <p className="text-ink-soft mb-6 text-sm">Movar takes no action on these domains.</p>
+
+      {settings.allowlist.length === 0 ? (
+        <p className="text-ink-faint mb-4 text-sm italic">No sites are exempt.</p>
+      ) : (
+        <ul className="mb-4 flex max-w-md flex-wrap gap-2">
+          {settings.allowlist.map((domain) => (
+            <li
+              key={domain}
+              className="border-border bg-surface-2 text-ink-strong flex items-center gap-2 rounded-lg border px-3 py-1.5 font-mono text-[12.5px]"
+            >
+              <span>{domain}</span>
+              <IconButton
+                label={`Remove ${domain}`}
+                onClick={() => {
+                  remove(domain);
+                }}
+              >
+                ×
+              </IconButton>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      <form onSubmit={submit} className="flex max-w-md gap-2">
+        <input
+          type="text"
+          value={draft}
+          onChange={(e) => {
+            setDraft(e.target.value);
+            setError(null);
+          }}
+          placeholder="example.com"
+          aria-label="Domain to exempt"
+          className="border-border bg-surface text-ink-strong placeholder:text-ink-faint focus:border-accent flex-1 rounded-lg border px-3 py-2 font-mono text-[13px] outline-none"
+        />
+        <button
+          type="submit"
+          className="bg-ink-strong text-bg hover:bg-ink rounded-lg px-4 py-2 text-[13px] font-medium transition-colors"
+        >
+          Add
+        </button>
+      </form>
+      {error ? <p className="text-accent mt-2 text-[12.5px]">{error}</p> : null}
+    </section>
+  );
+}

--- a/apps/extension/src/entrypoints/options/App.tsx
+++ b/apps/extension/src/entrypoints/options/App.tsx
@@ -1,28 +1,14 @@
 import { useEffect, useState } from 'react';
 import { browser } from 'wxt/browser';
-import {
-  defaultSettings,
-  FEEDBACK_URL,
-  type LanguageCode,
-  type MovarSettings,
-} from '@movar/shared';
-import { getSettings } from '../../lib/settings';
+import { FEEDBACK_URL, defaultSettings, type MovarSettings } from '@movar/shared';
+import { getSettings, setSettings as persistSettings } from '../../lib/settings';
 import { BrandMark } from '../../components/BrandMark';
+import { PrioritySection } from './PrioritySection';
+import { BlockedSection } from './BlockedSection';
+import { AllowlistSection } from './AllowlistSection';
+import { PageContentSection } from './PageContentSection';
 
 const version = browser.runtime.getManifest().version;
-
-function displayLanguage(code: LanguageCode, locale?: string): string {
-  try {
-    const names = new Intl.DisplayNames(locale ? [locale] : undefined, { type: 'language' });
-    return names.of(code) ?? code;
-  } catch {
-    return code;
-  }
-}
-
-function flagLetter(code: LanguageCode): string {
-  return displayLanguage(code, code).charAt(0).toUpperCase();
-}
 
 export function App() {
   const [settings, setSettings] = useState<MovarSettings>(defaultSettings);
@@ -32,6 +18,11 @@ export function App() {
       setSettings(await getSettings());
     })();
   }, []);
+
+  const update = (next: MovarSettings): void => {
+    setSettings(next);
+    void persistSettings(next);
+  };
 
   return (
     <main className="bg-bg text-ink-strong min-h-screen px-6 py-10 font-sans">
@@ -54,54 +45,25 @@ export function App() {
         </header>
 
         <div className="grid grid-cols-[1fr_240px] gap-14 px-7 py-9">
-          <section>
-            <h3 className="font-display text-ink-strong mb-1.5 text-[22px] font-bold tracking-tight">
-              Language priority
-            </h3>
-            <p className="text-ink-soft mb-6 text-sm">
-              Movar will request each site in this order; the first available wins.
-            </p>
-
-            <ol className="flex max-w-md flex-col gap-2">
-              {settings.priority.map((code, i) => {
-                const primary = i === 0;
-                return (
-                  <li
-                    key={code}
-                    className={`flex items-center gap-3 rounded-lg border px-3.5 py-3 ${
-                      primary ? 'border-accent/30 bg-accent-surface' : 'border-border bg-surface-2'
-                    }`}
-                  >
-                    <div className="text-ink-faint w-4 font-mono text-[11px]">{i + 1}</div>
-                    <div
-                      className={`font-display flex size-[22px] items-center justify-center rounded-full text-[10.5px] font-bold ${
-                        primary ? 'bg-accent text-accent-on' : 'bg-surface-3 text-ink-strong'
-                      }`}
-                    >
-                      {flagLetter(code)}
-                    </div>
-                    <div className="text-ink-strong flex-1 text-sm font-medium">
-                      {displayLanguage(code, code)}
-                      <span className="text-ink-soft ml-1.5 text-[13px] font-normal">
-                        {displayLanguage(code, 'en')}
-                      </span>
-                    </div>
-                    <div className="border-border bg-surface text-ink-soft rounded border px-1.5 py-0.5 font-mono text-[11px]">
-                      {code}
-                    </div>
-                  </li>
-                );
-              })}
-            </ol>
-          </section>
+          <div className="space-y-10">
+            <PrioritySection settings={settings} onChange={update} />
+            <BlockedSection settings={settings} onChange={update} />
+            <AllowlistSection settings={settings} onChange={update} />
+            <PageContentSection settings={settings} onChange={update} />
+          </div>
 
           <aside className="border-border text-ink-soft border-l pt-1 pl-4 text-[12.5px] leading-[1.6]">
             <b className="text-ink-strong mb-1 block text-[13px] font-semibold">
               How priority works
             </b>
             Movar negotiates each request with the site&apos;s available languages. If a site offers
-            Ukrainian, it serves Ukrainian. If only English, English. If only Russian, Movar strips
-            the page from results entirely.
+            Ukrainian, it serves Ukrainian. If only English, English. If only Russian, Movar tries
+            to switch you away.
+            <b className="text-ink-strong mt-4 mb-1 block text-[13px] font-semibold">
+              Blocked vs exempt
+            </b>
+            <em>Blocked</em> languages trigger an automatic switch away.
+            <em> Exempt</em> sites are ignored entirely — Movar does nothing on them.
           </aside>
         </div>
       </div>

--- a/apps/extension/src/entrypoints/options/BlockedSection.tsx
+++ b/apps/extension/src/entrypoints/options/BlockedSection.tsx
@@ -1,0 +1,67 @@
+import { useMemo } from 'react';
+import type { LanguageCode, MovarSettings } from '@movar/shared';
+import { AddLanguagePicker, IconButton, SUPPORTED_LANGUAGES, displayLanguage } from './shared';
+
+interface Props {
+  settings: MovarSettings;
+  onChange: (next: MovarSettings) => void;
+}
+
+export function BlockedSection({ settings, onChange }: Props) {
+  const addable = useMemo(
+    () => SUPPORTED_LANGUAGES.filter((c) => !settings.blocked.includes(c)),
+    [settings.blocked],
+  );
+
+  const remove = (code: LanguageCode): void => {
+    onChange({ ...settings, blocked: settings.blocked.filter((c) => c !== code) });
+  };
+
+  const add = (code: LanguageCode): void => {
+    if (!code || settings.blocked.includes(code)) return;
+    onChange({ ...settings, blocked: [...settings.blocked, code] });
+  };
+
+  return (
+    <section>
+      <h3 className="font-display text-ink-strong mb-1.5 text-[22px] font-bold tracking-tight">
+        Blocked languages
+      </h3>
+      <p className="text-ink-soft mb-6 text-sm">
+        Movar will switch away from any page served in these languages.
+      </p>
+
+      {settings.blocked.length === 0 ? (
+        <p className="text-ink-faint mb-4 text-sm italic">No languages are blocked.</p>
+      ) : (
+        <ul className="mb-4 flex max-w-md flex-wrap gap-2">
+          {settings.blocked.map((code) => (
+            <li
+              key={code}
+              className="border-border bg-surface-2 text-ink-strong flex items-center gap-2 rounded-lg border px-3 py-1.5 text-[13px] font-medium"
+            >
+              <span>
+                {displayLanguage(code, code)}
+                <span className="text-ink-soft ml-1.5 text-[12px] font-normal">
+                  ({displayLanguage(code, 'en')})
+                </span>
+              </span>
+              <IconButton
+                label={`Unblock ${displayLanguage(code, 'en')}`}
+                onClick={() => {
+                  remove(code);
+                }}
+              >
+                ×
+              </IconButton>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      {addable.length > 0 ? (
+        <AddLanguagePicker label="Block another" options={addable} onAdd={add} />
+      ) : null}
+    </section>
+  );
+}

--- a/apps/extension/src/entrypoints/options/PageContentSection.tsx
+++ b/apps/extension/src/entrypoints/options/PageContentSection.tsx
@@ -1,0 +1,37 @@
+import type { MovarSettings } from '@movar/shared';
+
+interface Props {
+  settings: MovarSettings;
+  onChange: (next: MovarSettings) => void;
+}
+
+export function PageContentSection({ settings, onChange }: Props) {
+  const toggle = (): void => {
+    onChange({ ...settings, contentModification: !settings.contentModification });
+  };
+
+  return (
+    <section>
+      <h3 className="font-display text-ink-strong mb-1.5 text-[22px] font-bold tracking-tight">
+        Page content
+      </h3>
+      <p className="text-ink-soft mb-4 text-sm">
+        When on, Movar also hides blocked-language entries from on-site language pickers and blurs
+        content cards (e.g. YouTube videos) in a blocked language. Off by default; turn on if you
+        want a tidier page.
+      </p>
+
+      <label className="flex max-w-md cursor-pointer items-start gap-3">
+        <input
+          type="checkbox"
+          checked={settings.contentModification}
+          onChange={toggle}
+          className="accent-accent mt-0.5 size-4"
+        />
+        <span className="text-ink text-[13px] leading-relaxed">
+          Allow Movar to modify page content on visited sites.
+        </span>
+      </label>
+    </section>
+  );
+}

--- a/apps/extension/src/entrypoints/options/PrioritySection.tsx
+++ b/apps/extension/src/entrypoints/options/PrioritySection.tsx
@@ -1,0 +1,136 @@
+import { useMemo } from 'react';
+import type { LanguageCode, MovarSettings } from '@movar/shared';
+import {
+  AddLanguagePicker,
+  IconButton,
+  SUPPORTED_LANGUAGES,
+  displayLanguage,
+  flagLetter,
+} from './shared';
+
+interface Props {
+  settings: MovarSettings;
+  onChange: (next: MovarSettings) => void;
+}
+
+export function PrioritySection({ settings, onChange }: Props) {
+  const addable = useMemo(
+    () => SUPPORTED_LANGUAGES.filter((c) => !settings.priority.includes(c)),
+    [settings.priority],
+  );
+
+  const move = (from: number, to: number): void => {
+    if (to < 0 || to >= settings.priority.length) return;
+    const next = [...settings.priority];
+    const [item] = next.splice(from, 1);
+    if (item === undefined) return;
+    next.splice(to, 0, item);
+    onChange({ ...settings, priority: next });
+  };
+
+  const remove = (code: LanguageCode): void => {
+    if (settings.priority.length <= 1) return;
+    onChange({ ...settings, priority: settings.priority.filter((c) => c !== code) });
+  };
+
+  const add = (code: LanguageCode): void => {
+    if (!code || settings.priority.includes(code)) return;
+    onChange({ ...settings, priority: [...settings.priority, code] });
+  };
+
+  return (
+    <section>
+      <h3 className="font-display text-ink-strong mb-1.5 text-[22px] font-bold tracking-tight">
+        Language priority
+      </h3>
+      <p className="text-ink-soft mb-6 text-sm">
+        Movar will request each site in this order; the first available wins.
+      </p>
+
+      <ol className="flex max-w-md flex-col gap-2">
+        {settings.priority.map((code, i) => (
+          <PriorityItem
+            key={code}
+            code={code}
+            index={i}
+            isLast={i === settings.priority.length - 1}
+            canRemove={settings.priority.length > 1}
+            onMove={move}
+            onRemove={remove}
+          />
+        ))}
+      </ol>
+
+      {addable.length > 0 ? (
+        <AddLanguagePicker label="Add language" options={addable} onAdd={add} />
+      ) : null}
+    </section>
+  );
+}
+
+interface PriorityItemProps {
+  code: LanguageCode;
+  index: number;
+  isLast: boolean;
+  canRemove: boolean;
+  onMove: (from: number, to: number) => void;
+  onRemove: (code: LanguageCode) => void;
+}
+
+function PriorityItem({ code, index, isLast, canRemove, onMove, onRemove }: PriorityItemProps) {
+  const primary = index === 0;
+  const localName = displayLanguage(code, 'en');
+
+  return (
+    <li
+      className={`flex items-center gap-3 rounded-lg border px-3.5 py-3 ${
+        primary ? 'border-accent/30 bg-accent-surface' : 'border-border bg-surface-2'
+      }`}
+    >
+      <div className="text-ink-faint w-4 font-mono text-[11px]">{index + 1}</div>
+      <div
+        className={`font-display flex size-[22px] items-center justify-center rounded-full text-[10.5px] font-bold ${
+          primary ? 'bg-accent text-accent-on' : 'bg-surface-3 text-ink-strong'
+        }`}
+      >
+        {flagLetter(code)}
+      </div>
+      <div className="text-ink-strong flex-1 text-sm font-medium">
+        {displayLanguage(code, code)}
+        <span className="text-ink-soft ml-1.5 text-[13px] font-normal">{localName}</span>
+      </div>
+      <div className="border-border bg-surface text-ink-soft rounded border px-1.5 py-0.5 font-mono text-[11px]">
+        {code}
+      </div>
+      <div className="flex items-center gap-1">
+        <IconButton
+          label={`Move ${localName} up`}
+          disabled={index === 0}
+          onClick={() => {
+            onMove(index, index - 1);
+          }}
+        >
+          ↑
+        </IconButton>
+        <IconButton
+          label={`Move ${localName} down`}
+          disabled={isLast}
+          onClick={() => {
+            onMove(index, index + 1);
+          }}
+        >
+          ↓
+        </IconButton>
+        <IconButton
+          label={`Remove ${localName}`}
+          disabled={!canRemove}
+          onClick={() => {
+            onRemove(code);
+          }}
+        >
+          ×
+        </IconButton>
+      </div>
+    </li>
+  );
+}

--- a/apps/extension/src/entrypoints/options/shared.tsx
+++ b/apps/extension/src/entrypoints/options/shared.tsx
@@ -1,0 +1,108 @@
+import { useState, type ReactNode } from 'react';
+import type { LanguageCode } from '@movar/shared';
+
+/**
+ * Catalog of languages users can pick from in either list. Mirrors the
+ * "Preferred-language options" list in apps/extension/STORE-LISTING.md —
+ * keep them in sync when adding support for a new language.
+ */
+export const SUPPORTED_LANGUAGES: readonly LanguageCode[] = [
+  'uk',
+  'en',
+  'de',
+  'fr',
+  'es',
+  'it',
+  'pl',
+  'ru',
+];
+
+export function displayLanguage(code: LanguageCode, locale?: string): string {
+  try {
+    const names = new Intl.DisplayNames(locale ? [locale] : undefined, { type: 'language' });
+    return names.of(code) ?? code;
+  } catch {
+    return code;
+  }
+}
+
+export function flagLetter(code: LanguageCode): string {
+  return displayLanguage(code, code).charAt(0).toUpperCase();
+}
+
+/** Strip protocol, path, and port from whatever the user typed. */
+export function normaliseDomain(input: string): string {
+  return input
+    .trim()
+    .toLowerCase()
+    .replace(/^https?:\/\//, '')
+    .replace(/^www\./, '')
+    .replace(/[/:].*$/, '');
+}
+
+export const DOMAIN_PATTERN = /^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)+$/i;
+
+interface IconButtonProps {
+  label: string;
+  onClick: () => void;
+  disabled?: boolean;
+  children: ReactNode;
+}
+
+export function IconButton({ label, onClick, disabled = false, children }: IconButtonProps) {
+  return (
+    <button
+      type="button"
+      aria-label={label}
+      onClick={onClick}
+      disabled={disabled}
+      className="text-ink-soft hover:text-ink-strong hover:bg-surface-3 disabled:text-ink-faint flex size-7 items-center justify-center rounded-md font-mono text-[14px] transition-colors disabled:cursor-not-allowed disabled:hover:bg-transparent"
+    >
+      {children}
+    </button>
+  );
+}
+
+interface AddLanguagePickerProps {
+  label: string;
+  options: readonly LanguageCode[];
+  onAdd: (code: LanguageCode) => void;
+}
+
+export function AddLanguagePicker({ label, options, onAdd }: AddLanguagePickerProps) {
+  const [draft, setDraft] = useState('');
+
+  const handleAdd = (): void => {
+    if (!draft) return;
+    onAdd(draft);
+    setDraft('');
+  };
+
+  return (
+    <div className="mt-4 flex max-w-md items-center gap-2">
+      <select
+        value={draft}
+        onChange={(e) => {
+          setDraft(e.target.value);
+        }}
+        aria-label={label}
+        className="border-border bg-surface text-ink-strong focus:border-accent flex-1 rounded-lg border px-3 py-2 text-[13px] outline-none"
+      >
+        <option value="">{label}…</option>
+        {options.map((code) => (
+          <option key={code} value={code}>
+            {displayLanguage(code, 'en')} ({code})
+          </option>
+        ))}
+      </select>
+      <button
+        type="button"
+        onClick={handleAdd}
+        disabled={!draft}
+        className="bg-ink-strong text-bg hover:bg-ink disabled:bg-surface-3 disabled:text-ink-faint rounded-lg px-4 py-2 text-[13px] font-medium transition-colors disabled:cursor-not-allowed"
+      >
+        Add
+      </button>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
Replaces [movar#6](https://github.com/rejifald/movar/pull/6) — the original branch had a 326-line `App()` function that tripped the fallow `metrics` gate. This PR splits the page into per-section components so the audit passes.

Same surface area as movar#6: the options page becomes interactive with priority reorder/add/remove, blocked-language list, exempt-domain form, and the `contentModification` toggle.

### Structure
- `App.tsx` — thin shell: loads settings, owns the `update()` callback, composes the four sections.
- `PrioritySection.tsx` — priority list + add picker. The list item is its own `PriorityItem` component.
- `BlockedSection.tsx` — blocked-language chips + add picker.
- `AllowlistSection.tsx` — domain input form + chip list; owns the draft/error state.
- `PageContentSection.tsx` — `contentModification` checkbox.
- `shared.tsx` — `IconButton`, `AddLanguagePicker`, `SUPPORTED_LANGUAGES`, `displayLanguage`, `flagLetter`, `normaliseDomain`, `DOMAIN_PATTERN`.

### Why the rewrite
[fallow audit](https://fallow.tools) is wired into CI as a regression gate. The combined component was 326 lines / 6 cyclomatic / 42 CRAP — too far above threshold to merge. Splitting brings the largest function well under the limit while keeping the public behaviour identical.

\`pnpm metrics:audit\` now exits 0 against current main.

## Test plan
Identical to movar#6:
- [ ] Load unpacked, open options
- [ ] Reorder priority — confirm order persists across reload
- [ ] Remove the only priority entry — should be blocked (× disabled)
- [ ] Add a language to priority — appears at the end
- [ ] Block/unblock a language — popup reflects it
- [ ] Add \`example.com\` to exempt sites — visit \`https://example.com\`, confirm Movar takes no action
- [ ] Add \`HTTPS://Example.com/path:8080\` — stored as \`example.com\`
- [ ] Add a domain twice — "Already on the list"
- [ ] Toggle Page content on — picker hiding / card blurring activates on a relevant site

🤖 Generated with [Claude Code](https://claude.com/claude-code)