### PR TITLE
feat(marketing): add named-site examples section

### DIFF
--- a/apps/marketing/src/components/Examples.astro
+++ b/apps/marketing/src/components/Examples.astro
@@ -1,0 +1,82 @@
+---
+interface Example {
+  site: string;
+  scenario: string;
+  without: string;
+  withMovar: string;
+  technique: string;
+}
+
+const examples: Example[] = [
+  {
+    site: 'google.com.ua',
+    scenario: 'Cyrillic query like "політика" or "новини"',
+    without:
+      'Top results are Russian-language articles. Google sees Cyrillic text and falls back to the larger Russian corpus.',
+    withMovar:
+      'Movar appends hl=uk and lr=lang_uk to /search requests so Google pins the result language. Ukrainian articles return.',
+    technique: 'URL parameter rewrite',
+  },
+  {
+    site: 'youtube.com',
+    scenario: 'Cyrillic search such as "новини" or "інтерв’ю"',
+    without:
+      'Recommendations and search results lean Russian. The interface picks up your browser locale but the recommendation engine does not.',
+    withMovar:
+      'Movar adds hl=uk and gl=UA so YouTube treats you as a Ukrainian-locale viewer for both interface and ranking.',
+    technique: 'URL parameter rewrite',
+  },
+  {
+    site: 'electrica-shop.com.ua',
+    scenario: 'Open any product page from a Ukrainian search result',
+    without:
+      'The site defaults to its Russian version at the root path even though it has a full Ukrainian version under /ua/.',
+    withMovar:
+      'Movar sets the site’s own lang cookie to "ua" and follows the page’s hreflang link to the Ukrainian counterpart. You stay in Ukrainian for the whole session.',
+    technique: 'Cookie + hreflang follow',
+  },
+];
+---
+
+<section id="examples" class="border-t border-border bg-bg px-6 py-20">
+  <div class="mx-auto max-w-5xl">
+    <h2 class="font-display text-3xl font-extrabold tracking-tight text-ink-strong sm:text-4xl">
+      What you&apos;ll actually notice
+    </h2>
+    <p class="mt-3 max-w-2xl text-ink-soft">
+      Three sites where Movar changes what reaches your screen. Same mechanism applies to
+      every Google ccTLD, Bing, DuckDuckGo, and a growing list of bilingual sites.
+    </p>
+
+    <div class="mt-10 space-y-6">
+      {
+        examples.map((example) => (
+          <article class="rounded-2xl border border-border bg-surface p-6 shadow-sm sm:p-8">
+            <div class="flex flex-wrap items-baseline justify-between gap-3">
+              <h3 class="font-display text-xl font-bold text-ink-strong">{example.site}</h3>
+              <span class="rounded-full border border-border bg-bg px-3 py-1 font-mono text-[11px] tracking-wide text-ink-soft uppercase">
+                {example.technique}
+              </span>
+            </div>
+            <p class="mt-2 text-sm text-ink-soft italic">{example.scenario}</p>
+
+            <div class="mt-5 grid gap-4 sm:grid-cols-2">
+              <div class="rounded-xl border border-border bg-bg p-4">
+                <div class="font-mono text-[10.5px] tracking-[0.1em] text-ink-faint uppercase">
+                  Without Movar
+                </div>
+                <p class="mt-2 text-sm leading-relaxed text-ink">{example.without}</p>
+              </div>
+              <div class="rounded-xl border border-accent/30 bg-accent-surface p-4">
+                <div class="font-mono text-[10.5px] tracking-[0.1em] text-accent uppercase">
+                  With Movar
+                </div>
+                <p class="mt-2 text-sm leading-relaxed text-ink-strong">{example.withMovar}</p>
+              </div>
+            </div>
+          </article>
+        ))
+      }
+    </div>
+  </div>
+</section>

--- a/apps/marketing/src/pages/index.astro
+++ b/apps/marketing/src/pages/index.astro
@@ -2,6 +2,7 @@
 import BaseLayout from '../layouts/BaseLayout.astro';
 import Header from '../components/Header.astro';
 import Hero from '../components/Hero.astro';
+import Examples from '../components/Examples.astro';
 import BeforeAfter from '../components/BeforeAfter.astro';
 import Features from '../components/Features.astro';
 import Footer from '../components/Footer.astro';
@@ -11,6 +12,7 @@ import Footer from '../components/Footer.astro';
   <Header />
   <main class="flex-1">
     <Hero />
+    <Examples />
     <BeforeAfter />
     <Features />
   </main>


### PR DESCRIPTION
## Summary
Replaces [movar#7](https://github.com/rejifald/movar/pull/7) — the original branch was inadvertently built on top of the editable-options-page branch, so it carried a 326-line `App.tsx` that tripped the fallow metrics gate. This PR is rebased onto current `main` so it contains only the Examples component + `index.astro` slot.

Adds an `Examples` component between Hero and Features showing three real sites with side-by-side "without Movar / with Movar" cards: `google.com.ua`, `youtube.com`, `electrica-shop.com.ua`. All three are real entries in `packages/rules/src/index.ts`.

### Difference from movar#7
- Drops the carried `feat: make options page editable` commit (now living separately in [movar#12](https://github.com/rejifald/movar/pull/12)).
- `index.astro` slots `<Examples />` *after* `<Hero />` and *before* `<BeforeAfter />` (from [movar#8](https://github.com/rejifald/movar/pull/8) which is already on main). Reading order: Hero → Examples → BeforeAfter → Features.

## Test plan
- [ ] After deploy, scroll through Hero → Examples → BeforeAfter → Features → Footer in that order
- [ ] Verify each "with Movar" claim against the actual rule in `packages/rules/src/index.ts`
- [ ] Spot-check Russian-language Cyrillic query on `google.com.ua` with/without the extension

🤖 Generated with [Claude Code](https://claude.com/claude-code)