### PR TITLE
feat(marketing): auto-detect locale via Accept-Language at the edge

### DIFF
--- a/.github/workflows/deploy-marketing.yml
+++ b/.github/workflows/deploy-marketing.yml
@@ -80,7 +80,12 @@ jobs:
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           wranglerVersion: '4.95.0'
           packageManager: pnpm
-          command: pages deploy apps/marketing/dist --project-name=movar-marketing --branch=${{ github.head_ref || github.ref_name }}
+          # wrangler resolves the Pages `functions/` directory relative to its
+          # cwd (process.cwd() + '/functions'; there is no --functions-directory
+          # flag). Running from apps/marketing/ means it picks up the locale
+          # auto-redirect middleware at apps/marketing/functions/_middleware.ts.
+          workingDirectory: apps/marketing
+          command: pages deploy dist --project-name=movar-marketing --branch=${{ github.head_ref || github.ref_name }}
           gitHubToken: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Missing-secrets notice

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ node_modules
 dist
 .output
 .wxt
+.wrangler
 .astro
 .nx/cache
 .nx/workspace-data

--- a/apps/marketing/functions/_middleware.ts
+++ b/apps/marketing/functions/_middleware.ts
@@ -1,0 +1,108 @@
+/**
+ * Locale autodetect middleware for movar.fyi.
+ *
+ * Cloudflare Pages Function that intercepts requests to the English canonical
+ * paths and 302-redirects users whose Accept-Language header prefers Ukrainian
+ * to the matching /uk/ page. Requests for static assets, the already-/uk/-
+ * prefixed pages, and any path without an EN canonical entry pass straight
+ * through.
+ *
+ * Mirror this map whenever a new EN page gains a UK counterpart in
+ * src/pages/. A missing entry means the EN URL still works but never auto-
+ * redirects, which is silent breakage rather than a loud failure.
+ *
+ * Locally: `pnpm --filter @movar/marketing build && cd apps/marketing &&
+ * pnpm exec wrangler pages dev dist` then curl with -H 'Accept-Language: uk'.
+ */
+
+interface PagesContext {
+  request: Request;
+  next: () => Promise<Response>;
+}
+
+// Targets use the trailing-slash form Cloudflare Pages serves directly for
+// each Astro-built directory route. Hitting /uk/privacy would otherwise
+// 308-redirect to /uk/privacy/, doubling the visible redirect for the user.
+const UK_COUNTERPART: Record<string, string> = {
+  '/': '/uk/',
+  '/privacy': '/uk/privacy/',
+};
+
+interface ParsedTag {
+  primary: string;
+  q: number;
+}
+
+/**
+ * Parse an Accept-Language header into primary subtags in user-preference
+ * order. Honours q-values; missing q defaults to 1. Bad q-values fall back
+ * to 1 so we degrade to "best effort" rather than dropping the entry.
+ *
+ *   "uk-UA,uk;q=0.9,en-US;q=0.8,en;q=0.7"  →  ['uk', 'uk', 'en', 'en']
+ */
+function preferredPrimaryTags(header: string | null): string[] {
+  if (!header) return [];
+  const parsed: ParsedTag[] = [];
+  for (const part of header.split(',')) {
+    const [rawTag, ...params] = part.trim().split(';');
+    if (!rawTag) continue;
+    const primary = rawTag.toLowerCase().split('-')[0];
+    if (!primary) continue;
+    const qParam = params.find((p) => p.trim().startsWith('q='));
+    const parsedQ = qParam ? Number.parseFloat(qParam.trim().slice(2)) : 1;
+    const q = Number.isFinite(parsedQ) ? parsedQ : 1;
+    if (q > 0) parsed.push({ primary, q });
+  }
+  parsed.sort((a, b) => b.q - a.q);
+  return parsed.map((entry) => entry.primary);
+}
+
+/**
+ * Did the visitor ask for Ukrainian above English? We only redirect when uk
+ * appears first; if the user explicitly prefers en over uk, we stay on EN.
+ * Any visitor without uk in their list keeps the EN default.
+ */
+function prefersUkrainian(header: string | null): boolean {
+  for (const tag of preferredPrimaryTags(header)) {
+    if (tag === 'uk') return true;
+    if (tag === 'en') return false;
+  }
+  return false;
+}
+
+/** Append Accept-Language to the response's Vary header without duplicating it. */
+function markVaryAcceptLanguage(response: Response): Response {
+  const merged = new Response(response.body, response);
+  const tokens = new Set(
+    (merged.headers.get('Vary') ?? '')
+      .split(',')
+      .map((token) => token.trim())
+      .filter(Boolean),
+  );
+  tokens.add('Accept-Language');
+  merged.headers.set('Vary', [...tokens].join(', '));
+  return merged;
+}
+
+export async function onRequest(context: PagesContext): Promise<Response> {
+  const url = new URL(context.request.url);
+  // Normalise trailing slash so /privacy and /privacy/ hit the same entry.
+  const path = url.pathname === '/' ? '/' : url.pathname.replace(/\/+$/, '');
+  const ukTarget = UK_COUNTERPART[path];
+
+  // Anything outside the EN canonical set (assets, /uk/*, unknown paths) is
+  // not our concern — fall through untouched so the edge cache stays clean.
+  if (!ukTarget) {
+    return context.next();
+  }
+
+  if (prefersUkrainian(context.request.headers.get('accept-language'))) {
+    const redirect = new URL(ukTarget, url.origin);
+    redirect.search = url.search;
+    return Response.redirect(redirect.toString(), 302);
+  }
+
+  // Served EN — tell shared caches the choice depended on Accept-Language so
+  // they don't hand the EN HTML to a Ukrainian visitor on a later request.
+  return markVaryAcceptLanguage(await context.next());
+}

--- a/apps/marketing/functions/tsconfig.json
+++ b/apps/marketing/functions/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "types": []
+  },
+  "include": ["**/*.ts"]
+}

--- a/apps/marketing/src/components/Header.astro
+++ b/apps/marketing/src/components/Header.astro
@@ -1,21 +1,18 @@
 ---
-import {
-  alternateLocaleHref,
-  localeHomeHref,
-  localePrivacyHref,
-  strings,
-  type Locale,
-} from '../i18n';
+import { localeHomeHref, localePrivacyHref, strings, type Locale } from '../i18n';
 
 interface Props {
   lang?: Locale;
 }
 
+// Locale is intentionally not user-switchable from the UI — the visitor's
+// Accept-Language header is the source of truth, applied at the edge by
+// functions/_middleware.ts. Anyone who needs the alternate locale can use
+// their browser's language preference or type the /uk/ path directly.
 const { lang = 'en' } = Astro.props;
 const t = strings[lang];
 const home = localeHomeHref(lang);
 const privacy = localePrivacyHref(lang);
-const alternateHref = alternateLocaleHref(Astro.url.pathname, lang);
 ---
 
 <header
@@ -30,12 +27,6 @@ const alternateHref = alternateLocaleHref(Astro.url.pathname, lang);
       <a href={`${home}#how`} class="hover:text-ink-strong transition">{t.nav.howItWorks}</a>
       <a href={`${home}#download`} class="hover:text-ink-strong transition">{t.nav.download}</a>
       <a href={privacy} class="hover:text-ink-strong transition">{t.nav.privacy}</a>
-      <a
-        href={alternateHref}
-        class="border-l border-border/60 pl-6 font-mono text-[12px] hover:text-ink-strong transition"
-      >
-        {t.switcher.alternateLabel}
-      </a>
     </nav>
   </div>
 </header>

--- a/apps/marketing/src/i18n.ts
+++ b/apps/marketing/src/i18n.ts
@@ -3,10 +3,13 @@
  *
  * Components accept a `lang: Locale` prop and look up their strings in the
  * dictionary below. Pages declare their lang by routing — /index.astro is
- * English, /uk/index.astro is Ukrainian — and pass it down.
+ * English, /uk/index.astro is Ukrainian — and pass it down. Visitors are
+ * routed between the two on first hit by functions/_middleware.ts, which
+ * reads Accept-Language and 302-redirects /* → /uk/* for Ukrainian speakers.
  *
  * Adding a third locale: extend the union, add a key to `strings`, update
- * `alternateLocaleHref` to handle the third path prefix.
+ * `alternateLocaleHref` to handle the third path prefix, and add a row to
+ * the UK_COUNTERPART map in functions/_middleware.ts (or generalise it).
  */
 
 export type Locale = 'en' | 'uk';
@@ -47,11 +50,6 @@ interface FooterStrings {
 interface DownloadStrings {
   add: Record<'chrome' | 'edge' | 'firefox', string>;
   soon: string;
-}
-
-interface SwitcherStrings {
-  /** Label of the OTHER locale (shown in the switcher link). */
-  alternateLabel: string;
 }
 
 interface MetaStrings {
@@ -96,7 +94,6 @@ export interface Strings {
   features: FeaturesStrings;
   footer: FooterStrings;
   download: DownloadStrings;
-  switcher: SwitcherStrings;
 }
 
 const en: Strings = {
@@ -199,9 +196,6 @@ const en: Strings = {
       firefox: 'Add to Firefox',
     },
     soon: 'Soon',
-  },
-  switcher: {
-    alternateLabel: 'Українська',
   },
 };
 
@@ -306,17 +300,13 @@ const uk: Strings = {
     },
     soon: 'Скоро',
   },
-  switcher: {
-    alternateLabel: 'English',
-  },
 };
 
 export const strings: Record<Locale, Strings> = { en, uk };
 
 function enToUk(pathname: string): string {
-  const trimmed = pathname.replace(/\/$/, '');
-  if (trimmed === '') return '/uk/';
-  return `/uk${trimmed}`;
+  if (pathname === '' || pathname === '/') return '/uk/';
+  return `/uk${pathname}`;
 }
 
 function ukToEn(pathname: string): string {
@@ -326,8 +316,9 @@ function ukToEn(pathname: string): string {
 }
 
 /**
- * Compute the path to the same page in the other locale. Used by the
- * language switcher in the header.
+ * Compute the path to the same page in the other locale. Used by
+ * BaseLayout's `<link rel="alternate" hreflang>` tags so search engines can
+ * route directly to the matching locale.
  *
  *   /                    →  /uk/
  *   /privacy             →  /uk/privacy

--- a/apps/marketing/src/layouts/BaseLayout.astro
+++ b/apps/marketing/src/layouts/BaseLayout.astro
@@ -1,6 +1,6 @@
 ---
 import '../styles/global.css';
-import { strings, type Locale } from '../i18n';
+import { alternateLocaleHref, strings, type Locale } from '../i18n';
 
 interface Props {
   lang?: Locale;
@@ -14,6 +14,15 @@ const resolvedTitle = title ?? t.meta.defaultTitle;
 const resolvedDescription = description ?? t.meta.defaultDescription;
 
 const canonicalURL = new URL(Astro.url.pathname, Astro.site).toString();
+
+// hreflang: every page declares both locales plus x-default (which we point
+// at the EN URL — same as what an Accept-Language=en visitor would land on).
+// Lets Google route SERP clicks straight to the right locale and prevents
+// the two versions from being treated as duplicates.
+const enPath = lang === 'en' ? Astro.url.pathname : alternateLocaleHref(Astro.url.pathname, lang);
+const ukPath = lang === 'uk' ? Astro.url.pathname : alternateLocaleHref(Astro.url.pathname, lang);
+const enHref = new URL(enPath, Astro.site).toString();
+const ukHref = new URL(ukPath, Astro.site).toString();
 ---
 
 <!doctype html>
@@ -25,6 +34,9 @@ const canonicalURL = new URL(Astro.url.pathname, Astro.site).toString();
     <title>{resolvedTitle}</title>
     <meta name="description" content={resolvedDescription} />
     <link rel="canonical" href={canonicalURL} />
+    <link rel="alternate" hreflang="en" href={enHref} />
+    <link rel="alternate" hreflang="uk" href={ukHref} />
+    <link rel="alternate" hreflang="x-default" href={enHref} />
     <link rel="icon" type="image/svg+xml" href="/icon.svg" />
     <meta name="theme-color" content="#1C1917" />
 

--- a/tooling/eslint-config-movar/configs/ignores.js
+++ b/tooling/eslint-config-movar/configs/ignores.js
@@ -10,6 +10,7 @@ export const workspaceIgnores = {
     '**/dist/**',
     '**/.output/**',
     '**/.wxt/**',
+    '**/.wrangler/**',
     '**/.nx/**',
     '**/coverage/**',
     '**/*.tsbuildinfo',


### PR DESCRIPTION
Ukrainian-browser visitors were landing on the English version because the static build had no language detection. A Cloudflare Pages Function now reads Accept-Language and 302-redirects the EN canonical paths to /uk/ when Ukrainian outranks English, with Vary: Accept-Language on the pass-through so shared caches don't poison.

Also adds hreflang link tags (en, uk, x-default) so Google can route SERP clicks directly to the right locale, removes the EN <-> UA switcher (the browser is now the source of truth), tightens enToUk to preserve trailing slashes so hreflang URLs reciprocate exactly, and sets workingDirectory on the deploy step so wrangler resolves functions/ from apps/marketing/.