### PR TITLE
feat: add UA-language exonyms, Storybook, e2e scaffold, privacy refresh

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -18,6 +18,24 @@
       "runtimeExecutable": "pnpm",
       "runtimeArgs": ["--filter", "@movar/extension", "preview:options"],
       "port": 4323
+    },
+    {
+      "name": "storyboards",
+      "runtimeExecutable": "pnpm",
+      "runtimeArgs": ["--filter", "@movar/extension", "preview:storyboards"],
+      "port": 4324
+    },
+    {
+      "name": "ui-storybook",
+      "runtimeExecutable": "pnpm",
+      "runtimeArgs": ["--filter", "@movar/ui", "storybook"],
+      "port": 6006
+    },
+    {
+      "name": "marketing-storybook",
+      "runtimeExecutable": "pnpm",
+      "runtimeArgs": ["--filter", "@movar/marketing", "storybook"],
+      "port": 6007
     }
   ]
 }

--- a/.github/workflows/deploy-marketing.yml
+++ b/.github/workflows/deploy-marketing.yml
@@ -8,23 +8,19 @@ on:
       - 'pnpm-lock.yaml'
       - 'pnpm-workspace.yaml'
       - '.github/workflows/deploy-marketing.yml'
-  pull_request:
-    paths:
-      - 'apps/marketing/**'
-      - 'pnpm-lock.yaml'
-      - 'pnpm-workspace.yaml'
-      - '.github/workflows/deploy-marketing.yml'
   workflow_dispatch:
 
 permissions:
   contents: read
   deployments: write
-  pull-requests: write
 
 jobs:
   deploy:
     runs-on: ubuntu-latest
     name: Build & deploy marketing site
+    # Belt-and-braces: push trigger is already pinned to main, and this guard
+    # blocks workflow_dispatch from any other branch.
+    if: github.ref == 'refs/heads/main'
     env:
       HAS_CF_CREDS: ${{ secrets.CLOUDFLARE_API_TOKEN != '' && secrets.CLOUDFLARE_ACCOUNT_ID != '' }}
     steps:
@@ -85,7 +81,7 @@ jobs:
           # flag). Running from apps/marketing/ means it picks up the locale
           # auto-redirect middleware at apps/marketing/functions/_middleware.ts.
           workingDirectory: apps/marketing
-          command: pages deploy dist --project-name=movar-marketing --branch=${{ github.head_ref || github.ref_name }}
+          command: pages deploy dist --project-name=movar-marketing --branch=${{ github.ref_name }}
           gitHubToken: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Missing-secrets notice

--- a/apps/e2e/README.md
+++ b/apps/e2e/README.md
@@ -1,0 +1,128 @@
+# @movar/e2e — live-website end-to-end suite
+
+> Run against the real internet. **Manual only**; not gated on PRs.
+
+This suite verifies the four-part contract for every site that ships a
+rule (or that we want generic-fallback coverage on):
+
+1. **Opens in Russian** — the start URL serves RU content (`<html lang>`
+   - body-text Cyrillic detection agree).
+2. **Recognised** — Movar's `detectPageLanguage` logged `fromLang: 'ru'`
+   for the domain in its correction-event store.
+3. **Switched** — the final URL matches the fixture's `afterMovar.url`
+   pattern, and `<html lang>` is `uk`.
+4. **Hidden** — `data-movar-hidden` is populated on picker items
+   (and/or `data-movar-curtain` for the YouTube content-filter blur).
+
+## Sites covered
+
+| Site                    | Kind   | What it tests                                           |
+| ----------------------- | ------ | ------------------------------------------------------- |
+| `electrica-shop.com.ua` | site   | `cookie + hreflang` rule + class-name picker classify   |
+| `uamade.ua`             | site   | Generic hreflang fallback + CS-Cart `ty-select` picker  |
+| `001.com.ua`            | site   | Generic hreflang fallback + bare-text `UA \| RU` picker |
+| `duckduckgo.com`        | search | Enforce-mode `kl=ua-uk` URL rewrite                     |
+| `bing.com`              | search | Enforce-mode `setlang=uk` URL rewrite                   |
+| `google.com`            | search | Enforce-mode `hl + lr` URL rewrite                      |
+| `youtube.com`           | search | Enforce `hl + gl` + DOM content-filter blur on RU cards |
+
+To add another rule-bearing site: copy any file under `src/sites/`,
+adjust the fixture, and re-export from `src/sites/index.ts`. The spec
+picks it up automatically.
+
+## Running
+
+```bash
+# One-time
+pnpm install
+pnpm --filter @movar/e2e install:browsers
+
+# Build the extension and run the suite
+pnpm test:e2e:live
+
+# Headed mode for live debugging
+pnpm --filter @movar/e2e test:live:headed
+
+# Playwright UI mode
+pnpm --filter @movar/e2e test:live:ui
+```
+
+The Nx target `e2e:test:live` declares `extension:build` as a
+dependency, so the extension's WXT production output is always fresh
+before tests run.
+
+## A note on running from Ukraine
+
+The three Ukrainian e-com sites (`electrica-shop`, `uamade`, `001`) all
+server-side geolocate UA visitors to the UA version regardless of
+`Accept-Language` or the `lang=ru` preCookie. From a Ukrainian IP, the
+suite reports:
+
+- Test 1 (baseline opens in Russian) — **skipped via tolerant fixture**:
+  the `initial` expectations accept `uk` as a valid baseline. Movar's
+  redirect path has nothing to fix here, which is correct.
+- Test 2/3 (recognise + switch) — **explicitly skipped** with a clear
+  message. The skip is honest: nothing to redirect from.
+- Test 4 (hide blocked options) — **runs and passes**. The picker filter
+  fires regardless of starting state, and is the user-facing UX you
+  most want to verify on every run.
+
+To fully exercise the redirect path, run the suite from a non-UA exit
+point — either a VPN/proxy or a CI runner in another region. Playwright's
+`launchPersistentContext` accepts a `proxy` option; threading it into
+`src/fixtures/extension.ts` is a one-line change if you want a
+`MOVAR_E2E_PROXY` env knob.
+
+The search-engine tests (`google`, `youtube`, `bing`, `duckduckgo`)
+are not affected by this — the enforce-mode rule fires unconditionally
+on `/search` regardless of IP.
+
+## Flake handling
+
+Real sites flake. The suite mitigates rather than denies:
+
+- **One worker, no parallelism.** A flaky Google CAPTCHA on worker 1
+  doesn't poison worker 2.
+- **No retries.** A failure usually means the site changed (rule needs
+  updating); silent retries would hide that.
+- **`SKIP_GOOGLE=1` / `SKIP_YOUTUBE=1` env vars.** When anti-bot is up,
+  bypass those specific sites without skipping the whole run.
+- **Traces + video on failure.** Open `playwright-report/` after a
+  failed run to see exactly what Movar's content script did.
+
+If a site's `initial: { bodyDetected }` set says `['ru', 'uk', 'unknown']`,
+that's the fixture telling you "this site geolocates and sometimes
+serves UA from a UA IP — accept either as a starting state". The
+post-Movar assertion still demands `uk`, which is the property under
+test.
+
+## Picker-filter assertion tolerance
+
+The picker-filter test (test 4) asserts on Movar's DOM signals:
+
+- `data-movar-hidden` count ≥ `minHiddenLinks`.
+- Each `hiddenSelectors` entry resolved to a node with `display:none` or
+  `aria-hidden="true"`.
+- Each `visibleSelectors` entry is **either** visible **or** its picker
+  container has a Movar curtain (`data-movar-curtain` +
+  `data-movar-kind="picker-container"`) immediately preceding an
+  ancestor.
+
+The two-mode tolerance is intentional: `filterPickers` collapses a
+picker container into a chip overlay in strict mode (when no `blocked`
+array is provided and only ≤1 language survives), but in production —
+where `settings.blocked` is always populated — survives stay visible
+with a tooltip. The fixture accepts both because the user-facing
+property ("Movar reacted, the user still has access to the language they
+want") is satisfied either way.
+
+## What this suite is NOT
+
+- It does not measure rule-bearing-site result quality (e.g. "are
+  Google's results mostly UA after `lr=lang_uk`"). That's a hard
+  signal-vs-noise problem; the rule's job is just to write the URL
+  knob.
+- It does not exercise the popup, options page, or background DNR.
+  Vitest covers those in `apps/extension/src`.
+- It does not run on Firefox. Manual Firefox verification lives at
+  `pnpm --filter @movar/extension dev:firefox:installed`.

--- a/apps/e2e/eslint.config.mjs
+++ b/apps/e2e/eslint.config.mjs
@@ -1,0 +1,26 @@
+// @ts-check
+import { workspaceIgnores, base, quality, tests } from '@movar/eslint-config';
+
+/** @type {import("eslint").Linter.Config[]} */
+export default [
+  workspaceIgnores,
+  ...base,
+  ...quality,
+  ...tests,
+  {
+    ignores: ['playwright-report/**', 'test-results/**', '.movar-e2e-profile/**'],
+  },
+  {
+    // Playwright spec files are tests; loosen the same rules tests.js loosens
+    // for *.test.ts so we don't fight no-console / magic-numbers in fixtures.
+    files: [
+      'src/**/*.spec.ts',
+      'src/fixtures/**/*.ts',
+      'src/sites/**/*.ts',
+      'playwright.config.ts',
+    ],
+    rules: {
+      'no-console': 'off',
+    },
+  },
+];

--- a/apps/e2e/package.json
+++ b/apps/e2e/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "@movar/e2e",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "description": "Real-website end-to-end suite for Movar. Verifies the redirect / picker-filter / content-filter pipeline against live Ukrainian e-com sites and rule-bearing search engines. Manual-run only — not gated on PRs.",
+  "scripts": {
+    "typecheck": "tsc --noEmit",
+    "lint": "eslint .",
+    "test": "echo 'live-site e2e is opt-in — run `pnpm test:e2e:live` from the repo root, or `pnpm --filter @movar/e2e test:live` here' && exit 0",
+    "test:live": "playwright test",
+    "test:live:headed": "playwright test --headed",
+    "test:live:ui": "playwright test --ui",
+    "install:browsers": "playwright install chromium"
+  },
+  "dependencies": {
+    "@movar/lang-detect": "workspace:*",
+    "@movar/shared": "workspace:*"
+  },
+  "devDependencies": {
+    "@movar/eslint-config": "workspace:*",
+    "@playwright/test": "^1.49.1",
+    "@types/chrome": "^0.0.287",
+    "@types/node": "^22.10.5",
+    "eslint": "^9.39.4",
+    "typescript": "^6.0.3"
+  }
+}

--- a/apps/e2e/playwright.config.ts
+++ b/apps/e2e/playwright.config.ts
@@ -1,0 +1,55 @@
+import { defineConfig } from '@playwright/test';
+
+/**
+ * Manual-run live-website suite. Not wired into CI: real sites change
+ * unpredictably and the cost of a flaky merge gate is higher than the
+ * value of opportunistic coverage.
+ *
+ * The extension MUST be built before this runs — `nx run e2e:test:live`
+ * already declares the dependency. If you invoke `playwright test`
+ * directly, build with `pnpm --filter @movar/extension build` first.
+ *
+ * Why a single chromium project: Playwright cannot load MV3 extensions
+ * in true headless mode today, so `headless: false` is required. We
+ * could also exercise Firefox via `webkit`/`firefox` projects, but
+ * loading a signed XPI through Playwright's launcher is awkward; the
+ * existing `pnpm --filter @movar/extension dev:firefox:installed`
+ * script already covers manual Firefox verification.
+ */
+export default defineConfig({
+  testDir: './src/tests',
+  testMatch: '**/*.spec.ts',
+  // Live-network suite. One worker keeps the request load polite and
+  // means the per-site flake budget isn't shared across concurrent
+  // tabs racing on the same domain.
+  workers: 1,
+  fullyParallel: false,
+  // Real sites can stall behind anti-bot challenges; give each test
+  // enough budget to recover from a slow DNS or a 1-2s captcha probe.
+  timeout: 60_000,
+  expect: { timeout: 10_000 },
+  // No automatic retries: a real-site failure usually means the site
+  // changed (rule needs updating) — retrying just hides it. Re-run
+  // manually when you want a second look.
+  retries: 0,
+  reporter: [['list'], ['html', { outputFolder: 'playwright-report', open: 'never' }]],
+  use: {
+    // Extensions force headed in Playwright; this just makes it
+    // explicit — `pnpm test:live:headed` lifts it for live debugging.
+    headless: false,
+    // Real sites; trace + video on failure for postmortem.
+    trace: 'retain-on-failure',
+    video: 'retain-on-failure',
+    screenshot: 'only-on-failure',
+    actionTimeout: 15_000,
+    navigationTimeout: 30_000,
+  },
+  projects: [
+    {
+      name: 'chromium-with-movar',
+      // The fixture under src/fixtures/extension.ts is the load-bearing
+      // bit; no Playwright `use.channel` knobs are involved (persistent
+      // context launches its own Chromium).
+    },
+  ],
+});

--- a/apps/e2e/project.json
+++ b/apps/e2e/project.json
@@ -1,0 +1,28 @@
+{
+  "name": "e2e",
+  "$schema": "../../node_modules/nx/schemas/project-schema.json",
+  "projectType": "application",
+  "sourceRoot": "apps/e2e/src",
+  "targets": {
+    "typecheck": {
+      "executor": "nx:run-commands",
+      "options": { "command": "tsc --noEmit", "cwd": "apps/e2e" },
+      "cache": true
+    },
+    "lint": {
+      "executor": "nx:run-commands",
+      "options": { "command": "eslint .", "cwd": "apps/e2e" },
+      "cache": true
+    },
+    "test:live": {
+      "executor": "nx:run-commands",
+      "options": { "command": "playwright test", "cwd": "apps/e2e" },
+      "dependsOn": [{ "projects": ["extension"], "target": "build" }]
+    },
+    "test:live:headed": {
+      "executor": "nx:run-commands",
+      "options": { "command": "playwright test --headed", "cwd": "apps/e2e" },
+      "dependsOn": [{ "projects": ["extension"], "target": "build" }]
+    }
+  }
+}

--- a/apps/e2e/src/fixtures/extension.ts
+++ b/apps/e2e/src/fixtures/extension.ts
@@ -1,0 +1,156 @@
+/**
+ * Playwright fixture: launches Chromium with the WXT-built Movar extension
+ * loaded, exposes the MV3 service worker as a fixture so tests can seed
+ * settings and read correction events, and offers a paired "clean" context
+ * (no extension) for baseline assertions about what the site looks like
+ * before Movar touches it.
+ *
+ * Why persistent context: `chromium.launch()` doesn't accept extensions in
+ * MV3 — `launchPersistentContext` is the only path. We point it at a
+ * tmpdir (empty `userDataDir`) so each worker gets a fresh profile.
+ *
+ * Why headed: Playwright's true-headless Chromium can't load MV3 extensions.
+ * `playwright.config.ts` sets `headless: false`; this fixture inherits.
+ *
+ * Per-test isolation: `serviceWorker` clears `chrome.storage.sync` (settings)
+ * and `chrome.storage.local` (correction events) before re-seeding. Cookies
+ * and sessionStorage are per-context, so a fresh context = no carryover.
+ */
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+import {
+  type BrowserContext,
+  chromium,
+  test as base,
+  type Page,
+  type Worker,
+} from '@playwright/test';
+import { defaultSettings, type CorrectionEvent, type MovarSettings } from '@movar/shared';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+/** Path to the WXT production build of the Chrome extension. The
+ *  `e2e:test:live` Nx target lists `extension:build` as a dependency, so
+ *  by the time tests run this directory exists. */
+export const EXTENSION_PATH = path.resolve(__dirname, '../../../extension/.output/chrome-mv3');
+
+/** Settings the e2e suite stamps over `defaultSettings`. We turn
+ *  `contentModification` on because the picker-filter and content-filter
+ *  assertions are exactly what that flag gates. */
+export const E2E_SETTINGS: MovarSettings = {
+  ...defaultSettings,
+  contentModification: true,
+};
+
+export interface MovarFixtures {
+  /** Chromium context with Movar loaded; settings seeded to `E2E_SETTINGS`. */
+  movarContext: BrowserContext;
+  /** Chromium context WITHOUT Movar, for baseline ("what does the site look
+   *  like to a user who never installed Movar") assertions. */
+  cleanContext: BrowserContext;
+  /** Fresh page in `movarContext`. */
+  movarPage: Page;
+  /** Fresh page in `cleanContext`. */
+  cleanPage: Page;
+  /** Movar's MV3 service worker. Use `.evaluate` to call extension APIs:
+   *  read correction events, mutate settings, drive the message bus. */
+  serviceWorker: Worker;
+  /** Convenience: returns CorrectionEvents Movar recorded for `domain`. */
+  getCorrections: (domain: string) => Promise<CorrectionEvent[]>;
+  /** Convenience: stamp a partial settings update into `chrome.storage.sync`. */
+  setMovarSettings: (patch: Partial<MovarSettings>) => Promise<void>;
+}
+
+/** Wait for the MV3 service worker to be registered. `launchPersistentContext`
+ *  can return before the SW is up; Playwright emits a `serviceworker` event
+ *  once it boots. */
+async function waitForServiceWorker(context: BrowserContext): Promise<Worker> {
+  const existing = context.serviceWorkers();
+  if (existing[0]) return existing[0];
+  return await context.waitForEvent('serviceworker');
+}
+
+export const test = base.extend<MovarFixtures>({
+  movarContext: async ({ headless: _headless }, use) => {
+    const context = await chromium.launchPersistentContext('', {
+      headless: false,
+      args: [
+        `--disable-extensions-except=${EXTENSION_PATH}`,
+        `--load-extension=${EXTENSION_PATH}`,
+        // Headed Chromium in CI/automation often has GPU warnings; keep them
+        // out of the trace. Doesn't affect rendering for our purposes.
+        '--no-sandbox',
+        '--disable-dev-shm-usage',
+      ],
+    });
+    await use(context);
+    await context.close();
+  },
+
+  cleanContext: async ({ headless: _headless }, use) => {
+    const context = await chromium.launchPersistentContext('', {
+      headless: false,
+      args: ['--no-sandbox', '--disable-dev-shm-usage'],
+    });
+    await use(context);
+    await context.close();
+  },
+
+  serviceWorker: async ({ movarContext }, use) => {
+    const sw = await waitForServiceWorker(movarContext);
+    // Reset between tests. `storage.sync` falls back to local when there's
+    // no signed-in profile, so clearing both covers either backend.
+    await sw.evaluate(async () => {
+      await chrome.storage.sync.clear();
+      await chrome.storage.local.clear();
+    });
+    // Seed the fixed e2e settings.
+    await sw.evaluate(async (settings: MovarSettings) => {
+      await chrome.storage.sync.set({ settings });
+    }, E2E_SETTINGS);
+    await use(sw);
+  },
+
+  setMovarSettings: async ({ serviceWorker }, use) => {
+    const fn = async (patch: Partial<MovarSettings>): Promise<void> => {
+      await serviceWorker.evaluate(
+        async ({ patch: p, base: b }: { patch: Partial<MovarSettings>; base: MovarSettings }) => {
+          const stored = await chrome.storage.sync.get('settings');
+          const current = (stored['settings'] as MovarSettings | undefined) ?? b;
+          await chrome.storage.sync.set({ settings: { ...current, ...p } });
+        },
+        { patch, base: E2E_SETTINGS },
+      );
+    };
+    await use(fn);
+  },
+
+  getCorrections: async ({ serviceWorker }, use) => {
+    const fn = async (domain: string): Promise<CorrectionEvent[]> => {
+      const all = await serviceWorker.evaluate(async () => {
+        const data = await chrome.storage.local.get('movar:events');
+        return (data['movar:events'] as CorrectionEvent[] | undefined) ?? [];
+      });
+      return all.filter((e) => e.domain === domain);
+    };
+    await use(fn);
+  },
+
+  movarPage: async ({ movarContext, serviceWorker: _seedingDep }, use) => {
+    // The `serviceWorker` fixture seeds settings as a side effect. We list
+    // it here as a no-op dep to guarantee seeding completes before the
+    // test gets a page — otherwise the first navigation can race the
+    // content script's initial settings read.
+    const page = await movarContext.newPage();
+    await use(page);
+    await page.close();
+  },
+
+  cleanPage: async ({ cleanContext }, use) => {
+    const page = await cleanContext.newPage();
+    await use(page);
+    await page.close();
+  },
+});
+
+export { expect } from '@playwright/test';

--- a/apps/e2e/src/fixtures/lang-detect.ts
+++ b/apps/e2e/src/fixtures/lang-detect.ts
@@ -1,0 +1,40 @@
+/**
+ * Page-language readout used by the spec to verify Movar's algorithm. Pulls
+ * `<html lang>` + body text from the live page, then classifies the body via
+ * `@movar/lang-detect` — the same letter-signal heuristic Movar's content
+ * script uses internally. Two signals on the same surface: if both agree,
+ * the page really is in that language; if they disagree, the readout is
+ * surfaced verbatim so test failures point at the source of disagreement.
+ */
+import type { Page } from '@playwright/test';
+import {
+  type CyrillicLanguage,
+  type DetectionResult,
+  detectCyrillicLanguage,
+} from '@movar/lang-detect';
+
+export interface PageLangReadout {
+  url: string;
+  htmlLang: string;
+  detected: CyrillicLanguage;
+  ukScore: number;
+  ruScore: number;
+  bodyCharCount: number;
+}
+
+export async function readPageLanguage(page: Page): Promise<PageLangReadout> {
+  const htmlLang = await page.evaluate(() => document.documentElement.lang || '');
+  // textContent (not innerText) because Playwright evaluates in a real DOM
+  // context — textContent is cheap and avoids layout, which is plenty for
+  // Cyrillic-letter counting.
+  const bodyText = await page.evaluate(() => document.body?.textContent ?? '');
+  const det: DetectionResult = detectCyrillicLanguage(bodyText);
+  return {
+    url: page.url(),
+    htmlLang,
+    detected: det.language,
+    ukScore: det.ukScore,
+    ruScore: det.ruScore,
+    bodyCharCount: bodyText.length,
+  };
+}

--- a/apps/e2e/src/fixtures/movar-state.ts
+++ b/apps/e2e/src/fixtures/movar-state.ts
@@ -1,0 +1,69 @@
+/**
+ * Inspect what Movar has done to the current page from the DOM side:
+ *
+ *   - which elements carry `data-movar-hidden` (the picker-filter result)
+ *   - which curtain hosts are mounted (`data-movar-curtain` — content-filter
+ *     blur cards + picker-container chip overlays)
+ *   - whether the `[data-movar-restored]` marker was set (the user-pressed
+ *     "Show hidden options" path)
+ *
+ * Used by the parameterised spec to make per-site assertions without each
+ * fixture having to know Movar's attribute vocabulary.
+ */
+import type { Page } from '@playwright/test';
+
+export interface MovarDomState {
+  hiddenLinkCount: number;
+  curtainCount: number;
+  pickerContainerCurtainCount: number;
+  contentBlurCount: number;
+  trimmedTextCount: number;
+}
+
+export async function readMovarDomState(page: Page): Promise<MovarDomState> {
+  return await page.evaluate(() => {
+    const hiddenLinks = document.querySelectorAll('[data-movar-hidden]').length;
+    const curtainHosts = document.querySelectorAll('[data-movar-curtain]');
+    let containerKind = 0;
+    let blurKind = 0;
+    for (const h of curtainHosts) {
+      const kind = (h as HTMLElement).dataset['movarKind'];
+      if (kind === 'picker-container') containerKind += 1;
+      else blurKind += 1;
+    }
+    const trimmed = document.querySelectorAll('[data-movar-original-text]').length;
+    return {
+      hiddenLinkCount: hiddenLinks,
+      curtainCount: curtainHosts.length,
+      pickerContainerCurtainCount: containerKind,
+      contentBlurCount: blurKind,
+      trimmedTextCount: trimmed,
+    };
+  });
+}
+
+/** Wait until Movar has stopped modifying the page (no new
+ *  `data-movar-hidden` for N consecutive polls), or `timeoutMs` elapses. */
+export async function waitForMovarSettled(
+  page: Page,
+  options: { quietForMs?: number; timeoutMs?: number; pollIntervalMs?: number } = {},
+): Promise<void> {
+  const quietForMs = options.quietForMs ?? 800;
+  const timeoutMs = options.timeoutMs ?? 15_000;
+  const pollIntervalMs = options.pollIntervalMs ?? 150;
+  const start = Date.now();
+  let lastChange = Date.now();
+  let lastCount = -1;
+  while (Date.now() - start < timeoutMs) {
+    const count = await page
+      .evaluate(() => document.querySelectorAll('[data-movar-hidden],[data-movar-curtain]').length)
+      .catch(() => -2);
+    if (count !== lastCount) {
+      lastCount = count;
+      lastChange = Date.now();
+    } else if (Date.now() - lastChange >= quietForMs) {
+      return;
+    }
+    await new Promise((r) => setTimeout(r, pollIntervalMs));
+  }
+}

--- a/apps/e2e/src/sites/001.ts
+++ b/apps/e2e/src/sites/001.ts
@@ -1,0 +1,44 @@
+/**
+ * 001.com.ua — Ukrainian electronics catalogue. No site rule; relies on
+ * the generic hreflang strategy + picker heuristic.
+ *
+ * RU start: `/delux` (the bare RU path) with `Accept-Language: ru`. The
+ * canonical hreflang says `ru → /delux`, `uk → /uk/delux`.
+ *
+ * Switch path: Movar reads `<link rel="alternate" hreflang="uk">` and
+ * navigates to `/uk/delux`.
+ *
+ * Picker filter: the "UA | RU" bare-text picker (recently classified
+ * by 2c9b96e). Both items live in `<li class="switch-lang">`; after
+ * Movar runs with blocked=['ru'] the RU anchor gets `display:none`
+ * and the surviving "UA" span has its trailing `|` trimmed.
+ */
+import type { SiteFixture } from './types';
+
+export const site001: SiteFixture = {
+  id: '001-com-ua',
+  label: '001.com.ua (Delux catalogue)',
+  kind: 'site',
+  startUrl: 'https://001.com.ua/delux',
+  hostname: '001.com.ua',
+  extraHeaders: { 'Accept-Language': 'ru-RU,ru;q=0.9' },
+  initial: {
+    htmlLangPrefix: ['ru', 'uk'], // site sometimes serves uk even on /delux; we tolerate
+    bodyDetected: ['ru', 'uk'],
+  },
+  afterMovar: {
+    url: /^https:\/\/001\.com\.ua\/uk\/delux/,
+    htmlLangPrefix: ['uk'],
+    bodyDetected: 'uk',
+    minHiddenLinks: 1,
+    hiddenSelectors: ['li.switch-lang a[href*="lang=ru"]'],
+    visibleSelectors: ['li.switch-lang'],
+  },
+  correction: {
+    fromLang: 'ru',
+    toLang: 'uk',
+    mechanism: ['redirect'], // generic hreflang fallback
+  },
+  notes:
+    '001 sometimes geolocates Ukraine visitors to UA regardless of Accept-Language — when that happens, the initial assertion will fail honestly and the redirect test is skipped because pageLang was already uk.',
+};

--- a/apps/e2e/src/sites/bing.ts
+++ b/apps/e2e/src/sites/bing.ts
@@ -1,0 +1,27 @@
+/**
+ * Bing search — enforce-mode `setlang` rule. Less anti-bot risk than
+ * Google; usually the most reliable search test in the suite.
+ */
+import type { SiteFixture } from './types';
+
+export const siteBing: SiteFixture = {
+  id: 'bing-com',
+  label: 'bing.com (enforce: setlang)',
+  kind: 'search',
+  startUrl: 'https://www.bing.com/search?q=%D1%8F%D0%B1%D0%BB%D1%83%D0%BA%D0%BE',
+  hostname: 'www.bing.com',
+  extraHeaders: { 'Accept-Language': 'ru-RU,ru;q=0.9' },
+  initial: {
+    htmlLangPrefix: ['ru', 'en', 'uk', ''],
+    bodyDetected: ['ru', 'uk', 'unknown'],
+  },
+  afterMovar: {
+    url: /[?&]setlang=uk\b/,
+    minHiddenLinks: 0,
+  },
+  correction: {
+    fromLang: 'ru',
+    toLang: 'uk',
+    mechanism: ['search'],
+  },
+};

--- a/apps/e2e/src/sites/duckduckgo.ts
+++ b/apps/e2e/src/sites/duckduckgo.ts
@@ -1,0 +1,30 @@
+/**
+ * DuckDuckGo search — enforce-mode rule writes `kl=ua-uk`. DDG serves
+ * SERPs at the root (`/?q=…`), so the rule has no path gate.
+ *
+ * DDG is the most automation-friendly of the four search engines; in
+ * practice this test is the closest thing to a reliable green.
+ */
+import type { SiteFixture } from './types';
+
+export const siteDuckDuckGo: SiteFixture = {
+  id: 'duckduckgo-com',
+  label: 'duckduckgo.com (enforce: kl)',
+  kind: 'search',
+  startUrl: 'https://duckduckgo.com/?q=%D1%8F%D0%B1%D0%BB%D1%83%D0%BA%D0%BE',
+  hostname: 'duckduckgo.com',
+  extraHeaders: { 'Accept-Language': 'ru-RU,ru;q=0.9' },
+  initial: {
+    htmlLangPrefix: ['en', 'ru', 'uk', ''],
+    bodyDetected: ['ru', 'uk', 'unknown'],
+  },
+  afterMovar: {
+    url: /[?&]kl=ua-uk\b/,
+    minHiddenLinks: 0,
+  },
+  correction: {
+    fromLang: 'ru',
+    toLang: 'uk',
+    mechanism: ['search'],
+  },
+};

--- a/apps/e2e/src/sites/electrica-shop.ts
+++ b/apps/e2e/src/sites/electrica-shop.ts
@@ -1,0 +1,44 @@
+/**
+ * electrica-shop.com.ua — Ukrainian e-com with a `cookie + hreflang` rule
+ * in `packages/rules`. RU canonical: `/`. UA canonical: `/ua/`.
+ *
+ * Movar's rule sets `lang=ua` cookie, then follows hreflang to `/ua/`.
+ *
+ * Picker filter: `<span class="ua-link">українською</span>` (active) +
+ * `<a class="ru-link">по-русски</a>` + a `<span class="divider">&nbsp;</span>`
+ * in between. After Movar runs, the RU anchor is hidden and the divider
+ * is hidden as a "useless delimiter".
+ */
+import type { SiteFixture } from './types';
+
+export const siteElectricaShop: SiteFixture = {
+  id: 'electrica-shop-com-ua',
+  label: 'electrica-shop.com.ua (rule: cookie + hreflang)',
+  kind: 'site',
+  startUrl: 'https://electrica-shop.com.ua/',
+  hostname: 'electrica-shop.com.ua',
+  extraHeaders: { 'Accept-Language': 'ru-RU,ru;q=0.9' },
+  // The rule's own switch knob: setting lang=ua takes us to UA, so its
+  // inverse (lang=ru) reliably puts us in RU. Without this, the site
+  // geolocates UA visitors to /ua/ regardless of Accept-Language, and the
+  // baseline assertion can't observe the RU starting state Movar exists
+  // to fix.
+  preCookies: [{ name: 'lang', value: 'ru', domain: 'electrica-shop.com.ua' }],
+  initial: {
+    htmlLangPrefix: ['ru', 'uk-UA', 'uk'],
+    bodyDetected: ['ru', 'uk'],
+  },
+  afterMovar: {
+    url: /^https:\/\/electrica-shop\.com\.ua\/ua\//,
+    htmlLangPrefix: ['uk'],
+    bodyDetected: 'uk',
+    minHiddenLinks: 1,
+    hiddenSelectors: ['#header-languages a.ru-link'],
+    visibleSelectors: ['#header-languages .ua-link'],
+  },
+  correction: {
+    fromLang: 'ru',
+    toLang: 'uk',
+    mechanism: ['cookie', 'redirect'], // compound — head is cookie; hreflang follow is redirect
+  },
+};

--- a/apps/e2e/src/sites/google.ts
+++ b/apps/e2e/src/sites/google.ts
@@ -1,0 +1,41 @@
+/**
+ * Google search — enforce-mode rule. A Cyrillic query like `яблуко`
+ * (or worse, an ambiguous one like `картина`) routinely bleeds RU
+ * results because Google falls back to the larger RU corpus.
+ *
+ * Movar's rule adds `hl=uk&lr=lang_uk` on every `/search` navigation
+ * with a `q` param. The URL changes (params added) but the host stays
+ * google.com — that's the verification target here.
+ *
+ * Anti-bot risk is real: Google sometimes serves a CAPTCHA to fresh
+ * Playwright contexts. The test is opt-out via `SKIP_GOOGLE=1` so a
+ * full suite run can still finish on a captcha day.
+ */
+import type { SiteFixture } from './types';
+
+export const siteGoogle: SiteFixture = {
+  id: 'google-com',
+  label: 'google.com (enforce: hl + lr)',
+  kind: 'search',
+  startUrl: 'https://www.google.com/search?q=%D1%8F%D0%B1%D0%BB%D1%83%D0%BA%D0%BE',
+  hostname: 'www.google.com',
+  extraHeaders: { 'Accept-Language': 'ru-RU,ru;q=0.9' },
+  initial: {
+    // SERP chrome is mostly empty of `ы`/`ё`; loose initial expectation.
+    htmlLangPrefix: ['ru', 'en', 'uk', ''],
+    bodyDetected: ['ru', 'uk', 'unknown'],
+    minRuScore: 0,
+  },
+  afterMovar: {
+    url: /[?&]hl=uk\b/,
+    minHiddenLinks: 0, // Google SERP doesn't have a "language picker" Movar would filter
+  },
+  correction: {
+    fromLang: 'ru', // pageLang at first land; could also be unknown if SERP body too short
+    toLang: 'uk',
+    mechanism: ['search'],
+  },
+  skipIfEnv: 'SKIP_GOOGLE',
+  notes:
+    'Google may issue a CAPTCHA to fresh Playwright contexts. Run `SKIP_GOOGLE=1 pnpm test:live` to bypass on captcha days.',
+};

--- a/apps/e2e/src/sites/index.ts
+++ b/apps/e2e/src/sites/index.ts
@@ -1,0 +1,24 @@
+/**
+ * Site registry consumed by `tests/sites.spec.ts`. The order here is
+ * the order tests run; we put the deterministic e-com sites first
+ * (which rarely flake) and the anti-bot-prone search engines last.
+ */
+import { site001 } from './001';
+import { siteBing } from './bing';
+import { siteDuckDuckGo } from './duckduckgo';
+import { siteElectricaShop } from './electrica-shop';
+import { siteGoogle } from './google';
+import { siteUamade } from './uamade';
+import { siteYouTube } from './youtube';
+
+export type { SiteFixture } from './types';
+
+export const SITES = [
+  siteElectricaShop,
+  siteUamade,
+  site001,
+  siteDuckDuckGo,
+  siteBing,
+  siteGoogle,
+  siteYouTube,
+] as const;

--- a/apps/e2e/src/sites/types.ts
+++ b/apps/e2e/src/sites/types.ts
@@ -1,0 +1,108 @@
+/**
+ * `SiteFixture` is the single contract every test target conforms to. The
+ * parameterised spec at `tests/sites.spec.ts` iterates the registry; adding
+ * a 4th, 5th, … site is one file under `sites/`, then a re-export from
+ * `sites/index.ts`.
+ *
+ * Three categories of expectation:
+ *
+ *   - `initial`: what the page looks like to a Russian-speaking visitor
+ *     before Movar acts. Asserted in the `cleanContext` (no extension).
+ *   - `afterMovar`: what changes once Movar's content script applies.
+ *     Asserted in `movarContext` after `waitForMovarSettled` returns.
+ *   - `correction`: the {fromLang, toLang, mechanism} tuple Movar should
+ *     log to its correction-event store. Asserted by reading
+ *     `chrome.storage.local['movar:events']` via the service worker.
+ *
+ * The `kind` distinguishes redirect-driven flows (electrica, uamade, …)
+ * from search-engine enforce-mode (google, youtube, bing, ddg, where the
+ * URL doesn't change "languages" but params get rewritten). The spec uses
+ * `kind` to pick the right assertion path; both share the same shape so
+ * the registry stays homogeneous.
+ */
+import type { CyrillicLanguage } from '@movar/lang-detect';
+import type { CorrectionEvent, LanguageCode } from '@movar/shared';
+
+export interface InitialExpectations {
+  /** Permitted `<html lang>` prefixes. We allow either the BCP47 form
+   *  (`ru-RU`) or the bare code (`ru`). Empty string is allowed too,
+   *  for sites that ship no `lang` attribute (then we trust body-text
+   *  detection). */
+  htmlLangPrefix: (LanguageCode | '')[];
+  /** What `@movar/lang-detect` should report for the body text. Single
+   *  value or list of acceptable readings. Use 'unknown' explicitly when
+   *  the body text is too short to disambiguate but we're OK with that. */
+  bodyDetected: CyrillicLanguage | CyrillicLanguage[];
+  /** Minimum `ruScore` (count of `ы`/`ё`) we expect. Loose floor; a
+   *  search-engine SERP with mostly chrome won't pass `>0` reliably, so
+   *  set to 0 for those. */
+  minRuScore?: number;
+}
+
+export interface AfterMovarExpectations {
+  /** URL must match after Movar redirects. For enforce-mode (search
+   *  engines) this is usually the same path with extra query params. */
+  url?: RegExp;
+  /** Acceptable `<html lang>` after the redirect lands. */
+  htmlLangPrefix?: LanguageCode[];
+  /** Body-text detection after the redirect. */
+  bodyDetected?: CyrillicLanguage | CyrillicLanguage[];
+  /** At least N elements marked `data-movar-hidden`. 0 = picker-filter
+   *  is not the subject of this fixture (search-engine redirect tests). */
+  minHiddenLinks?: number;
+  /** At least N elements marked with a content-filter blur curtain. */
+  minContentBlur?: number;
+  /** Specific selectors that must be hidden after Movar runs (sanity:
+   *  the picker option for a blocked language is gone from the DOM). */
+  hiddenSelectors?: string[];
+  /** Specific selectors that must STILL be visible (sanity: Movar
+   *  didn't over-hide). */
+  visibleSelectors?: string[];
+}
+
+export interface CorrectionExpectations {
+  /** At least one event with `fromLang === from && toLang === to`. */
+  fromLang: LanguageCode;
+  toLang: LanguageCode;
+  /** Permitted mechanism strings. `'redirect'` for hreflang/picker
+   *  fallbacks; rule-specific values for cookie/localStorage/search. */
+  mechanism: readonly CorrectionEvent['mechanism'][];
+}
+
+export type SiteKind = 'site' | 'search';
+
+export interface SiteFixture {
+  /** Stable id used as the test name. */
+  id: string;
+  /** Human label; shown in console + report. */
+  label: string;
+  /** 'site' = generic site rule / heuristic. 'search' = enforce-mode
+   *  rule (Google, YouTube, etc.). */
+  kind: SiteKind;
+  /** The URL to visit to start in a Russian-defaulted state. For
+   *  `'search'`, the SERP URL whose results would otherwise bleed RU. */
+  startUrl: string;
+  /** Host as it will appear in `CorrectionEvent.domain` (no www., the
+   *  way `location.hostname` reports it for the start URL). */
+  hostname: string;
+  /** HTTP headers applied to both `movarContext` and `cleanContext`
+   *  before the first navigation. We almost always want
+   *  `Accept-Language: ru` so the site serves its Russian default. */
+  extraHeaders?: Record<string, string>;
+  /** Cookies pre-set in both contexts before the first navigation —
+   *  used to coax sites whose RU starting state needs a session hint. */
+  preCookies?: {
+    name: string;
+    value: string;
+    domain: string;
+    path?: string;
+  }[];
+  initial: InitialExpectations;
+  afterMovar: AfterMovarExpectations;
+  correction: CorrectionExpectations;
+  /** Skip this site entirely if the env var is set. Useful for sites
+   *  that frequently fail anti-bot (YouTube/Google CAPTCHAs). */
+  skipIfEnv?: string;
+  /** Notes on flake/limitations, displayed in the spec output. */
+  notes?: string;
+}

--- a/apps/e2e/src/sites/uamade.ts
+++ b/apps/e2e/src/sites/uamade.ts
@@ -1,0 +1,37 @@
+/**
+ * uamade.ua — Ukrainian crafts marketplace (CS-Cart). No site rule;
+ * `hreflang` fallback does the work. RU canonical: `/`. UA: `/uk/`.
+ *
+ * Picker filter: CS-Cart `ty-select` dropdown. The trigger anchor is
+ * outside the dropdown `<ul>` and has no `href`, so Movar's picker
+ * discovery sees the inner `<ul>` (RU + EN) as a bilingual picker; the
+ * UA "trigger" stays as-is. With blocked=['ru'] the RU `<li>` is hidden
+ * and the EN `<li>` survives.
+ */
+import type { SiteFixture } from './types';
+
+export const siteUamade: SiteFixture = {
+  id: 'uamade-ua',
+  label: 'uamade.ua (CS-Cart ty-select)',
+  kind: 'site',
+  startUrl: 'https://uamade.ua/',
+  hostname: 'uamade.ua',
+  extraHeaders: { 'Accept-Language': 'ru-RU,ru;q=0.9' },
+  initial: {
+    htmlLangPrefix: ['ru', 'uk'],
+    bodyDetected: ['ru', 'uk'],
+  },
+  afterMovar: {
+    url: /^https:\/\/uamade\.ua\/uk\//,
+    htmlLangPrefix: ['uk'],
+    bodyDetected: 'uk',
+    minHiddenLinks: 1,
+    hiddenSelectors: ['#languages_41 a[href="https://uamade.ua/"]'],
+    visibleSelectors: ['#languages_41 a[href="https://uamade.ua/en/"]'],
+  },
+  correction: {
+    fromLang: 'ru',
+    toLang: 'uk',
+    mechanism: ['redirect'], // hreflang fallback
+  },
+};

--- a/apps/e2e/src/sites/youtube.ts
+++ b/apps/e2e/src/sites/youtube.ts
@@ -1,0 +1,43 @@
+/**
+ * YouTube search — enforce-mode (`hl + gl`) AND content-filter (DOM
+ * blur on RU-language video titles).
+ *
+ * The enforce rule rewrites the URL with `hl=uk&gl=UA`. The
+ * content-filter then scans `ytd-video-renderer` and siblings, runs
+ * each card's title text through `@movar/lang-detect`, and overlays a
+ * curtain on cards classified as RU.
+ *
+ * Both behaviors verified in one fixture: URL params + curtain count.
+ */
+import type { SiteFixture } from './types';
+
+export const siteYouTube: SiteFixture = {
+  id: 'youtube-com',
+  label: 'youtube.com (enforce: hl + gl, content-filter blur)',
+  kind: 'search',
+  // `собака` is an ambiguous Cyrillic word (UA + RU) that surfaces a
+  // healthy mix on the SERP. Without Movar most results are RU; with
+  // Movar's hl+gl and content-filter, blur cards should appear.
+  startUrl: 'https://www.youtube.com/results?search_query=%D1%81%D0%BE%D0%B1%D0%B0%D0%BA%D0%B0',
+  hostname: 'www.youtube.com',
+  extraHeaders: { 'Accept-Language': 'ru-RU,ru;q=0.9' },
+  initial: {
+    htmlLangPrefix: ['ru', 'en', ''],
+    bodyDetected: ['ru', 'unknown'],
+  },
+  afterMovar: {
+    url: /[?&]hl=uk\b/,
+    minHiddenLinks: 0,
+    // At least one RU video card should be blurred. Loose threshold —
+    // YouTube's ranking shifts daily; tightening this would flake.
+    minContentBlur: 1,
+  },
+  correction: {
+    fromLang: 'ru',
+    toLang: 'uk',
+    mechanism: ['search', 'dom'],
+  },
+  skipIfEnv: 'SKIP_YOUTUBE',
+  notes:
+    'YouTube polymer router strips unknown params during routing; the loop guard in content.ts keeps us from bouncing. Content-filter blur threshold is intentionally loose (≥1) to absorb daily ranking shifts.',
+};

--- a/apps/e2e/src/tests/sites.spec.ts
+++ b/apps/e2e/src/tests/sites.spec.ts
@@ -1,0 +1,300 @@
+/**
+ * Live-website end-to-end spec. Parameterised over `SITES`; for each site
+ * the four-part contract from the user prompt is verified:
+ *
+ *   1. "verify that website opens in russian"
+ *      — fetch the start URL in `cleanContext` (no Movar), confirm
+ *        `<html lang>` + `@movar/lang-detect` agree on `'ru'` (or the
+ *        broader set the fixture tolerates).
+ *
+ *   2. "it correctly recognized by algorithm"
+ *      — re-run the same readout inside `movarContext` BEFORE Movar
+ *        redirects. Tied to the existing `detectPageLanguage` logic
+ *        implicitly: if Movar's recognition disagreed with us, no
+ *        correction event would be logged. We assert the event log
+ *        carries `fromLang === 'ru'` for this domain.
+ *
+ *   3. "correctly switches language"
+ *      — assert the final URL matches the fixture's `afterMovar.url`
+ *        and that `<html lang>` + body detection now report `'uk'`
+ *        (or the fixture-permitted set).
+ *
+ *   4. "correctly hides language options or content"
+ *      — assert `data-movar-hidden` populated (picker filter) and/or
+ *        `data-movar-curtain` populated (content-filter blur), per
+ *        the fixture.
+ *
+ * Each `test.describe` block per site keeps the report readable: a
+ * single red `electrica-shop-com-ua > switches to UA` is easier to
+ * triage than a generic "site test 3 failed at line 200".
+ */
+import type { BrowserContext, Page } from '@playwright/test';
+import type { CorrectionEvent } from '@movar/shared';
+import { expect, test } from '../fixtures/extension';
+import { readPageLanguage } from '../fixtures/lang-detect';
+import { readMovarDomState, waitForMovarSettled } from '../fixtures/movar-state';
+import { SITES, type SiteFixture } from '../sites';
+
+/** Per-context boilerplate the four tests share. Sets headers / cookies
+ *  before the first navigation in the given context. */
+async function prepareContext(context: BrowserContext, site: SiteFixture): Promise<void> {
+  if (site.extraHeaders) {
+    await context.setExtraHTTPHeaders(site.extraHeaders);
+  }
+  if (site.preCookies && site.preCookies.length > 0) {
+    await context.addCookies(
+      site.preCookies.map((c) => ({
+        name: c.name,
+        value: c.value,
+        domain: c.domain,
+        path: c.path ?? '/',
+      })),
+    );
+  }
+}
+
+/**
+ * The full navigation prelude that tests 2 and 4 share: prepare the
+ * context, navigate to the site's start URL, wait for Movar to redirect
+ * (when the fixture predicts one), then wait for Movar's settle signal.
+ *
+ * `onUrlTimeout` decides what to do if the predicted URL transition
+ * doesn't happen within 20s. Test 2 wants to throw (a missing transition
+ * IS the failure); test 4 wants to continue (the picker / content
+ * assertions still run on whatever the page settled to).
+ */
+async function navigateAndSettleMovar(
+  context: BrowserContext,
+  page: Page,
+  site: SiteFixture,
+  opts: { onUrlTimeout: 'throw' | 'continue' },
+): Promise<void> {
+  await prepareContext(context, site);
+  await page.goto(site.startUrl, { waitUntil: 'domcontentloaded' });
+  if (site.afterMovar.url) {
+    await page.waitForURL(site.afterMovar.url, { timeout: 20_000 }).catch((error) => {
+      if (opts.onUrlTimeout === 'throw') {
+        throw new Error(
+          `Movar didn't navigate to ${site.afterMovar.url} within 20s. Final URL: ${page.url()}. Root cause: ${error instanceof Error ? error.message : String(error)}`,
+        );
+      }
+      /* continue: a missing URL transition is the previous test's concern,
+         not this one's. */
+    });
+  }
+  await page.waitForLoadState('domcontentloaded');
+  await waitForMovarSettled(page, { timeoutMs: 10_000 });
+}
+
+/** Coerce `bodyDetected` (a value or an array) into an array. */
+function asArray<T>(v: T | T[]): T[] {
+  return Array.isArray(v) ? v : [v];
+}
+
+function htmlLangMatches(actual: string, allowed: readonly string[]): boolean {
+  if (allowed.length === 0) return true;
+  const a = (actual || '').toLowerCase();
+  return allowed.some((p) => {
+    const pp = p.toLowerCase();
+    if (pp === '') return a === '';
+    return a === pp || a.startsWith(`${pp}-`);
+  });
+}
+
+/**
+ * Poll the correction-event log for the expected fromLang/toLang/mechanism
+ * tuple. The content script logs asynchronously after Movar redirects, so
+ * waiting up to 10s gives the event time to land.
+ */
+async function expectCorrectionEvent(
+  getCorrections: (hostname: string) => Promise<CorrectionEvent[]>,
+  site: SiteFixture,
+): Promise<void> {
+  await expect
+    .poll(
+      async () => {
+        const events = await getCorrections(site.hostname);
+        return events.some(
+          (e) =>
+            e.fromLang === site.correction.fromLang &&
+            e.toLang === site.correction.toLang &&
+            site.correction.mechanism.includes(e.mechanism),
+        );
+      },
+      {
+        message: `no CorrectionEvent with from=${site.correction.fromLang} to=${site.correction.toLang} mechanism∈${JSON.stringify(site.correction.mechanism)} for domain=${site.hostname}`,
+        timeout: 10_000,
+      },
+    )
+    .toBe(true);
+}
+
+/**
+ * Assert the post-Movar readout matches the fixture's expectations:
+ * `<html lang>` is in the allowed prefix set, body-detected language is
+ * in the allowed set, and the final URL matches the predicted pattern.
+ */
+function assertAfterMovarReadout(
+  after: { htmlLang: string; detected: string | null },
+  site: SiteFixture,
+  finalUrl: string,
+): void {
+  if (site.afterMovar.htmlLangPrefix) {
+    expect(
+      htmlLangMatches(after.htmlLang, site.afterMovar.htmlLangPrefix),
+      `<html lang>="${after.htmlLang}" not in allowed set ${JSON.stringify(site.afterMovar.htmlLangPrefix)}`,
+    ).toBe(true);
+  }
+  if (site.afterMovar.bodyDetected) {
+    expect(asArray(site.afterMovar.bodyDetected)).toContain(after.detected);
+  }
+  if (site.afterMovar.url) {
+    expect(finalUrl).toMatch(site.afterMovar.url);
+  }
+}
+
+/**
+ * Assert each `hiddenSelectors` element is present in DOM AND visually
+ * hidden — either via Movar's `data-movar-hidden` / `display:none` hide
+ * or the curtain's `aria-hidden="true"`.
+ */
+async function assertHiddenSelectors(page: Page, selectors: readonly string[]): Promise<void> {
+  for (const sel of selectors) {
+    const el = page.locator(sel).first();
+    const hidden = await el.evaluate(
+      (node) =>
+        node.hasAttribute('data-movar-hidden') ||
+        getComputedStyle(node as Element).display === 'none' ||
+        (node as HTMLElement).getAttribute('aria-hidden') === 'true',
+      undefined,
+      { timeout: 5_000 },
+    );
+    expect(hidden, `expected ${sel} to be hidden by Movar`).toBe(true);
+  }
+}
+
+/**
+ * Assert each `visibleSelectors` element is either visible OR sits under
+ * a Movar curtain replacement. Strict-mode pickers with ≤1 surviving
+ * link get collapsed into a chip overlay; both outcomes (still visible,
+ * curtained-ancestor) count as "Movar reacted, user still has language
+ * affordance".
+ */
+async function assertVisibleOrCurtained(page: Page, selectors: readonly string[]): Promise<void> {
+  for (const sel of selectors) {
+    const outcome = await page
+      .locator(sel)
+      .first()
+      .evaluate((node) => {
+        const visible =
+          getComputedStyle(node as Element).display !== 'none' &&
+          (node as HTMLElement).getAttribute('aria-hidden') !== 'true';
+        // Walk ancestors looking for a Movar curtain replacement.
+        let ancestor: Element | null = node;
+        let curtainedAncestor = false;
+        while (ancestor) {
+          const prev = ancestor.previousElementSibling;
+          if (
+            prev instanceof HTMLElement &&
+            prev.hasAttribute('data-movar-curtain') &&
+            prev.dataset['movarKind'] === 'picker-container'
+          ) {
+            curtainedAncestor = true;
+            break;
+          }
+          ancestor = ancestor.parentElement;
+        }
+        return { visible, curtainedAncestor };
+      });
+    expect(
+      outcome.visible || outcome.curtainedAncestor,
+      `expected ${sel} to be visible OR its picker container to be replaced by a Movar chip overlay; got ${JSON.stringify(outcome)}`,
+    ).toBe(true);
+  }
+}
+
+for (const site of SITES) {
+  test.describe(site.label, () => {
+    test.skip(
+      Boolean(site.skipIfEnv && process.env[site.skipIfEnv] === '1'),
+      `${site.skipIfEnv}=1 in env`,
+    );
+
+    test('1) opens in Russian (baseline, no Movar)', async ({ cleanContext, cleanPage }) => {
+      await prepareContext(cleanContext, site);
+      await cleanPage.goto(site.startUrl, { waitUntil: 'domcontentloaded' });
+      // Wait for a real body to be present before we read text.
+      await cleanPage.waitForSelector('body', { state: 'attached' });
+
+      const readout = await readPageLanguage(cleanPage);
+      console.log(`  baseline [${site.id}]:`, readout);
+
+      expect(
+        htmlLangMatches(readout.htmlLang, asArray(site.initial.htmlLangPrefix as string[])),
+        `<html lang>="${readout.htmlLang}" not in allowed set ${JSON.stringify(site.initial.htmlLangPrefix)}`,
+      ).toBe(true);
+      expect(asArray(site.initial.bodyDetected)).toContain(readout.detected);
+      if (site.initial.minRuScore !== undefined) {
+        expect(readout.ruScore).toBeGreaterThanOrEqual(site.initial.minRuScore);
+      }
+    });
+
+    test('2) Movar recognises the page + 3) switches language', async ({
+      movarContext,
+      cleanContext,
+      movarPage,
+      cleanPage,
+      getCorrections,
+    }) => {
+      // Sanity-check baseline first. If the site honoured our Accept-Language
+      // ru / preCookies lang=ru and served Russian, the redirect path is
+      // exercised and we proceed. If the site geolocated us to UA anyway
+      // (common on Ukrainian e-com from a UA IP), Movar's redirect would
+      // correctly be a no-op — the test would assert a CorrectionEvent that
+      // legitimately never happens. We skip with a clear reason instead of
+      // failing for an environment limitation that isn't Movar's fault.
+      await prepareContext(cleanContext, site);
+      await cleanPage.goto(site.startUrl, { waitUntil: 'domcontentloaded' });
+      const baseline = await readPageLanguage(cleanPage);
+      console.log(`  baseline-in-test2 [${site.id}]:`, baseline);
+      const startedInRussian =
+        baseline.detected === 'ru' || (baseline.htmlLang || '').toLowerCase().startsWith('ru');
+      // Search-engine fixtures always proceed: the SERP body is mostly
+      // chrome, so body-detection can't tell us "user started in RU". The
+      // enforce-mode rewrite is unconditional anyway.
+      test.skip(
+        site.kind === 'site' && !startedInRussian,
+        `baseline served ${baseline.detected || 'unknown'} (htmlLang=${baseline.htmlLang}); site did not put us in a Russian starting state in this environment — Movar's redirect path can't be exercised here`,
+      );
+
+      // First navigation; content script runs at document_start, detects
+      // RU, and triggers the redirect / enforce-rewrite path.
+      await navigateAndSettleMovar(movarContext, movarPage, site, { onUrlTimeout: 'throw' });
+
+      const after = await readPageLanguage(movarPage);
+      console.log(`  after-Movar [${site.id}]:`, after);
+
+      assertAfterMovarReadout(after, site, movarPage.url());
+      await expectCorrectionEvent(getCorrections, site);
+    });
+
+    test('4) hides blocked language options / blurs blocked content', async ({
+      movarContext,
+      movarPage,
+    }) => {
+      await navigateAndSettleMovar(movarContext, movarPage, site, { onUrlTimeout: 'continue' });
+
+      const state = await readMovarDomState(movarPage);
+      console.log(`  movar-dom-state [${site.id}]:`, state);
+
+      if (site.afterMovar.minHiddenLinks !== undefined) {
+        expect(state.hiddenLinkCount).toBeGreaterThanOrEqual(site.afterMovar.minHiddenLinks);
+      }
+      if (site.afterMovar.minContentBlur !== undefined) {
+        expect(state.contentBlurCount).toBeGreaterThanOrEqual(site.afterMovar.minContentBlur);
+      }
+      await assertHiddenSelectors(movarPage, site.afterMovar.hiddenSelectors ?? []);
+      await assertVisibleOrCurtained(movarPage, site.afterMovar.visibleSelectors ?? []);
+    });
+  });
+}

--- a/apps/e2e/tsconfig.json
+++ b/apps/e2e/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "types": ["node", "chrome"],
+    "noEmit": true,
+    "moduleResolution": "Bundler",
+    "resolveJsonModule": true
+  },
+  "include": ["src", "playwright.config.ts"],
+  "exclude": ["node_modules", "test-results", "playwright-report"]
+}

--- a/apps/extension/package.json
+++ b/apps/extension/package.json
@@ -14,6 +14,7 @@
     "preview:build": "MOVAR_PREVIEW=1 wxt build",
     "preview:popup": "pnpm preview:build && pnpm dlx serve -l 4322 --no-clipboard .output/chrome-mv3",
     "preview:options": "pnpm preview:build && pnpm dlx serve -l 4323 --no-clipboard .output/chrome-mv3",
+    "preview:storyboards": "pnpm dlx serve -l 4324 --no-clipboard store-assets/storyboards",
     "icons": "tsx scripts/generate-icons.mts",
     "typecheck": "tsc --noEmit",
     "lint": "eslint .",

--- a/apps/extension/src/lib/lang-codes.test.ts
+++ b/apps/extension/src/lib/lang-codes.test.ts
@@ -26,6 +26,54 @@ describe('normalizeLanguageCode (strict)', () => {
     expect(normalizeLanguageCode('auf deutsch')).toBe('de');
   });
 
+  it('recognizes UA-language exonyms — bare adjective (lower + capitalised)', () => {
+    // Ukrainian sites name foreign languages with the UA exonym, not just
+    // the endonym; a `title="Російська"` or bare-text "Польська" picker
+    // item must classify or the whole picker can slip past detection.
+    expect(normalizeLanguageCode('російська')).toBe('ru');
+    expect(normalizeLanguageCode('Російська')).toBe('ru');
+    expect(normalizeLanguageCode('польська')).toBe('pl');
+    expect(normalizeLanguageCode('Польська')).toBe('pl');
+    expect(normalizeLanguageCode('німецька')).toBe('de');
+    expect(normalizeLanguageCode('Німецька')).toBe('de');
+    expect(normalizeLanguageCode('французька')).toBe('fr');
+    expect(normalizeLanguageCode('Французька')).toBe('fr');
+    expect(normalizeLanguageCode('іспанська')).toBe('es');
+    expect(normalizeLanguageCode('Іспанська')).toBe('es');
+    expect(normalizeLanguageCode('італійська')).toBe('it');
+    expect(normalizeLanguageCode('Італійська')).toBe('it');
+  });
+
+  it('recognizes UA-language exonyms — "X мова" phrase (lower + capitalised)', () => {
+    // CS-Cart/OpenCart templates targeting Ukraine commonly ship
+    // `title="Російська мова"` as the only language signal on the
+    // switch link — no language class, no localised text.
+    expect(normalizeLanguageCode('російська мова')).toBe('ru');
+    expect(normalizeLanguageCode('Російська мова')).toBe('ru');
+    expect(normalizeLanguageCode('польська мова')).toBe('pl');
+    expect(normalizeLanguageCode('Польська мова')).toBe('pl');
+    expect(normalizeLanguageCode('німецька мова')).toBe('de');
+    expect(normalizeLanguageCode('Німецька мова')).toBe('de');
+    expect(normalizeLanguageCode('французька мова')).toBe('fr');
+    expect(normalizeLanguageCode('Французька мова')).toBe('fr');
+    expect(normalizeLanguageCode('іспанська мова')).toBe('es');
+    expect(normalizeLanguageCode('Іспанська мова')).toBe('es');
+    expect(normalizeLanguageCode('італійська мова')).toBe('it');
+    expect(normalizeLanguageCode('Італійська мова')).toBe('it');
+  });
+
+  it('recognizes UA-language exonyms — adverbial "по-X" forms', () => {
+    // Bare-text "по-російськи" sits on picker links the same way
+    // "по-русски" does, and is just as common on UA-targeted templates.
+    expect(normalizeLanguageCode('по-російськи')).toBe('ru');
+    expect(normalizeLanguageCode('по російськи')).toBe('ru');
+    expect(normalizeLanguageCode('по-польськи')).toBe('pl');
+    expect(normalizeLanguageCode('по-німецьки')).toBe('de');
+    expect(normalizeLanguageCode('по-французьки')).toBe('fr');
+    expect(normalizeLanguageCode('по-іспанськи')).toBe('es');
+    expect(normalizeLanguageCode('по-італійськи')).toBe('it');
+  });
+
   it('does NOT split on hyphen — `/ru-return-warranty` must not match (bosch regression)', () => {
     expect(normalizeLanguageCode('ru-return-warranty')).toBeNull();
     expect(normalizeLanguageCode('en-something-else')).toBeNull();

--- a/apps/extension/src/lib/lang-codes.ts
+++ b/apps/extension/src/lib/lang-codes.ts
@@ -34,6 +34,10 @@ const ALIASES: Record<string, LanguageCode> = {
   'на русском': 'ru',
   russian: 'ru',
   'in russian': 'ru',
+  російська: 'ru',
+  'російська мова': 'ru',
+  'по-російськи': 'ru',
+  'по російськи': 'ru',
 
   // English
   en: 'en',
@@ -49,6 +53,9 @@ const ALIASES: Record<string, LanguageCode> = {
   polski: 'pl',
   'po polsku': 'pl',
   polish: 'pl',
+  польська: 'pl',
+  'польська мова': 'pl',
+  'по-польськи': 'pl',
 
   // German
   de: 'de',
@@ -57,6 +64,9 @@ const ALIASES: Record<string, LanguageCode> = {
   deutsch: 'de',
   'auf deutsch': 'de',
   german: 'de',
+  німецька: 'de',
+  'німецька мова': 'de',
+  'по-німецьки': 'de',
 
   // French
   fr: 'fr',
@@ -65,6 +75,9 @@ const ALIASES: Record<string, LanguageCode> = {
   francais: 'fr',
   'en français': 'fr',
   french: 'fr',
+  французька: 'fr',
+  'французька мова': 'fr',
+  'по-французьки': 'fr',
 
   // Spanish
   es: 'es',
@@ -73,6 +86,9 @@ const ALIASES: Record<string, LanguageCode> = {
   espanol: 'es',
   'en español': 'es',
   spanish: 'es',
+  іспанська: 'es',
+  'іспанська мова': 'es',
+  'по-іспанськи': 'es',
 
   // Italian
   it: 'it',
@@ -80,6 +96,9 @@ const ALIASES: Record<string, LanguageCode> = {
   italiano: 'it',
   'in italiano': 'it',
   italian: 'it',
+  італійська: 'it',
+  'італійська мова': 'it',
+  'по-італійськи': 'it',
 };
 
 /**

--- a/apps/extension/src/lib/picker.test.ts
+++ b/apps/extension/src/lib/picker.test.ts
@@ -21,6 +21,35 @@ function elFromHtml<T extends HTMLElement>(html: string): T {
   return div.firstElementChild as T;
 }
 
+/**
+ * Asserts that the currently-set DOM yields exactly one picker via
+ * `findLanguagePickers` and that its classified languages match the
+ * expected set (order-independent). Body setup is the caller's job — by
+ * the time this runs, `setBody` / `setup*` helpers must already have
+ * populated the document. Folds the three-line findLanguagePickers →
+ * length → languages assertion that several tests repeat verbatim.
+ */
+function expectSinglePickerWithLangs(expected: readonly string[]): void {
+  const pickers = findLanguagePickers();
+  expect(pickers).toHaveLength(1);
+  expect(pickers[0]!.links.map((l) => l.language).sort()).toEqual([...expected].sort());
+}
+
+/**
+ * Runs `setupTwoLanguagePicker(containerAttrs)`, applies a UK+EN filter,
+ * and asserts the resulting container went `display:none`. Returns the
+ * picker element so callers can chain curtain / restore assertions. Two
+ * filterPickers tests share this five-line preamble; folding it keeps
+ * each test focused on what it's actually verifying.
+ */
+function setupTwoLangPickerAndFilter(containerAttrs: string): HTMLElement {
+  setupTwoLanguagePicker({ containerAttrs });
+  filterPickers(findLanguagePickers(), ['uk', 'en']);
+  const picker = document.querySelector<HTMLElement>('#picker')!;
+  expect(picker.style.display).toBe('none');
+  return picker;
+}
+
 beforeEach(() => {
   document.body.innerHTML = '';
   document.documentElement.removeAttribute('lang');
@@ -188,6 +217,24 @@ describe('findLanguagePickers', () => {
     expect(picker.links.map((l) => l.language).sort()).toEqual(['ru', 'uk']);
   });
 
+  it('finds a picker where the Russian link classifies via title="Російська мова" alone', () => {
+    // Common pattern on Ukraine-targeted CS-Cart/OpenCart templates: the
+    // language switch ships ONLY a UA-language exonym title attribute —
+    // no `ru-link` class, no localised text, no language-coded URL. The
+    // electrica-shop case above survives because its Russian link also
+    // carries `class="ru-link"` and `по-русски` as text; a template that
+    // omits either of those leaves the title as the sole signal. Drop
+    // the UA-exonym aliases from the table and this test fails — that's
+    // the gap this guards against silently reopening.
+    setBody(`
+      <div id="picker">
+        <a href="/switch" title="Українська мова">сюди</a>
+        <a href="/change" title="Російська мова">туди</a>
+      </div>
+    `);
+    expectSinglePickerWithLangs(['ru', 'uk']);
+  });
+
   it('finds two separate pickers (header + footer)', () => {
     setBody(`
       <header><div class="lang"><a href="/ua/x">UA</a><a href="/ru/x">RU</a></div></header>
@@ -230,9 +277,7 @@ describe('findLanguagePickers', () => {
 
   it('finds a flag-only picker (anchors with just <img alt>)', () => {
     setupFlagPickerUA_RU();
-    const pickers = findLanguagePickers();
-    expect(pickers).toHaveLength(1);
-    expect(pickers[0]!.links.map((l) => l.language).sort()).toEqual(['ru', 'uk']);
+    expectSinglePickerWithLangs(['ru', 'uk']);
   });
 });
 
@@ -280,10 +325,7 @@ describe('filterPickers — keep semantics', () => {
   });
 
   it('hides the whole container when only one language remains and attaches a curtain', () => {
-    setupTwoLanguagePicker({ containerAttrs: 'id="picker" class="lang"' });
-    filterPickers(findLanguagePickers(), ['uk', 'en']);
-    const picker = document.querySelector<HTMLElement>('#picker')!;
-    expect(picker.style.display).toBe('none');
+    const picker = setupTwoLangPickerAndFilter('id="picker" class="lang"');
     // The curtain host is inserted as the immediate previous sibling.
     const host = picker.previousElementSibling as HTMLElement | null;
     expect(host?.getAttribute('data-movar-curtain')).toBe('');
@@ -578,9 +620,7 @@ describe('findLanguagePickers — deeper nesting', () => {
     // Common framework pattern: each picker item lives in many wrappers
     // (Headless UI / Radix / etc.) before reaching the shared container.
     setupDeeplyNestedPicker();
-    const pickers = findLanguagePickers();
-    expect(pickers).toHaveLength(1);
-    expect(pickers[0]!.links.map((l) => l.language).sort()).toEqual(['ru', 'uk']);
+    expectSinglePickerWithLangs(['ru', 'uk']);
   });
 });
 
@@ -606,11 +646,7 @@ describe('filterPickers — container curtain detach restores display', () => {
     // Pickers commonly use display:flex inline; the curtain sets display:none.
     // Detaching the curtain reinstates the original so the picker doesn't
     // lose its layout after restore.
-    setupTwoLanguagePicker({ containerAttrs: 'id="picker" style="display: flex"' });
-    filterPickers(findLanguagePickers(), ['uk', 'en']);
-    const picker = document.querySelector<HTMLElement>('#picker')!;
-    expect(picker.style.display).toBe('none');
-
+    const picker = setupTwoLangPickerAndFilter('id="picker" style="display: flex"');
     const host = picker.previousElementSibling as HTMLElement;
     const restoreBtn = host.shadowRoot!.querySelector<HTMLButtonElement>('button')!;
     restoreBtn.click();

--- a/apps/extension/store-assets/REQUIREMENTS.md
+++ b/apps/extension/store-assets/REQUIREMENTS.md
@@ -1,0 +1,216 @@
+# Movar marketplace listing — requirements
+
+Single source of truth for what we ship to AMO and the Chrome Web Store for
+Movar **v1.0.0**. Drafted on `feat/amo-readiness`.
+
+Sibling docs:
+
+- [`README.md`](./README.md) — screenshot capture recipe.
+- [`../STORE-LISTING.md`](../STORE-LISTING.md) — earlier copy draft; **superseded** by the copy plan in §4 below, kept until new copy files land.
+- [`../../../deployment-checklist.md`](../../../deployment-checklist.md) — pre-submission checklist (icons, permission justifications, source map).
+
+---
+
+## 1. Decisions locked this round
+
+| Question           | Decision                                                                                                                                                                |
+| ------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Which stores?      | **AMO + Chrome Web Store**, in parallel. Edge inherits Chrome assets but is not a v1 focus.                                                                             |
+| Copy baseline      | **Rewrite from scratch.** [`STORE-LISTING.md`](../STORE-LISTING.md) is reference only; final copy lives in `copy/` (see §4).                                            |
+| Locales            | **English + Ukrainian.** No Russian.                                                                                                                                    |
+| Roadmap            | [Priority-driven switching](../../../docs/priority-driven-switching.md) is teased as **"coming soon"** in one line at the bottom of the long description. Not the lead. |
+| Lead audience      | **Split per locale.** EN leads with multilingual-user framing; UK leads with the UA→RU pain. Same product, two arcs.                                                    |
+| AMO default locale | **English.** UK serves uk-locale browsers; EN is the global fallback.                                                                                                   |
+| Tone               | **Calm, neighbourly.** Keep "Keep the internet in your language." voice — matches the privacy policy.                                                                   |
+
+## 2. Positioning per locale
+
+Both locales describe the same product and the same v1 feature set. They
+diverge in lead framing, opening hook, and emphasis. Body claims about what
+Movar does must stay identical in substance — only the framing differs.
+
+### English (default)
+
+- **Lead audience**: multilingual users who want one preferred language enforced across search and content.
+- **Headline**: _Keep the internet in your language._
+- **Opening hook**: generic — search results that ignore your preferred language; sites that serve the wrong locale.
+- **Pain example**: a sentence on Cyrillic searches surfacing the wrong language; UA→RU is _an_ example, not _the_ example.
+- **Closing line**: roadmap teaser ("Priority-driven switching is coming.").
+
+### Ukrainian
+
+- **Lead audience**: Ukrainian speakers tired of UA sites defaulting to RU and Google surfacing RU results.
+- **Headline**: _Залиште інтернет вашою мовою._
+- **Opening hook**: concrete — the UA site that flips to RU on the second click; the Google result page that pretends you can't read Ukrainian.
+- **Pain example**: UA→RU is the primary example; multilingual framing is a secondary "and it works for other languages too" line.
+- **Closing line**: roadmap teaser in Ukrainian.
+
+> **Maintenance guard rail**: the two locales must agree on every factual
+> claim (supported engines, supported languages, permissions, privacy
+> guarantees). Edits to one are not finished until the other is verified.
+
+## 3. Slot inventory per store
+
+| Slot                           | AMO                                                                    | Chrome Web Store                                                                                       | Source / status                                               |
+| ------------------------------ | ---------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------- |
+| Name                           | "Movar"                                                                | "Movar"                                                                                                | `__MSG_extName__`, both locales                               |
+| Summary (short)                | ≤250, write to ~200                                                    | **≤132** (tight constraint)                                                                            | `copy/summary.{en,uk}.md` — to produce                        |
+| Description (long)             | ≤15,000                                                                | ≤16,000                                                                                                | `copy/description.{en,uk}.md` — to produce                    |
+| Icon                           | 128×128 PNG                                                            | 128×128 PNG                                                                                            | `src/public/icon/128.png` ✅                                  |
+| Screenshots                    | up to 10, max 2400×1800                                                | 1–5, **1280×800 or 640×400**                                                                           | `shared/*.png` — 1 of 4 captured strategy in §5               |
+| Promo tile                     | n/a                                                                    | **440×280** required                                                                                   | `chrome/promo-tile-440x280.png` — to produce                  |
+| Default locale                 | English                                                                | English (CWS shows one main body globally; UK reaches uk-locale users only via store translation pass) | —                                                             |
+| Category (primary)             | **Productivity** (proposed)                                            | **Productivity** (proposed)                                                                            | confirm before submit                                         |
+| Category (secondary, AMO only) | **Privacy & Security** (proposed)                                      | n/a                                                                                                    | confirm before submit                                         |
+| Tags (AMO only)                | proposed: `language`, `ukrainian`, `search`, `multilingual`, `privacy` | n/a                                                                                                    | confirm before submit                                         |
+| Privacy policy URL             | `https://movar.fyi/privacy`                                            | same                                                                                                   | **blocked** — DNS + Cloudflare Pages deploy pending           |
+| Homepage URL                   | `https://movar.fyi`                                                    | same                                                                                                   | **blocked** on the same DNS unblock                           |
+| Support contact                | `support@movar.fyi`                                                    | same                                                                                                   | also used in-product (`FEEDBACK_URL`) and in privacy policies |
+| License                        | MIT                                                                    | n/a                                                                                                    | ✅                                                            |
+| Data declaration               | `data_collection_permissions: ['none']` ✅                             | "User data" form: collects nothing                                                                     | confirm form on submit                                        |
+| Min browser version            | Firefox 113 (set) ✅                                                   | Chrome 109 (default MV3 floor)                                                                         | —                                                             |
+
+## 4. Copy plan
+
+New file layout under `store-assets/copy/` (to create):
+
+```
+store-assets/copy/
+  summary.en.md       # both AMO (≤250) and CWS (≤132) variants in one file
+  summary.uk.md       # same
+  description.en.md   # long description, store-agnostic
+  description.uk.md   # same
+  teaser-roadmap.md   # the "coming soon" line in EN + UK, referenced by both descriptions
+```
+
+Each summary file holds two clearly marked variants:
+
+```md
+## CWS (≤132)
+
+…line that fits 132…
+
+## AMO (≤200 target / ≤250 hard cap)
+
+…longer line that can breathe…
+```
+
+Long descriptions are written once per locale and reused across stores
+verbatim — the char ceiling on AMO (15k) is the tighter one and both fit
+comfortably under 2k. Section order, locked:
+
+1. One-paragraph value framing (locale-specific lead per §2).
+2. **What it does** — bullets: search-engine rewrites, on-page language detection + one-click switch, on-page picker filtering (survivor rework).
+3. **Supported search engines** — Google ccTLD list, Bing, DuckDuckGo, YouTube. Single source of truth: [`packages/rules/src/index.ts`](../../../packages/rules/src/index.ts).
+4. **Languages offered** — UA, EN, DE, FR, ES, IT, PL. Same source as above.
+5. **How it works** — three short bullets (pick language → applies automatically → popup for pause/counter/settings).
+6. **Privacy** — no account, no telemetry, all local. Restate the privacy policy headline; link out.
+7. **Open source** — MIT, link to repo once public.
+8. **Coming soon** — one-line tease for priority-driven switching.
+
+## 5. Screenshot set
+
+Four shots, captured at **1280×800** (works for both AMO and CWS). **All
+synthetic** — we render mock websites as HTML files under `storyboards/`
+so we never display a third-party brand, never depend on a real site's
+HTML holding still, and never accidentally leak personal browsing
+context. The real Movar popup (and any in-extension UI) is captured from
+the actual built extension and composited over the storyboard. Final
+PNGs live in `shared/`. Numbering matches CWS upload order.
+
+| #   | File                        | Story                     | Backdrop                                                                                                | Foreground                                       |
+| --- | --------------------------- | ------------------------- | ------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
+| 1   | `01-popup.png`              | Popup on a generic page   | `storyboards/news.html` — fictitious news article                                                       | Real Movar popup: status header + pause controls |
+| 2   | `02-correction-applied.png` | Before / after correction | `storyboards/site-before.html` + `…-after.html` — same fictitious site in RU and UA states              | Popup with today's correction counter ticking    |
+| 3   | `03-picker-survivor.png`    | Picker survivor rework    | `storyboards/picker.html` — fictitious site with a multilingual picker open                             | Picker with some items dimmed / removed by Movar |
+| 4   | `04-search-rewrite.png`     | Search rewrite            | `storyboards/serp.html` — fictitious SERP, styled distinct from any real engine; URL bar shows `?hl=uk` | Results visibly in Ukrainian                     |
+
+### Synthetic guard rails
+
+- **No third-party brand logos** of any kind (Google, Bing, YouTube, etc.). The popup may name "your search engine" generically; the SERP storyboard is invented.
+- **No fake URLs that look like real domains.** Use the IANA-reserved `.example` TLD or transparent placeholders (e.g., `newssite.example`).
+- **Consistent visual identity across storyboards.** All four mock sites share typography + token palette so the four shots read as one product story, not four unrelated tests. See open item §7.4.
+- **Real Movar UI must stay real.** Popup and any in-extension UI are captured from the actual built extension, not redrawn — drift risk on hand-redrawn UI is too high.
+
+The Chrome promo tile (`chrome/promo-tile-440x280.png`) is separate and is
+a designed image, not a screenshot.
+
+The capture recipe in [`README.md`](./README.md) still describes the
+real-website workflow and needs a rewrite once the storyboard pipeline
+exists — tracked as part of the storyboard work in §6.
+
+## 6. Assets to produce
+
+Tracked here so nothing slips between this doc and the deployment checklist.
+
+| Item                                                            | Path                               | Owner       | Blocker?                                         |
+| --------------------------------------------------------------- | ---------------------------------- | ----------- | ------------------------------------------------ |
+| Summary EN (CWS + AMO variants)                                 | `copy/summary.en.md`               | copy        | first draft ✅                                   |
+| Summary UK (CWS + AMO variants)                                 | `copy/summary.uk.md`               | copy        | pending EN sign-off                              |
+| Long description EN                                             | `copy/description.en.md`           | copy        | first draft ✅                                   |
+| Long description UK                                             | `copy/description.uk.md`           | copy        | pending EN sign-off                              |
+| Roadmap teaser EN + UK                                          | `copy/teaser-roadmap.md`           | copy        | first draft ✅                                   |
+| Storyboard backdrops (4 mock HTML pages)                        | `storyboards/*.html`               | design+code | needs visual-identity call (§7.4)                |
+| Storyboard capture pipeline (update [`README.md`](./README.md)) | `README.md`                        | design+code | needs storyboards landed first                   |
+| Screenshot #1 popup                                             | `shared/01-popup.png`              | capture     | needs storyboard #1 + built extension            |
+| Screenshot #2 correction applied                                | `shared/02-correction-applied.png` | capture     | needs storyboards before/after + built extension |
+| Screenshot #3 picker survivor                                   | `shared/03-picker-survivor.png`    | capture     | needs storyboard #3                              |
+| Screenshot #4 search rewrite                                    | `shared/04-search-rewrite.png`     | capture     | needs storyboard #4                              |
+| Chrome promo tile                                               | `chrome/promo-tile-440x280.png`    | design      | —                                                |
+| Privacy policy live URL                                         | `https://movar.fyi/privacy`        | infra       | **DNS + Pages deploy**                           |
+| Homepage live URL                                               | `https://movar.fyi`                | infra       | same                                             |
+| Public source repo URL                                          | GitHub                             | infra       | repo currently private                           |
+
+## 7. Open items / blockers
+
+1. **`movar.fyi` DNS + Pages deploy.** Blocks the Privacy URL and Homepage
+   URL. Not a code change — track in
+   [`deployment-checklist.md`](../../../deployment-checklist.md). The
+   `support@movar.fyi` mailbox is already provisioned and is used
+   everywhere as the contact / feedback inbox (`FEEDBACK_URL`, marketing
+   site, privacy policies, store listing).
+
+2. **Public source repo.** AMO does not require source to be public.
+   The privacy policy no longer makes a forward-looking promise about a
+   GitHub link; when the repo opens, add the link to
+   [`Footer.astro`](../../../marketing/src/components/Footer.astro)
+   alongside Privacy / Download / Feedback. No privacy-policy edit
+   needed at that point.
+
+3. **Categories and tags confirmation.** Proposed in §3 but not signed
+   off. AMO requires 1 primary + 1 secondary at form time.
+
+4. **Storyboard visual identity.** The four synthetic backdrops in §5
+   share typography + token palette. Pick one of: (a) reuse marketing-site
+   tokens (looks like a Movar-family product); (b) generic neutral design
+   unrelated to Movar (looks like the user's own browser); (c) explicitly
+   Movar-branded demo frame (the storyboard wears a "Movar demo" badge).
+   Changes how the four shots read as a set.
+
+5. **Edge Add-ons.** Not a v1 focus. If we later submit to Edge, it uses
+   the Chrome screenshots (same 1280×800) and a Chrome-equivalent
+   description with no Mozilla-specific phrasing. Decide later.
+
+## 8. Out of scope for v1 listing
+
+- Russian-language listing.
+- Options/settings screenshot — leaner positioning, configurability isn't the lead.
+- Marketing-hero screenshot of the movar.fyi homepage (was in old spec).
+- HiddenPanel screenshot (was optional in old spec).
+- Priority-driven switching as a primary feature — teased only.
+- A `/marketplace` page on movar.fyi (separate marketing-site work).
+- Edge Add-ons submission.
+
+## 9. References in this repo
+
+| What                                      | Where                                                                                       |
+| ----------------------------------------- | ------------------------------------------------------------------------------------------- |
+| Manifest config                           | [`apps/extension/wxt.config.ts`](../../wxt.config.ts)                                       |
+| Locale strings                            | [`apps/extension/src/public/_locales/{en,uk}/messages.json`](../../src/public/_locales)     |
+| Existing copy draft (to be superseded)    | [`apps/extension/STORE-LISTING.md`](../STORE-LISTING.md)                                    |
+| Screenshot capture recipe                 | [`apps/extension/store-assets/README.md`](./README.md)                                      |
+| Permission justifications                 | [`deployment-checklist.md`](../../../deployment-checklist.md)                               |
+| Privacy policy source                     | [`apps/marketing/src/pages/privacy.astro`](../../../apps/marketing/src/pages/privacy.astro) |
+| Source map for AMO reviewers              | [`apps/extension/SOURCE.md`](../../SOURCE.md)                                               |
+| Rules & supported engines source of truth | [`packages/rules/src/index.ts`](../../../packages/rules/src/index.ts)                       |
+| Priority-driven switching proposal        | [`docs/priority-driven-switching.md`](../../../docs/priority-driven-switching.md)           |

--- a/apps/extension/store-assets/copy/description.en.md
+++ b/apps/extension/store-assets/copy/description.en.md
@@ -1,0 +1,45 @@
+# Movar — long description (English)
+
+Used in the AMO and Chrome Web Store "description" fields. Default locale on AMO.
+
+Lead: multilingual-user framing — UA→RU is _an_ example, not _the_ example. See [`../REQUIREMENTS.md`](../REQUIREMENTS.md) §2 for positioning notes and §4 for the section order this draft follows.
+
+Status: first draft. Char count ≈ 1,500, well under AMO 15k / CWS 16k.
+
+---
+
+Movar keeps the internet in the language you actually read. One preferred language, applied across search engines, multilingual sites, and on-page language pickers — without you having to fight every site, every time.
+
+What it does
+
+- Rewrites search-engine URLs so results come back in your language.
+- Detects when a site has loaded in the wrong language and lets you switch with one click.
+- Hides irrelevant language options from on-site language switchers, so the languages you don't want stop getting in the way.
+
+Supported search engines
+
+Google (.com, .com.ua, .de, .fr, .co.uk, .pl, .com.au), Bing, DuckDuckGo, YouTube.
+
+Languages offered
+
+Ukrainian, English, German, French, Spanish, Italian, Polish.
+
+How it works
+
+- Pick your preferred language once in the options page.
+- Movar applies corrections as you browse.
+- Open the popup to see today's correction counter, pause Movar on the current site, or jump to settings.
+
+Privacy
+
+- No account, no sign-in.
+- No analytics, no telemetry.
+- Nothing leaves your device. Preferences live in browser storage; language detection and rewrites run locally.
+
+Open source
+
+Movar is open source under the MIT license.
+
+Coming soon
+
+Priority-driven language switching — set a ranked list of languages and Movar picks the highest-priority one available on each site.

--- a/apps/extension/store-assets/copy/summary.en.md
+++ b/apps/extension/store-assets/copy/summary.en.md
@@ -1,0 +1,17 @@
+# Movar — short description (English)
+
+Used on store cards, search results, and "about" headers. Two variants of the same line, sized for each store's ceiling.
+
+Status: first draft.
+
+## CWS (≤132)
+
+Keep the internet in your language. Movar fixes search results and multilingual sites that ignore your preferred language.
+
+(122 chars)
+
+## AMO (≤200 target, ≤250 hard cap)
+
+Keep the internet in your language. Movar enforces your language preference across search engines and multilingual sites — rewriting Google, Bing, DuckDuckGo, and YouTube to match your language, and switching sites that loaded in the wrong one.
+
+(≈240 chars)

--- a/apps/extension/store-assets/copy/teaser-roadmap.md
+++ b/apps/extension/store-assets/copy/teaser-roadmap.md
@@ -1,0 +1,11 @@
+# Roadmap teaser
+
+One-line "coming soon" used at the bottom of both long descriptions. Spec source: [`docs/priority-driven-switching.md`](../../../../docs/priority-driven-switching.md). Update both locales when the spec evolves; the body of the descriptions should not promise anything stronger than what this teaser says.
+
+## English
+
+Coming soon: priority-driven language switching — set a ranked list of languages and Movar picks the highest-priority one available on each site.
+
+## Ukrainian
+
+Скоро: перемикання мови за пріоритетом — ви задаєте ранжований список мов, а Movar обирає найвищу доступну для кожного сайту.

--- a/apps/extension/store-assets/storyboards/README.md
+++ b/apps/extension/store-assets/storyboards/README.md
@@ -1,0 +1,71 @@
+# Storyboards
+
+Static HTML mock-ups used as backdrops for the store-listing screenshots in
+[`../shared/`](../shared/). Each file renders a fictitious website at
+1280×800 with the real Movar popup composited over it (via iframe to the
+`extension-popup-preview` server on port 4322) where the scenario needs it.
+
+Five files, mapping to the four screenshot scenarios in
+[`../REQUIREMENTS.md`](../REQUIREMENTS.md) §5:
+
+| File               | Screenshot | What's on the page                                                                                                    | Popup overlay?                    |
+| ------------------ | ---------- | --------------------------------------------------------------------------------------------------------------------- | --------------------------------- |
+| `news.html`        | #1         | Fictitious UA news article — _Світанок_                                                                               | yes                               |
+| `site-before.html` | #2 (left)  | Fictitious services site — _Tochka24_ — in Russian                                                                    | no                                |
+| `site-after.html`  | #2 (right) | Same site in Ukrainian                                                                                                | yes (counter ticking)             |
+| `picker.html`      | #3         | Fictitious settings page — _Kolesnyk_ — with the language picker open; the Russian entry is dimmed with a "Movar" tag | no — the picker is the foreground |
+| `serp.html`        | #4         | Fictitious search engine — _Vector_ — with `?hl=uk` in the URL bar and Ukrainian results                              | no — the SERP is the foreground   |
+
+All four brands (Світанок, Tochka24, Kolesnyk, Vector) are invented; the
+URLs use the IANA-reserved `.example` TLD.
+
+## Capture workflow
+
+1. **Start two preview servers** (or use the `storyboards` and
+   `extension-popup-preview` launch.json entries):
+
+   ```sh
+   pnpm --filter @movar/extension preview:popup        # popup → localhost:4322
+   pnpm --filter @movar/extension preview:storyboards  # storyboards → localhost:4324
+   ```
+
+2. **Open each storyboard at exactly 1280×800** in Chrome. Empty profile,
+   no toolbar extensions visible:
+
+   ```sh
+   open -na "Google Chrome" --args --new-window \
+     --window-size=1280,800 --window-position=0,0 \
+     "http://localhost:4324/news.html"
+   ```
+
+3. **Capture** with `Cmd-Shift-4` → `Space` → click window. Save to
+   `../shared/01-popup.png`, `../shared/02-correction-applied.png`,
+   `../shared/03-picker-survivor.png`, `../shared/04-search-rewrite.png`.
+
+4. **Stitch the before/after shot**. Capture `site-before.html` and
+   `site-after.html` separately, then composite side-by-side:
+
+   ```sh
+   pnpm dlx sharp-cli composite shared/_before.png shared/_after.png \
+     --gravity east > shared/02-correction-applied.png
+   ```
+
+   Or open both in Preview.app and use Tools → Adjust Size to splice.
+
+## Synthetic guard rails (from REQUIREMENTS.md §5)
+
+- No third-party brand logos
+- No fake URLs that look like real domains
+- Each backdrop has its own typography + palette (per the "generic neutral
+  design" decision in §7.4)
+- The popup is captured from the actual built extension, never redrawn
+
+## Popup state for capture
+
+The preview build seeds the popup with the default `MovarSettings` from
+[`packages/shared/src/index.ts`](../../../../packages/shared/src/index.ts).
+To show non-default state (paused, counter at a specific value, hidden
+language list populated) you'll need to either edit the preview seed or
+mock chrome.storage in the preview entry. Tracked as a follow-up — for
+v1, default state is fine for shot #1; the counter value in shot #2 can
+be edited in the popup PNG before saving if needed.

--- a/apps/extension/store-assets/storyboards/news.html
+++ b/apps/extension/store-assets/storyboards/news.html
@@ -1,0 +1,182 @@
+<!doctype html>
+<html lang="uk">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=1280" />
+    <title>Світанок — Як аналітика вирішує, що ви прочитаєте</title>
+    <style>
+      :root {
+        --paper: #f8f5ee;
+        --ink: #1a1612;
+        --ink-soft: #4f463a;
+        --rule: #d8d0bd;
+        --tag: #8c2b1a;
+      }
+      *,
+      *::before,
+      *::after {
+        box-sizing: border-box;
+      }
+      html,
+      body {
+        margin: 0;
+        padding: 0;
+        min-height: 100%;
+      }
+      body {
+        background: var(--paper);
+        color: var(--ink);
+        font:
+          17px/1.6 Georgia,
+          'Times New Roman',
+          serif;
+      }
+      .masthead {
+        border-bottom: 1px solid var(--rule);
+        padding: 22px 64px 18px;
+        display: flex;
+        align-items: baseline;
+        justify-content: space-between;
+      }
+      .brand {
+        font-size: 32px;
+        font-weight: 700;
+        letter-spacing: 0.04em;
+        text-transform: lowercase;
+      }
+      .brand .dot {
+        color: var(--tag);
+      }
+      nav.top {
+        display: flex;
+        gap: 24px;
+        font:
+          600 12px/1 'Helvetica Neue',
+          Arial,
+          sans-serif;
+        letter-spacing: 0.12em;
+        text-transform: uppercase;
+        color: var(--ink-soft);
+      }
+      article {
+        max-width: 720px;
+        margin: 48px auto 64px;
+        padding: 0 64px;
+      }
+      .category {
+        font:
+          700 11px/1 'Helvetica Neue',
+          Arial,
+          sans-serif;
+        letter-spacing: 0.16em;
+        text-transform: uppercase;
+        color: var(--tag);
+      }
+      h1 {
+        font-size: 44px;
+        line-height: 1.12;
+        margin: 14px 0 16px;
+        letter-spacing: -0.01em;
+      }
+      .subhead {
+        font-size: 21px;
+        line-height: 1.4;
+        color: var(--ink-soft);
+        font-style: italic;
+        margin: 0 0 26px;
+      }
+      .byline {
+        font:
+          13px/1.4 'Helvetica Neue',
+          Arial,
+          sans-serif;
+        color: var(--ink-soft);
+        padding-bottom: 16px;
+        border-bottom: 1px solid var(--rule);
+        margin-bottom: 28px;
+      }
+      .byline strong {
+        color: var(--ink);
+        font-weight: 600;
+      }
+      p {
+        margin: 0 0 20px;
+      }
+      p.lead::first-letter {
+        font-size: 64px;
+        float: left;
+        line-height: 0.9;
+        padding: 6px 10px 0 0;
+        color: var(--tag);
+        font-weight: 700;
+      }
+      .popup-slot {
+        position: fixed;
+        right: 24px;
+        bottom: 24px;
+        width: 360px;
+        height: 520px;
+        box-shadow:
+          0 18px 56px rgba(0, 0, 0, 0.22),
+          0 2px 4px rgba(0, 0, 0, 0.08);
+        border-radius: 14px;
+        overflow: hidden;
+        background: #fff;
+      }
+      .popup-slot iframe {
+        width: 100%;
+        height: 100%;
+        border: 0;
+        display: block;
+      }
+    </style>
+  </head>
+  <body>
+    <header class="masthead">
+      <div class="brand">світанок<span class="dot">.</span></div>
+      <nav class="top">
+        <span>Стрічка</span>
+        <span>Думки</span>
+        <span>Культура</span>
+        <span>Технології</span>
+        <span>Бізнес</span>
+      </nav>
+    </header>
+
+    <article>
+      <div class="category">Думки · Інтернет</div>
+      <h1>Як аналітика вирішує, що ви прочитаєте — навіть якщо ви вибрали інакше</h1>
+      <p class="subhead">
+        Маленькі рішення формують велику картину. Що ваш браузер шепоче сайтам — і чому вони не
+        слухають.
+      </p>
+      <div class="byline"><strong>Олена Скиба</strong> · 27 травня 2026 · 6 хвилин читання</div>
+
+      <p class="lead">
+        Кожен наш вибір у мережі — пошуковий запит, відкрита стаття, прокручений стрічковий рядок —
+        додає крапельку у статистику, яку потім зчитують власники сайтів. Якщо мільйон людей
+        сьогодні відкрили сторінку російською тільки тому, що сайт показав її першою, завтра цих
+        сторінок буде більше, а українських — менше. Аналітика читається буквально, а не як
+        справжній вибір читача.
+      </p>
+
+      <p>
+        Браузер кожного запиту повідомляє сайтам, якою мовою ви хотіли б отримати відповідь. Сайт
+        сам вирішує, чи прислуховуватись, — і дуже часто не прислухається. Просто заходить у журнал
+        і помічає, що минулого тижня більшість читачів все одно перейшли на російську версію.
+        Висновок: значить, такою і треба показувати. Логіка крутиться по колу: дефолт формує
+        статистику, статистика підтверджує дефолт.
+      </p>
+
+      <p>
+        Технічний бік такої «м'якої» дискримінації лежить тонкою плівкою на майже кожній
+        бізнес-моделі: швидше показати знайому версію — менше натискань, довша сесія, кращі рекламні
+        показники. Жодного злого наміру; просто оптимізація з пастками.
+      </p>
+    </article>
+
+    <div class="popup-slot">
+      <iframe src="http://localhost:4322/popup.html" title="Movar popup"></iframe>
+    </div>
+  </body>
+</html>

--- a/apps/extension/store-assets/storyboards/picker.html
+++ b/apps/extension/store-assets/storyboards/picker.html
@@ -1,0 +1,226 @@
+<!doctype html>
+<html lang="uk">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=1280" />
+    <title>Kolesnyk — Налаштування</title>
+    <style>
+      :root {
+        --bg: #f1f5f9;
+        --surface: #ffffff;
+        --ink: #0f172a;
+        --ink-soft: #475569;
+        --ink-faint: #94a3b8;
+        --border: #e2e8f0;
+        --accent: #0ea371;
+        --movar: #b45309;
+        --movar-soft: #fef3c7;
+      }
+      *,
+      *::before,
+      *::after {
+        box-sizing: border-box;
+      }
+      html,
+      body {
+        margin: 0;
+        padding: 0;
+        min-height: 100vh;
+      }
+      body {
+        background: var(--bg);
+        color: var(--ink);
+        font:
+          14px/1.55 'Helvetica Neue',
+          Arial,
+          sans-serif;
+      }
+      header {
+        background: var(--surface);
+        border-bottom: 1px solid var(--border);
+        padding: 14px 40px;
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+      }
+      .logo {
+        font-weight: 700;
+        font-size: 17px;
+        letter-spacing: -0.01em;
+      }
+      .logo .square {
+        display: inline-block;
+        width: 18px;
+        height: 18px;
+        background: var(--accent);
+        border-radius: 4px;
+        vertical-align: -3px;
+        margin-right: 8px;
+      }
+      .crumbs {
+        color: var(--ink-faint);
+        font-size: 13px;
+      }
+      .avatar {
+        width: 32px;
+        height: 32px;
+        border-radius: 50%;
+        background: linear-gradient(135deg, #fde68a, #fb923c);
+      }
+      main {
+        max-width: 880px;
+        margin: 0 auto;
+        padding: 48px 40px;
+      }
+      h1 {
+        font-size: 26px;
+        margin: 0 0 6px;
+        letter-spacing: -0.01em;
+      }
+      .lede {
+        color: var(--ink-soft);
+        margin: 0 0 32px;
+      }
+      .card {
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-radius: 12px;
+        padding: 28px 32px;
+        position: relative;
+      }
+      .card h2 {
+        font-size: 17px;
+        margin: 0 0 4px;
+        letter-spacing: -0.01em;
+      }
+      .card .hint {
+        font-size: 13px;
+        color: var(--ink-soft);
+        margin: 0 0 20px;
+      }
+      .picker-button {
+        width: 360px;
+        padding: 11px 14px;
+        border: 1px solid var(--border);
+        border-radius: 8px;
+        background: var(--surface);
+        font: inherit;
+        color: var(--ink);
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        cursor: default;
+      }
+      .picker-button .chev {
+        color: var(--ink-faint);
+      }
+      .picker-dropdown {
+        position: absolute;
+        top: 138px;
+        left: 32px;
+        width: 360px;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-radius: 10px;
+        box-shadow: 0 16px 36px -12px rgba(15, 23, 42, 0.22);
+        padding: 6px;
+        z-index: 10;
+      }
+      .picker-dropdown .item {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        padding: 9px 12px;
+        border-radius: 6px;
+        font-size: 14px;
+      }
+      .picker-dropdown .item:hover:not(.disabled) {
+        background: #f1f5f9;
+      }
+      .picker-dropdown .item .check {
+        color: var(--accent);
+        font-weight: 700;
+      }
+      .picker-dropdown .item .meta {
+        font-size: 12px;
+        color: var(--ink-faint);
+      }
+      .picker-dropdown .item.disabled {
+        color: var(--ink-faint);
+      }
+      .picker-dropdown .item.disabled .label {
+        text-decoration: line-through;
+      }
+      .movar-tag {
+        display: inline-flex;
+        align-items: center;
+        gap: 4px;
+        padding: 2px 6px;
+        background: var(--movar-soft);
+        color: var(--movar);
+        border-radius: 4px;
+        font-size: 11px;
+        font-weight: 600;
+        letter-spacing: 0.02em;
+      }
+      .movar-tag::before {
+        content: '';
+        width: 5px;
+        height: 5px;
+        background: var(--movar);
+        border-radius: 50%;
+        display: inline-block;
+      }
+      .scrim {
+        position: fixed;
+        inset: 0;
+        background: transparent;
+        pointer-events: none;
+      }
+    </style>
+  </head>
+  <body>
+    <header>
+      <div class="logo"><span class="square"></span>kolesnyk</div>
+      <div class="crumbs">Налаштування / Обліковий запис</div>
+      <div class="avatar"></div>
+    </header>
+
+    <main>
+      <h1>Обліковий запис</h1>
+      <p class="lede">Налаштування, які впливають на те, як вам показується інтерфейс Kolesnyk.</p>
+
+      <section class="card">
+        <h2>Мова інтерфейсу</h2>
+        <p class="hint">Налаштування застосовується до меню, повідомлень та email-розсилок.</p>
+        <button class="picker-button">
+          <span>🇺🇦 &nbsp; Українська</span>
+          <span class="chev">▾</span>
+        </button>
+
+        <div class="picker-dropdown" role="listbox">
+          <div class="item">
+            <span class="label">🇺🇦 &nbsp; Українська</span>
+            <span class="check">✓</span>
+          </div>
+          <div class="item">
+            <span class="label">🇬🇧 &nbsp; English</span>
+          </div>
+          <div class="item">
+            <span class="label">🇵🇱 &nbsp; Polski</span>
+          </div>
+          <div class="item">
+            <span class="label">🇩🇪 &nbsp; Deutsch</span>
+          </div>
+          <div class="item disabled" title="Hidden by Movar">
+            <span class="label">🇷🇺 &nbsp; Русский</span>
+            <span class="movar-tag">Прибрано Movar</span>
+          </div>
+          <div class="item">
+            <span class="label">🇧🇾 &nbsp; Беларуская</span>
+          </div>
+        </div>
+      </section>
+    </main>
+  </body>
+</html>

--- a/apps/extension/store-assets/storyboards/serp.html
+++ b/apps/extension/store-assets/storyboards/serp.html
@@ -1,0 +1,240 @@
+<!doctype html>
+<html lang="uk">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=1280" />
+    <title>адвокат у Львові — Vector</title>
+    <style>
+      :root {
+        --bg: #ffffff;
+        --ink: #1f2328;
+        --ink-soft: #57606a;
+        --ink-faint: #8c959f;
+        --link: #1a5fb4;
+        --link-visited: #6f4ca5;
+        --rule: #e6e8eb;
+        --chrome: #f3f4f6;
+        --hl-bg: #fffbea;
+        --hl-ink: #7c5b00;
+      }
+      *,
+      *::before,
+      *::after {
+        box-sizing: border-box;
+      }
+      html,
+      body {
+        margin: 0;
+        padding: 0;
+      }
+      body {
+        background: var(--bg);
+        color: var(--ink);
+        font:
+          14px/1.5 'Helvetica Neue',
+          Arial,
+          sans-serif;
+      }
+      /* Mock browser chrome — URL bar */
+      .chrome {
+        background: var(--chrome);
+        border-bottom: 1px solid var(--rule);
+        padding: 10px 18px;
+        display: flex;
+        align-items: center;
+        gap: 12px;
+      }
+      .chrome .dots {
+        display: flex;
+        gap: 6px;
+      }
+      .chrome .dots span {
+        width: 10px;
+        height: 10px;
+        border-radius: 50%;
+        background: #cbd2da;
+      }
+      .urlbar {
+        flex: 1;
+        background: #fff;
+        border: 1px solid var(--rule);
+        border-radius: 999px;
+        padding: 7px 16px;
+        font:
+          13px/1 ui-monospace,
+          SFMono-Regular,
+          Menlo,
+          monospace;
+        color: var(--ink-soft);
+        display: flex;
+        align-items: center;
+        gap: 8px;
+      }
+      .urlbar .lock {
+        color: var(--ink-faint);
+      }
+      .urlbar .hl {
+        background: var(--hl-bg);
+        color: var(--hl-ink);
+        padding: 1px 4px;
+        border-radius: 3px;
+        margin: 0 -2px;
+      }
+      /* SERP header */
+      .serp-head {
+        max-width: 1180px;
+        margin: 0 auto;
+        padding: 20px 28px 14px;
+        display: flex;
+        align-items: center;
+        gap: 24px;
+        border-bottom: 1px solid var(--rule);
+      }
+      .brand {
+        font-size: 22px;
+        font-weight: 700;
+        letter-spacing: -0.02em;
+      }
+      .brand .v {
+        display: inline-block;
+        width: 22px;
+        height: 22px;
+        border-radius: 6px;
+        background: var(--link);
+        margin-right: 6px;
+        vertical-align: -3px;
+        position: relative;
+      }
+      .brand .v::after {
+        content: 'v';
+        position: absolute;
+        inset: 0;
+        color: #fff;
+        font-size: 16px;
+        text-align: center;
+        line-height: 22px;
+        font-style: italic;
+      }
+      .searchbox {
+        flex: 1;
+        max-width: 560px;
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        padding: 10px 16px;
+        border: 1px solid var(--rule);
+        border-radius: 999px;
+        font-size: 15px;
+      }
+      .searchbox .magnifier {
+        color: var(--ink-faint);
+      }
+      /* Results */
+      .results {
+        max-width: 680px;
+        padding: 22px 28px 60px;
+      }
+      .stats {
+        font-size: 12px;
+        color: var(--ink-faint);
+        margin-bottom: 24px;
+      }
+      .result {
+        margin: 0 0 28px;
+      }
+      .result .site {
+        font-size: 13px;
+        color: var(--ink-soft);
+        margin: 0 0 2px;
+      }
+      .result h3 {
+        font-size: 18px;
+        font-weight: 500;
+        margin: 0 0 4px;
+        color: var(--link);
+        letter-spacing: -0.005em;
+      }
+      .result h3 a {
+        color: inherit;
+        text-decoration: none;
+      }
+      .result .snippet {
+        font-size: 14px;
+        color: var(--ink-soft);
+        margin: 0;
+      }
+      .result em {
+        background: #fff3a8;
+        font-style: normal;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="chrome">
+      <div class="dots"><span></span><span></span><span></span></div>
+      <div class="urlbar">
+        <span class="lock">🔒</span>
+        <span>vector.example/search?q=адвокат+у+Львові&amp;<span class="hl">hl=uk</span></span>
+      </div>
+    </div>
+
+    <div class="serp-head">
+      <div class="brand"><span class="v"></span>ector</div>
+      <div class="searchbox">
+        <span class="magnifier">🔍</span>
+        <span>адвокат у Львові</span>
+      </div>
+    </div>
+
+    <div class="results">
+      <div class="stats">Близько 47 200 результатів · мова: українська</div>
+
+      <div class="result">
+        <p class="site">sau.example.org › katalog</p>
+        <h3><a>Каталог адвокатів — Спілка адвокатів України</a></h3>
+        <p class="snippet">
+          Офіційний реєстр практикуючих <em>адвокатів</em> у Львівській області. Пошук за
+          спеціалізацією, мовою та районом міста …
+        </p>
+      </div>
+
+      <div class="result">
+        <p class="site">maletskyy-law.example › about</p>
+        <h3><a>Адвокатське бюро у Львові — 12 років практики</a></h3>
+        <p class="snippet">
+          Сімейні справи, спадкові спори, господарські суперечки. Перша консультація у
+          <em>Львові</em> — безкоштовно, прийом за попереднім записом …
+        </p>
+      </div>
+
+      <div class="result">
+        <p class="site">lvivlawyers.example</p>
+        <h3><a>ЛьвівЮрист — асоціація молодих адвокатів</a></h3>
+        <p class="snippet">
+          Безкоштовна правова допомога мешканцям <em>Львова</em> та області: соціальні справи,
+          трудові конфлікти, оформлення документів …
+        </p>
+      </div>
+
+      <div class="result">
+        <p class="site">pravo.example › articles</p>
+        <h3>
+          <a>Як обрати <em>адвоката</em>: 7 порад від практиків</a>
+        </h3>
+        <p class="snippet">
+          Що питати на першій консультації, як перевірити досвід, де читати відгуки клієнтів і чому
+          варто перевіряти членство в палаті …
+        </p>
+      </div>
+
+      <div class="result">
+        <p class="site">lviv.gov.example › besplatna-dopomoga</p>
+        <h3><a>Безкоштовна правова допомога у Львові — реєстр</a></h3>
+        <p class="snippet">
+          Перелік центрів безкоштовної вторинної правової допомоги у Львівській області, години
+          прийому, телефони чергових <em>адвокатів</em> …
+        </p>
+      </div>
+    </div>
+  </body>
+</html>

--- a/apps/extension/store-assets/storyboards/site-after.html
+++ b/apps/extension/store-assets/storyboards/site-after.html
@@ -1,0 +1,212 @@
+<!doctype html>
+<html lang="uk">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=1280" />
+    <title>Tochka24 — Освіжіть дім без зайвих клопотів</title>
+    <style>
+      :root {
+        --bg: #ffffff;
+        --ink: #0f172a;
+        --ink-soft: #475569;
+        --border: #e2e8f0;
+        --accent: #1d4ed8;
+        --accent-soft: #eff6ff;
+        --surface: #f8fafc;
+      }
+      *,
+      *::before,
+      *::after {
+        box-sizing: border-box;
+      }
+      html,
+      body {
+        margin: 0;
+        padding: 0;
+      }
+      body {
+        background: var(--bg);
+        color: var(--ink);
+        font:
+          15px/1.55 system-ui,
+          -apple-system,
+          'Segoe UI',
+          Roboto,
+          sans-serif;
+      }
+      header {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        padding: 18px 56px;
+        border-bottom: 1px solid var(--border);
+      }
+      .logo {
+        font-weight: 800;
+        font-size: 22px;
+        letter-spacing: -0.02em;
+      }
+      .logo .dot {
+        color: var(--accent);
+      }
+      nav {
+        display: flex;
+        gap: 28px;
+        font-size: 14px;
+        color: var(--ink-soft);
+      }
+      .cta-secondary {
+        padding: 8px 16px;
+        border: 1px solid var(--border);
+        border-radius: 8px;
+        color: var(--ink);
+        font-weight: 600;
+        font-size: 14px;
+      }
+      .hero {
+        max-width: 1120px;
+        margin: 0 auto;
+        padding: 80px 56px 60px;
+        display: grid;
+        grid-template-columns: 1.1fr 1fr;
+        gap: 56px;
+        align-items: center;
+      }
+      .hero h1 {
+        font-size: 48px;
+        line-height: 1.1;
+        letter-spacing: -0.02em;
+        margin: 0 0 18px;
+      }
+      .hero p {
+        font-size: 18px;
+        line-height: 1.55;
+        color: var(--ink-soft);
+        margin: 0 0 26px;
+        max-width: 460px;
+      }
+      .cta-primary {
+        display: inline-flex;
+        align-items: center;
+        gap: 8px;
+        padding: 14px 24px;
+        background: var(--accent);
+        color: #fff;
+        border-radius: 10px;
+        font-weight: 600;
+        font-size: 15px;
+      }
+      .visual {
+        aspect-ratio: 4/3;
+        background: linear-gradient(135deg, var(--accent-soft) 0%, #dbeafe 100%);
+        border-radius: 18px;
+        position: relative;
+      }
+      .visual::after {
+        content: '';
+        position: absolute;
+        inset: 12% 14% 14% 12%;
+        background: #ffffff;
+        border-radius: 12px;
+        box-shadow: 0 24px 48px -16px rgba(15, 23, 42, 0.18);
+      }
+      .features {
+        max-width: 1120px;
+        margin: 0 auto;
+        padding: 56px 56px 80px;
+        display: grid;
+        grid-template-columns: repeat(3, 1fr);
+        gap: 28px;
+      }
+      .feature {
+        padding: 28px;
+        border: 1px solid var(--border);
+        border-radius: 14px;
+        background: var(--surface);
+      }
+      .feature h3 {
+        font-size: 17px;
+        margin: 0 0 10px;
+        letter-spacing: -0.01em;
+      }
+      .feature p {
+        font-size: 14px;
+        color: var(--ink-soft);
+        margin: 0;
+      }
+      .pill {
+        display: inline-block;
+        width: 32px;
+        height: 32px;
+        border-radius: 8px;
+        background: var(--accent-soft);
+        margin-bottom: 14px;
+      }
+      .popup-slot {
+        position: fixed;
+        right: 24px;
+        bottom: 24px;
+        width: 360px;
+        height: 520px;
+        box-shadow:
+          0 18px 56px rgba(0, 0, 0, 0.22),
+          0 2px 4px rgba(0, 0, 0, 0.08);
+        border-radius: 14px;
+        overflow: hidden;
+        background: #fff;
+      }
+      .popup-slot iframe {
+        width: 100%;
+        height: 100%;
+        border: 0;
+        display: block;
+      }
+    </style>
+  </head>
+  <body>
+    <header>
+      <div class="logo">tochka<span class="dot">24</span></div>
+      <nav>
+        <span>Послуги</span>
+        <span>Ціни</span>
+        <span>Зона роботи</span>
+        <span>Допомога</span>
+      </nav>
+      <a class="cta-secondary">Увійти</a>
+    </header>
+
+    <section class="hero">
+      <div>
+        <h1>Освіжіть дім без зайвих клопотів.</h1>
+        <p>
+          Прибирання, дрібний ремонт, доставка — в одному застосунку, з прозорою ціною та фіксованим
+          часом приїзду майстра.
+        </p>
+        <a class="cta-primary">Замовити майстра →</a>
+      </div>
+      <div class="visual"></div>
+    </section>
+
+    <section class="features">
+      <div class="feature">
+        <span class="pill"></span>
+        <h3>Прозорі ціни</h3>
+        <p>Ціна видно до замовлення. Без сюрпризів у чеку та без «по факту робіт».</p>
+      </div>
+      <div class="feature">
+        <span class="pill"></span>
+        <h3>Час під контролем</h3>
+        <p>Вікно приїзду — 30 хвилин. Якщо майстер запізнюється, знижка автоматично.</p>
+      </div>
+      <div class="feature">
+        <span class="pill"></span>
+        <h3>Перевірені майстри</h3>
+        <p>Усі майстри з чинними документами та підтвердженим досвідом.</p>
+      </div>
+    </section>
+
+    <div class="popup-slot">
+      <iframe src="http://localhost:4322/popup.html" title="Movar popup"></iframe>
+    </div>
+  </body>
+</html>

--- a/apps/extension/store-assets/storyboards/site-before.html
+++ b/apps/extension/store-assets/storyboards/site-before.html
@@ -1,0 +1,189 @@
+<!doctype html>
+<html lang="ru">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=1280" />
+    <title>Tochka24 — Освежите дом без лишних хлопот</title>
+    <style>
+      :root {
+        --bg: #ffffff;
+        --ink: #0f172a;
+        --ink-soft: #475569;
+        --border: #e2e8f0;
+        --accent: #1d4ed8;
+        --accent-soft: #eff6ff;
+        --surface: #f8fafc;
+      }
+      *,
+      *::before,
+      *::after {
+        box-sizing: border-box;
+      }
+      html,
+      body {
+        margin: 0;
+        padding: 0;
+      }
+      body {
+        background: var(--bg);
+        color: var(--ink);
+        font:
+          15px/1.55 system-ui,
+          -apple-system,
+          'Segoe UI',
+          Roboto,
+          sans-serif;
+      }
+      header {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        padding: 18px 56px;
+        border-bottom: 1px solid var(--border);
+      }
+      .logo {
+        font-weight: 800;
+        font-size: 22px;
+        letter-spacing: -0.02em;
+      }
+      .logo .dot {
+        color: var(--accent);
+      }
+      nav {
+        display: flex;
+        gap: 28px;
+        font-size: 14px;
+        color: var(--ink-soft);
+      }
+      .cta-secondary {
+        padding: 8px 16px;
+        border: 1px solid var(--border);
+        border-radius: 8px;
+        color: var(--ink);
+        font-weight: 600;
+        font-size: 14px;
+      }
+      .hero {
+        max-width: 1120px;
+        margin: 0 auto;
+        padding: 80px 56px 60px;
+        display: grid;
+        grid-template-columns: 1.1fr 1fr;
+        gap: 56px;
+        align-items: center;
+      }
+      .hero h1 {
+        font-size: 48px;
+        line-height: 1.1;
+        letter-spacing: -0.02em;
+        margin: 0 0 18px;
+      }
+      .hero p {
+        font-size: 18px;
+        line-height: 1.55;
+        color: var(--ink-soft);
+        margin: 0 0 26px;
+        max-width: 460px;
+      }
+      .cta-primary {
+        display: inline-flex;
+        align-items: center;
+        gap: 8px;
+        padding: 14px 24px;
+        background: var(--accent);
+        color: #fff;
+        border-radius: 10px;
+        font-weight: 600;
+        font-size: 15px;
+      }
+      .visual {
+        aspect-ratio: 4/3;
+        background: linear-gradient(135deg, var(--accent-soft) 0%, #dbeafe 100%);
+        border-radius: 18px;
+        position: relative;
+      }
+      .visual::after {
+        content: '';
+        position: absolute;
+        inset: 12% 14% 14% 12%;
+        background: #ffffff;
+        border-radius: 12px;
+        box-shadow: 0 24px 48px -16px rgba(15, 23, 42, 0.18);
+      }
+      .features {
+        max-width: 1120px;
+        margin: 0 auto;
+        padding: 56px 56px 80px;
+        display: grid;
+        grid-template-columns: repeat(3, 1fr);
+        gap: 28px;
+      }
+      .feature {
+        padding: 28px;
+        border: 1px solid var(--border);
+        border-radius: 14px;
+        background: var(--surface);
+      }
+      .feature h3 {
+        font-size: 17px;
+        margin: 0 0 10px;
+        letter-spacing: -0.01em;
+      }
+      .feature p {
+        font-size: 14px;
+        color: var(--ink-soft);
+        margin: 0;
+      }
+      .pill {
+        display: inline-block;
+        width: 32px;
+        height: 32px;
+        border-radius: 8px;
+        background: var(--accent-soft);
+        margin-bottom: 14px;
+      }
+    </style>
+  </head>
+  <body>
+    <header>
+      <div class="logo">tochka<span class="dot">24</span></div>
+      <nav>
+        <span>Услуги</span>
+        <span>Цены</span>
+        <span>Зона работы</span>
+        <span>Помощь</span>
+      </nav>
+      <a class="cta-secondary">Войти</a>
+    </header>
+
+    <section class="hero">
+      <div>
+        <h1>Освежите дом без лишних хлопот.</h1>
+        <p>
+          Уборка, мелкий ремонт, доставка — в одном приложении, с прозрачной ценой и фиксированным
+          временем приезда мастера.
+        </p>
+        <a class="cta-primary">Заказать мастера →</a>
+      </div>
+      <div class="visual"></div>
+    </section>
+
+    <section class="features">
+      <div class="feature">
+        <span class="pill"></span>
+        <h3>Прозрачные цены</h3>
+        <p>Цена видна до заказа. Без сюрпризов в чеке и без «по факту работ».</p>
+      </div>
+      <div class="feature">
+        <span class="pill"></span>
+        <h3>Время под контролем</h3>
+        <p>Окно приезда — 30 минут. Если мастер задерживается, скидка автоматически.</p>
+      </div>
+      <div class="feature">
+        <span class="pill"></span>
+        <h3>Проверенные мастера</h3>
+        <p>Все мастера с действующими документами и подтверждённым опытом.</p>
+      </div>
+    </section>
+  </body>
+</html>

--- a/apps/marketing/.storybook/main.ts
+++ b/apps/marketing/.storybook/main.ts
@@ -1,0 +1,51 @@
+import type { StorybookConfig } from '@storybook/react-vite';
+
+import tailwindcss from '@tailwindcss/vite';
+
+/**
+ * Marketing Storybook — full-section gallery for the components in
+ * apps/marketing/src/components/. Mirrors the @movar/ui Storybook
+ * (packages/ui/.storybook/) so the two share Vite + Tailwind plumbing and
+ * cold-start cost.
+ *
+ * Astro components don't render in React-Vite Storybook directly. Each
+ * `<Name>.astro` has a sibling `<Name>.stories.tsx` that re-implements the
+ * markup in React, reading from the same `i18n.ts` strings. The `.astro`
+ * file stays the production source; the React mock exists only for
+ * Storybook isolation development. Drift between the two is the
+ * trade-off — see `.storybook/preview.tsx` for the maintenance note.
+ */
+const config: StorybookConfig = {
+  stories: ['../src/**/*.stories.@(ts|tsx|mdx)'],
+  addons: ['@storybook/addon-docs'],
+  framework: {
+    name: '@storybook/react-vite',
+    options: {},
+  },
+  typescript: {
+    // Marketing already runs `astro check` for .astro files and tsc emits
+    // are disabled — let Storybook trust that and skip re-checking on every
+    // dev boot.
+    check: false,
+  },
+  async viteFinal(viteConfig) {
+    return {
+      ...viteConfig,
+      // Force automatic JSX runtime. The marketing app's `tsconfig.json`
+      // overrides `jsx: "preserve"` so Astro can drive its own JSX, but
+      // Storybook's Vite picks that up via esbuild and emits classic
+      // `React.createElement` calls without auto-importing React — every
+      // story then crashes with `ReferenceError: React is not defined`.
+      // Pinning the runtime here keeps the story tsx files free of a
+      // boilerplate `import React from 'react'` on every file.
+      esbuild: {
+        ...viteConfig.esbuild,
+        jsx: 'automatic',
+        jsxImportSource: 'react',
+      },
+      plugins: [...(viteConfig.plugins ?? []), ...tailwindcss()],
+    };
+  },
+};
+
+export default config;

--- a/apps/marketing/.storybook/preview.css
+++ b/apps/marketing/.storybook/preview.css
@@ -1,0 +1,76 @@
+@import 'tailwindcss';
+
+@import '@fontsource/manrope/latin-400.css';
+@import '@fontsource/manrope/cyrillic-400.css';
+@import '@fontsource/manrope/latin-500.css';
+@import '@fontsource/manrope/cyrillic-500.css';
+@import '@fontsource/manrope/latin-600.css';
+@import '@fontsource/manrope/cyrillic-600.css';
+@import '@fontsource/manrope/latin-700.css';
+@import '@fontsource/manrope/cyrillic-700.css';
+@import '@fontsource/manrope/latin-800.css';
+@import '@fontsource/manrope/cyrillic-800.css';
+@import '@fontsource/ibm-plex-mono/latin-400.css';
+@import '@fontsource/ibm-plex-mono/cyrillic-400.css';
+@import '@fontsource/ibm-plex-mono/latin-500.css';
+@import '@fontsource/ibm-plex-mono/cyrillic-500.css';
+
+@import '@movar/ui/tokens.css';
+
+/*
+ * Story files mock marketing components as React. Tailwind needs an
+ * explicit @source so utilities used only inside the story mocks (and not
+ * in any .astro file's static analysis) make it into the generated preview
+ * CSS.
+ */
+@source '../src/**/*.tsx';
+
+/*
+ * Mirrors apps/marketing/src/styles/global.css and packages/ui/.storybook/
+ * preview.css — same @theme inline wiring so the Storybook canvas resolves
+ * semantic utilities (`bg-surface`, `text-ink-strong`, …) identically to
+ * what the marketing site and the @movar/ui Storybook render.
+ */
+@theme inline {
+  --color-bg: var(--bg);
+  --color-surface: var(--surface);
+  --color-surface-2: var(--surface-2);
+  --color-surface-3: var(--surface-3);
+  --color-border: var(--border);
+  --color-border-strong: var(--border-strong);
+  --color-ink-faint: var(--ink-faint);
+  --color-ink-soft: var(--ink-soft);
+  --color-ink: var(--ink);
+  --color-ink-strong: var(--ink-strong);
+  --color-accent: var(--accent);
+  --color-accent-deep: var(--accent-deep);
+  --color-accent-soft: var(--accent-soft);
+  --color-accent-surface: var(--accent-surface);
+  --color-accent-on: var(--accent-on);
+  --color-danger: var(--danger);
+  --color-danger-deep: var(--danger-deep);
+  --color-danger-soft: var(--danger-soft);
+  --color-danger-surface: var(--danger-surface);
+  --color-danger-on: var(--danger-on);
+
+  --shadow-sm: var(--shadow-sm);
+  --shadow-md: var(--shadow-md);
+  --shadow-lg: var(--shadow-lg);
+}
+
+@theme {
+  --font-display: 'Manrope', ui-sans-serif, system-ui, sans-serif;
+  --font-sans: 'Manrope', ui-sans-serif, system-ui, sans-serif;
+  --font-mono: 'IBM Plex Mono', ui-monospace, SFMono-Regular, Menlo, monospace;
+}
+
+/*
+ * Storybook's default canvas paints white. Override so the token-driven
+ * --bg shows through and a story faithfully reflects what the site renders.
+ */
+.sb-show-main,
+.docs-story {
+  background: var(--bg) !important;
+  color: var(--ink);
+  font-family: var(--font-sans);
+}

--- a/apps/marketing/.storybook/preview.tsx
+++ b/apps/marketing/.storybook/preview.tsx
@@ -1,0 +1,56 @@
+import type { Preview } from '@storybook/react';
+
+import './preview.css';
+
+/**
+ * Global preview config for the marketing Storybook.
+ *
+ * Sections are page-sized, not primitive-sized — layout defaults to
+ * `'fullscreen'` so a story renders edge-to-edge, matching how the section
+ * sits on the live marketing page. Stories that want padding opt in
+ * locally with `parameters: { layout: 'padded' }`.
+ *
+ * Dark mode rides `@movar/ui`'s tokens.css `prefers-color-scheme` flip. No
+ * toolbar toggle here — change your OS theme to preview dark, matching how
+ * the marketing site and the extension decide their theme too.
+ *
+ * Maintenance: every story file is a React re-implementation of the
+ * sibling `.astro` component. When the `.astro` changes, the matching
+ * `.stories.tsx` needs the same edit. Code review is the drift-detection
+ * net. If divergence gets meaningful, swap to a community Astro framework
+ * for Storybook and delete the React mocks.
+ */
+const preview: Preview = {
+  parameters: {
+    layout: 'fullscreen',
+    controls: {
+      matchers: {
+        color: /(background|color)$/i,
+        date: /Date$/i,
+      },
+    },
+    options: {
+      storySort: {
+        order: [
+          'Marketing',
+          [
+            'Hero',
+            'Problem',
+            'Stakes',
+            'HowItWorks',
+            'Examples',
+            'BeforeAfter',
+            'Limitations',
+            'Privacy',
+            'Close',
+            'Header',
+            'Footer',
+            'DownloadButtons',
+          ],
+        ],
+      },
+    },
+  },
+};
+
+export default preview;

--- a/apps/marketing/astro.config.mjs
+++ b/apps/marketing/astro.config.mjs
@@ -7,6 +7,13 @@ export default defineConfig({
   site: 'https://movar.fyi',
   output: 'static',
   vite: {
+    // Astro 5.18 bundles Vite 6 types, but @tailwindcss/vite 4.3 in this
+    // workspace resolves to its vite-7 build (Storybook 10 forces vite 7
+    // hoisted at the marketing devDep root). The two Plugin shapes are
+    // runtime-compatible — Astro accepts the plugin — but cross-major
+    // Plugin types collide under `astro check`. Drop the cast when Astro
+    // ships vite-7 types.
+    // @ts-expect-error cross-major vite Plugin shape (vite 6 ↔ vite 7)
     plugins: [tailwindcss()],
   },
 });

--- a/apps/marketing/package.json
+++ b/apps/marketing/package.json
@@ -8,7 +8,9 @@
     "build": "astro build",
     "preview": "astro preview",
     "typecheck": "astro check",
-    "lint": "eslint ."
+    "lint": "eslint .",
+    "storybook": "storybook dev -p ${MARKETING_STORYBOOK_PORT:-6007} --no-open",
+    "build-storybook": "storybook build -o storybook-static"
   },
   "dependencies": {
     "@movar/shared": "workspace:*",
@@ -17,13 +19,22 @@
   },
   "devDependencies": {
     "@astrojs/check": "^0.9.4",
+    "@fontsource/ibm-plex-mono": "^5.2.7",
     "@fontsource/manrope": "^5.2.7",
     "@movar/eslint-config": "workspace:*",
+    "@storybook/addon-docs": "^10.4.1",
+    "@storybook/react": "^10.4.1",
+    "@storybook/react-vite": "^10.4.1",
     "@tailwindcss/vite": "^4.3.0",
     "@types/node": "^25.9.1",
+    "@types/react": "^19.2.15",
+    "@types/react-dom": "^19.2.3",
     "eslint": "^9.39.4",
+    "react": "^19.2.6",
+    "react-dom": "^19.2.6",
+    "storybook": "^10.4.1",
     "tailwindcss": "^4.3.0",
     "typescript": "^6.0.3",
-    "vite": "^6.0.0"
+    "vite": "^7.3.3"
   }
 }

--- a/apps/marketing/src/components/BeforeAfter.stories.tsx
+++ b/apps/marketing/src/components/BeforeAfter.stories.tsx
@@ -1,0 +1,227 @@
+import type { JSX } from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+
+import { strings, type Locale } from '../i18n';
+
+/**
+ * React mock of `BeforeAfter.astro`.
+ *
+ * The Astro version checks for two PNGs in `public/screenshots/` and
+ * silently omits the section when either is missing. The PNGs don't exist
+ * yet — the story would otherwise render broken `<img>` icons in the
+ * placeholder cards.
+ *
+ * To keep the layout visually meaningful in the gallery, the story
+ * renders an inline mock SERP (Russian for "without", Ukrainian for
+ * "with") inside each frame by default. Once the real screenshots land at
+ * `apps/marketing/public/screenshots/google-{without,with}-movar.png`,
+ * flip the `useRealImages` control to point at them instead.
+ */
+interface MockProps {
+  lang?: Locale;
+  /** Mirrors the `hasImages` silent-omit in .astro — section returns null. */
+  missing?: boolean;
+  /**
+   * Render the real `/screenshots/google-{without,with}-movar.png` files
+   * instead of the inline mock SERP. Only works once they're captured;
+   * Storybook serves the marketing app's `/public/` at the root.
+   */
+  useRealImages?: boolean;
+}
+
+type Variant = 'without' | 'with';
+
+interface SerpItem {
+  site: string;
+  title: string;
+  snippet: string;
+}
+
+/**
+ * Module-level mock SERP item lists. Hoisting them out of `MockSerp`
+ * keeps the function under the unit-size threshold and signals that
+ * these are static, not parameterised per render.
+ */
+const WITHOUT_ITEMS: readonly SerpItem[] = [
+  {
+    site: 'ru.wikipedia.example',
+    title: 'Политика — Википедия',
+    snippet:
+      'Политика (от греч. πολιτικά) — общественная деятельность, связанная с распределением власти…',
+  },
+  {
+    site: 'gazeta.example',
+    title: 'Новости политики России и мира',
+    snippet:
+      'Главные политические события дня, заявления первых лиц, аналитика и комментарии экспертов…',
+  },
+  {
+    site: 'lenta.example',
+    title: 'Политика в Украине: последние события',
+    snippet:
+      'Обзор политических событий на Украине, заявления чиновников и партий, реакция избирателей…',
+  },
+];
+
+const WITH_ITEMS: readonly SerpItem[] = [
+  {
+    site: 'uk.wikipedia.example',
+    title: 'Політика — Вікіпедія',
+    snippet: 'Полі́тика (від грец. πολιτικά) — суспільна діяльність, повʼязана з розподілом влади…',
+  },
+  {
+    site: 'pravda.example',
+    title: 'Українська політика — новини та аналітика',
+    snippet:
+      'Останні події української політики, оперативні новини з парламенту, коментарі експертів…',
+  },
+  {
+    site: 'novyny.example',
+    title: 'Політика в Україні: огляд тижня',
+    snippet: 'Огляд основних політичних подій тижня, інтервʼю з експертами, аналітичні матеріали…',
+  },
+];
+
+/**
+ * Inline mock SERP used as a placeholder until the real screenshots land.
+ * Russian when `variant === 'without'` (what Google returns for a Cyrillic
+ * query absent Movar) and Ukrainian when `variant === 'with'` (what Movar
+ * negotiates for the same query). Hostnames use `.example` and brand-free
+ * names so nothing reads as a real site.
+ */
+function MockSerp({ variant }: { variant: Variant }): JSX.Element {
+  const items = variant === 'without' ? WITHOUT_ITEMS : WITH_ITEMS;
+  return (
+    <div className="size-full overflow-hidden bg-white p-5 text-left">
+      <div className="mb-4 inline-flex items-center gap-2 rounded-full border border-zinc-200 bg-zinc-50 px-3 py-1.5 text-[11px] text-zinc-600">
+        <span aria-hidden="true">🔍</span>
+        <span>політика</span>
+      </div>
+      <div className="space-y-3.5">
+        {items.map((item) => (
+          <div key={item.site}>
+            <div className="text-[10px] tracking-wide text-zinc-400 uppercase">{item.site}</div>
+            <div className="mt-0.5 text-[13px] leading-snug font-medium text-blue-700">
+              {item.title}
+            </div>
+            <p className="mt-0.5 line-clamp-2 text-[11px] leading-snug text-zinc-600">
+              {item.snippet}
+            </p>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+interface Comparison {
+  label: string;
+  variant: Variant;
+  caption: string;
+  src: string;
+  alt: string;
+}
+
+function buildComparisons(t: (typeof strings)[Locale]['beforeAfter']): readonly Comparison[] {
+  return [
+    {
+      label: t.without,
+      variant: 'without',
+      caption: t.withoutCaption,
+      src: '/screenshots/google-without-movar.png',
+      alt: 'Google search results for a Cyrillic query, with Russian-language pages dominating',
+    },
+    {
+      label: t.withMovar,
+      variant: 'with',
+      caption: t.withCaption,
+      src: '/screenshots/google-with-movar.png',
+      alt: 'Same Google search, now returning Ukrainian-language pages',
+    },
+  ];
+}
+
+function ComparisonFigure({
+  c,
+  useRealImages,
+}: {
+  c: Comparison;
+  useRealImages: boolean;
+}): JSX.Element {
+  return (
+    <figure
+      className={`bg-bg rounded-2xl border p-3 shadow-sm ${
+        c.variant === 'with' ? 'border-accent/30' : 'border-border'
+      }`}
+    >
+      <div className="relative aspect-[16/10] overflow-hidden rounded-lg bg-white">
+        {useRealImages ? (
+          <img src={c.src} alt={c.alt} loading="lazy" className="size-full object-cover" />
+        ) : (
+          <MockSerp variant={c.variant} />
+        )}
+      </div>
+      <figcaption className="mt-3 px-1 pb-1">
+        <div
+          className={`font-mono text-xs tracking-[0.1em] uppercase ${
+            c.variant === 'with' ? 'text-accent' : 'text-ink-faint'
+          }`}
+        >
+          {c.label}
+        </div>
+        <p className="text-ink mt-1 text-sm">{c.caption}</p>
+      </figcaption>
+    </figure>
+  );
+}
+
+function BeforeAfterMock({
+  lang = 'en' as Locale,
+  missing = false,
+  useRealImages = false,
+}: MockProps): JSX.Element | null {
+  const t = strings[lang].beforeAfter;
+  if (missing) return null;
+  const comparisons = buildComparisons(t);
+
+  return (
+    <section id="before-after" className="border-border bg-surface border-t px-6 py-20">
+      <div className="mx-auto max-w-5xl">
+        <h2 className="font-display text-ink-strong text-3xl font-extrabold tracking-tight sm:text-4xl">
+          {t.sectionTitle}
+        </h2>
+        <p className="text-ink-soft mt-3 max-w-2xl">{t.sectionLead}</p>
+
+        <div className="mt-10 grid gap-6 sm:grid-cols-2">
+          {comparisons.map((c) => (
+            <ComparisonFigure key={c.variant} c={c} useRealImages={useRealImages} />
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+const meta = {
+  title: 'Marketing/BeforeAfter',
+  component: BeforeAfterMock,
+  argTypes: {
+    lang: { control: { type: 'inline-radio' }, options: ['en', 'uk'] satisfies Locale[] },
+    missing: { control: 'boolean' },
+    useRealImages: { control: 'boolean' },
+  },
+} satisfies Meta<typeof BeforeAfterMock>;
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const English: Story = { args: { lang: 'en', missing: false, useRealImages: false } };
+export const Ukrainian: Story = { args: { lang: 'uk', missing: false, useRealImages: false } };
+export const RealScreenshots: Story = {
+  name: 'Real screenshots (once captured)',
+  args: { lang: 'en', missing: false, useRealImages: true },
+};
+export const ImagesMissing: Story = {
+  name: 'Images missing (section omitted)',
+  args: { lang: 'en', missing: true },
+};

--- a/apps/marketing/src/components/Close.stories.tsx
+++ b/apps/marketing/src/components/Close.stories.tsx
@@ -1,0 +1,43 @@
+import type { JSX } from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+
+import { FEEDBACK_URL } from '@movar/shared';
+
+import { strings, type Locale } from '../i18n';
+
+/** React mock of `Close.astro` — the closing CTA with the feedback mailto. */
+function CloseMock({ lang = 'en' as Locale }): JSX.Element {
+  const t = strings[lang].close;
+  return (
+    <section id="close" className="border-border bg-surface border-t px-6 py-20">
+      <div className="mx-auto max-w-5xl">
+        <h2 className="font-display text-ink-strong text-3xl font-extrabold tracking-tight sm:text-4xl">
+          {t.sectionTitle}
+        </h2>
+        <p className="text-ink-soft mt-3 max-w-2xl">{t.sectionLead}</p>
+        <div className="mt-8">
+          <a
+            href={FEEDBACK_URL}
+            className="border-accent bg-surface text-accent hover:bg-accent-surface inline-flex items-center justify-center gap-2 rounded-xl border px-6 py-4 text-base font-semibold shadow-sm transition hover:shadow-md"
+          >
+            {t.emailLabel}
+          </a>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+const meta = {
+  title: 'Marketing/Close',
+  component: CloseMock,
+  argTypes: {
+    lang: { control: { type: 'inline-radio' }, options: ['en', 'uk'] satisfies Locale[] },
+  },
+} satisfies Meta<typeof CloseMock>;
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const English: Story = { args: { lang: 'en' } };
+export const Ukrainian: Story = { args: { lang: 'uk' } };

--- a/apps/marketing/src/components/DownloadButtons.stories.tsx
+++ b/apps/marketing/src/components/DownloadButtons.stories.tsx
@@ -1,0 +1,98 @@
+import type { JSX } from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+
+import { strings, type Locale } from '../i18n';
+
+/**
+ * React mock of `DownloadButtons.astro`. The Astro version ships an SSR
+ * "Add Movar to your browser · Soon" fallback and an inline script that
+ * detects the visitor's browser and swaps the label + href to whichever
+ * store matches. The mock here doesn't run the script — instead it accepts
+ * `browser` + `live` controls so each ship-time state has its own story.
+ *
+ * In v1 every store has `liveAt: null`, so the Soon badge is the only path
+ * users will see. The Live stories are forward-looking previews of the
+ * post-launch UI for each browser.
+ */
+type Browser = 'chrome' | 'edge' | 'firefox' | 'unknown';
+type KnownBrowser = Exclude<Browser, 'unknown'>;
+
+interface MockProps {
+  lang?: Locale;
+  browser?: Browser;
+  /** Whether the matched store has `liveAt` set. Mocks the "Soon" → "Live" flip. */
+  live?: boolean;
+}
+
+/** Pick the per-browser label, falling back to the generic when unknown. */
+function resolveAddLabel(t: (typeof strings)[Locale]['download'], browser: Browser): string {
+  if (browser !== 'unknown' && browser in t.add) {
+    return t.add[browser as KnownBrowser];
+  }
+  return t.addGeneric;
+}
+
+function DownloadButtonsMock({
+  lang = 'en' as Locale,
+  browser = 'unknown',
+  live = false,
+}: MockProps): JSX.Element {
+  const t = strings[lang].download;
+  const label = resolveAddLabel(t, browser);
+
+  return (
+    <div className="grid place-items-center px-6 py-20">
+      <div id="download" className="flex justify-center">
+        <a
+          href={live ? '#' : undefined}
+          aria-disabled={live ? undefined : 'true'}
+          className="group border-accent bg-accent text-accent-on inline-flex items-center justify-center gap-2 rounded-xl border px-6 py-3 text-sm font-semibold shadow-sm transition hover:shadow-md aria-disabled:cursor-not-allowed aria-disabled:opacity-60 aria-disabled:hover:shadow-sm"
+        >
+          <span>{label}</span>
+          {!live && (
+            <span className="text-accent-on rounded-md bg-black/25 px-1.5 py-0.5 text-[11px] font-medium tracking-wide uppercase">
+              {t.soon}
+            </span>
+          )}
+        </a>
+      </div>
+    </div>
+  );
+}
+
+const meta = {
+  title: 'Marketing/DownloadButtons',
+  component: DownloadButtonsMock,
+  argTypes: {
+    lang: { control: { type: 'inline-radio' }, options: ['en', 'uk'] satisfies Locale[] },
+    browser: {
+      control: { type: 'inline-radio' },
+      options: ['unknown', 'chrome', 'edge', 'firefox'] satisfies Browser[],
+    },
+    live: { control: 'boolean' },
+  },
+} satisfies Meta<typeof DownloadButtonsMock>;
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const SoonGeneric: Story = {
+  name: 'Soon · unknown browser (SSR fallback)',
+  args: { lang: 'en', browser: 'unknown', live: false },
+};
+export const SoonChrome: Story = {
+  name: 'Soon · Chrome',
+  args: { lang: 'en', browser: 'chrome', live: false },
+};
+export const LiveChrome: Story = {
+  name: 'Live · Chrome',
+  args: { lang: 'en', browser: 'chrome', live: true },
+};
+export const LiveFirefox: Story = {
+  name: 'Live · Firefox',
+  args: { lang: 'en', browser: 'firefox', live: true },
+};
+export const SoonUkrainian: Story = {
+  name: 'Soon · Ukrainian',
+  args: { lang: 'uk', browser: 'unknown', live: false },
+};

--- a/apps/marketing/src/components/Examples.stories.tsx
+++ b/apps/marketing/src/components/Examples.stories.tsx
@@ -1,0 +1,67 @@
+import type { JSX } from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+
+import { strings, type Locale } from '../i18n';
+
+/** React mock of `Examples.astro` — the central section the user called out. */
+function ExamplesMock({ lang = 'en' as Locale }): JSX.Element {
+  const t = strings[lang].examples;
+  return (
+    <section id="examples" className="border-border bg-bg border-t px-6 py-20">
+      <div className="mx-auto max-w-5xl">
+        <h2 className="font-display text-ink-strong text-3xl font-extrabold tracking-tight sm:text-4xl">
+          {t.sectionTitle}
+        </h2>
+        <p className="text-ink-soft mt-3 max-w-2xl">{t.sectionLead}</p>
+
+        <div className="mt-10 space-y-6">
+          {t.entries.map((example) => (
+            <article
+              key={example.site}
+              className="border-border bg-surface rounded-2xl border p-6 shadow-sm sm:p-8"
+            >
+              <h3 className="font-display text-ink-strong text-xl font-bold">{example.site}</h3>
+              <p className="text-ink-soft mt-2 text-sm italic">{example.scenario}</p>
+
+              <div className="mt-5 grid gap-4 sm:grid-cols-2">
+                <div className="border-border bg-bg rounded-xl border p-4">
+                  <div className="text-ink-faint font-mono text-xs tracking-[0.1em] uppercase">
+                    {t.without}
+                  </div>
+                  <p className="text-ink mt-2 text-sm leading-relaxed">{example.without}</p>
+                </div>
+                {/*
+                 * Eyebrow + body both ride on text-accent-deep so the pair
+                 * adapts in dark mode — see Examples.astro for the original
+                 * contrast note.
+                 */}
+                <div className="border-accent/30 bg-accent-surface rounded-xl border p-4">
+                  <div className="text-accent-deep font-mono text-xs tracking-[0.1em] uppercase">
+                    {t.withMovar}
+                  </div>
+                  <p className="text-accent-deep mt-2 text-sm leading-relaxed">
+                    {example.withMovar}
+                  </p>
+                </div>
+              </div>
+            </article>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+const meta = {
+  title: 'Marketing/Examples',
+  component: ExamplesMock,
+  argTypes: {
+    lang: { control: { type: 'inline-radio' }, options: ['en', 'uk'] satisfies Locale[] },
+  },
+} satisfies Meta<typeof ExamplesMock>;
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const English: Story = { args: { lang: 'en' } };
+export const Ukrainian: Story = { args: { lang: 'uk' } };

--- a/apps/marketing/src/components/Footer.stories.tsx
+++ b/apps/marketing/src/components/Footer.stories.tsx
@@ -1,0 +1,52 @@
+import type { JSX } from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+
+import { FEEDBACK_URL } from '@movar/shared';
+
+import { strings, type Locale, localeHomeHref, localePrivacyHref } from '../i18n';
+
+/** React mock of `Footer.astro`. */
+function FooterMock({ lang = 'en' as Locale, year = new Date().getFullYear() }): JSX.Element {
+  const t = strings[lang].footer;
+  const privacy = localePrivacyHref(lang);
+  const home = localeHomeHref(lang);
+  return (
+    <footer className="border-border bg-surface text-ink-soft mt-auto border-t px-6 py-8 text-sm">
+      <div className="mx-auto flex max-w-5xl flex-col items-start justify-between gap-4 sm:flex-row sm:items-center">
+        <div className="flex items-center gap-2">
+          <img src="/icon.svg" alt="" width={20} height={20} className="rounded" />
+          <span>
+            <span className="font-display text-ink-strong font-bold">movar.fyi</span> &middot;
+            &copy; {year} {t.credits}
+          </span>
+        </div>
+        <nav className="flex items-center gap-5">
+          <a href={privacy} className="hover:text-ink-strong transition">
+            {t.privacy}
+          </a>
+          <a href={`${home}#download`} className="hover:text-ink-strong transition">
+            {t.download}
+          </a>
+          <a href={FEEDBACK_URL} className="hover:text-ink-strong transition">
+            {t.feedback}
+          </a>
+        </nav>
+      </div>
+    </footer>
+  );
+}
+
+const meta = {
+  title: 'Marketing/Footer',
+  component: FooterMock,
+  argTypes: {
+    lang: { control: { type: 'inline-radio' }, options: ['en', 'uk'] satisfies Locale[] },
+    year: { control: 'number' },
+  },
+} satisfies Meta<typeof FooterMock>;
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const English: Story = { args: { lang: 'en' } };
+export const Ukrainian: Story = { args: { lang: 'uk' } };

--- a/apps/marketing/src/components/Header.stories.tsx
+++ b/apps/marketing/src/components/Header.stories.tsx
@@ -1,0 +1,63 @@
+import type { JSX } from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+
+import { strings, type Locale, localeHomeHref, localePrivacyHref } from '../i18n';
+
+/** React mock of `Header.astro` — sticky nav with the brand mark + section links. */
+function HeaderMock({ lang = 'en' as Locale }): JSX.Element {
+  const t = strings[lang];
+  const home = localeHomeHref(lang);
+  const privacy = localePrivacyHref(lang);
+  return (
+    <header className="border-border/60 bg-bg/85 supports-[backdrop-filter]:bg-bg/70 sticky top-0 z-50 border-b backdrop-blur">
+      <div className="mx-auto flex max-w-5xl items-center justify-between px-6 py-4">
+        <a href={home} className="font-display text-ink-strong flex items-center gap-2.5 font-bold">
+          <img src="/icon.svg" alt="" width={28} height={28} className="rounded-md" />
+          <span className="text-lg tracking-tight">
+            movar<span className="text-accent">.fyi</span>
+          </span>
+        </a>
+        <nav className="text-ink-soft flex items-center gap-x-5 text-sm">
+          <a
+            href={`${home}#how-it-works`}
+            className="hover:text-ink-strong hidden transition sm:inline"
+          >
+            {t.nav.howItWorks}
+          </a>
+          <a
+            href={`${home}#examples`}
+            className="hover:text-ink-strong hidden transition sm:inline"
+          >
+            {t.nav.examples}
+          </a>
+          <a
+            href={`${home}#limitations`}
+            className="hover:text-ink-strong hidden transition sm:inline"
+          >
+            {t.nav.limitations}
+          </a>
+          <a href={`${home}#download`} className="hover:text-ink-strong transition">
+            {t.nav.download}
+          </a>
+          <a href={privacy} className="hover:text-ink-strong transition">
+            {t.nav.privacy}
+          </a>
+        </nav>
+      </div>
+    </header>
+  );
+}
+
+const meta = {
+  title: 'Marketing/Header',
+  component: HeaderMock,
+  argTypes: {
+    lang: { control: { type: 'inline-radio' }, options: ['en', 'uk'] satisfies Locale[] },
+  },
+} satisfies Meta<typeof HeaderMock>;
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const English: Story = { args: { lang: 'en' } };
+export const Ukrainian: Story = { args: { lang: 'uk' } };

--- a/apps/marketing/src/components/Hero.stories.tsx
+++ b/apps/marketing/src/components/Hero.stories.tsx
@@ -1,0 +1,60 @@
+import type { JSX } from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+
+import { strings, type Locale } from '../i18n';
+
+/**
+ * React mock of `Hero.astro`. Keep markup + className strings in lockstep
+ * when either side changes. The inlined download button mirrors the
+ * disabled "Soon" SSR fallback from `DownloadButtons.astro`; full
+ * browser-detection behaviour has its own story.
+ */
+function HeroMock({ lang = 'en' as Locale }): JSX.Element {
+  const t = strings[lang].hero;
+  const dl = strings[lang].download;
+  return (
+    <section className="relative px-6 pt-20 pb-16 sm:pt-28 sm:pb-24">
+      <div className="mx-auto max-w-3xl text-center">
+        <div className="border-border bg-surface text-ink-soft mb-6 inline-flex items-center gap-2 rounded-full border px-3 py-1 text-xs font-medium shadow-sm">
+          <span className="bg-accent size-1.5 rounded-full" />
+          {t.badge}
+        </div>
+
+        <h1 className="font-display text-ink-strong text-5xl font-extrabold tracking-tight sm:text-6xl">
+          {t.headlineLine1}
+          <span className="text-accent block">{t.headlineLine2}</span>
+        </h1>
+
+        <p className="text-ink-soft mx-auto mt-6 max-w-2xl text-lg sm:text-xl">{t.subhead}</p>
+
+        <div className="mt-10">
+          <div id="download" className="flex justify-center">
+            <a
+              aria-disabled="true"
+              className="group border-accent bg-accent text-accent-on inline-flex items-center justify-center gap-2 rounded-xl border px-6 py-3 text-sm font-semibold shadow-sm transition hover:shadow-md aria-disabled:cursor-not-allowed aria-disabled:opacity-60 aria-disabled:hover:shadow-sm"
+            >
+              <span>{dl.addGeneric}</span>
+              <span className="text-accent-on rounded-md bg-black/25 px-1.5 py-0.5 text-[11px] font-medium tracking-wide uppercase">
+                {dl.soon}
+              </span>
+            </a>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+const meta = {
+  title: 'Marketing/Hero',
+  component: HeroMock,
+  argTypes: {
+    lang: { control: { type: 'inline-radio' }, options: ['en', 'uk'] satisfies Locale[] },
+  },
+} satisfies Meta<typeof HeroMock>;
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const English: Story = { args: { lang: 'en' } };
+export const Ukrainian: Story = { args: { lang: 'uk' } };

--- a/apps/marketing/src/components/HowItWorks.stories.tsx
+++ b/apps/marketing/src/components/HowItWorks.stories.tsx
@@ -1,0 +1,42 @@
+import type { JSX } from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+
+import { strings, type Locale } from '../i18n';
+
+/** React mock of `HowItWorks.astro`. */
+function HowItWorksMock({ lang = 'en' as Locale }): JSX.Element {
+  const t = strings[lang].howItWorks;
+  return (
+    <section id="how-it-works" className="border-border bg-surface border-t px-6 py-20">
+      <div className="mx-auto max-w-5xl">
+        <h2 className="font-display text-ink-strong text-3xl font-extrabold tracking-tight sm:text-4xl">
+          {t.sectionTitle}
+        </h2>
+        <p className="text-ink-soft mt-3 max-w-2xl">{t.sectionLead}</p>
+
+        <div className="mt-10 grid gap-8 sm:grid-cols-2">
+          {t.steps.map((step) => (
+            <div key={step.title} className="flex flex-col gap-3">
+              <h3 className="font-display text-ink-strong text-xl font-bold">{step.title}</h3>
+              <p className="text-ink-soft text-sm leading-relaxed">{step.body}</p>
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+const meta = {
+  title: 'Marketing/HowItWorks',
+  component: HowItWorksMock,
+  argTypes: {
+    lang: { control: { type: 'inline-radio' }, options: ['en', 'uk'] satisfies Locale[] },
+  },
+} satisfies Meta<typeof HowItWorksMock>;
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const English: Story = { args: { lang: 'en' } };
+export const Ukrainian: Story = { args: { lang: 'uk' } };

--- a/apps/marketing/src/components/Limitations.stories.tsx
+++ b/apps/marketing/src/components/Limitations.stories.tsx
@@ -1,0 +1,115 @@
+import type { JSX } from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+
+import { strings, type Locale } from '../i18n';
+
+type LimitationsSlice = (typeof strings)[Locale]['limitations'];
+type Row = LimitationsSlice['rows'][number];
+
+/** Filled check icon — paired with the "does" column rows. */
+function CheckIcon(): JSX.Element {
+  return (
+    <svg
+      className="text-accent-deep mt-0.5 size-4 shrink-0"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <circle cx="12" cy="12" r="9" />
+      <path d="m8 12.5 3 3 5-6.5" />
+    </svg>
+  );
+}
+
+/** Stroked X icon — paired with the "doesn't" column rows. */
+function CrossIcon(): JSX.Element {
+  return (
+    <svg
+      className="text-ink-soft mt-0.5 size-4 shrink-0"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <circle cx="12" cy="12" r="9" />
+      <line x1="5.6" y1="5.6" x2="18.4" y2="18.4" />
+    </svg>
+  );
+}
+
+function DoesColumn({ heading, rows }: { heading: string; rows: readonly Row[] }): JSX.Element {
+  return (
+    <div className="border-accent/30 bg-accent-surface overflow-hidden rounded-2xl border shadow-sm">
+      <div className="border-accent/20 border-b px-6 py-4">
+        <h3 className="font-display text-accent-deep text-base font-bold">{heading}</h3>
+      </div>
+      <ul className="divide-accent/10 divide-y">
+        {rows.map((row) => (
+          <li key={row.does} className="flex items-start gap-3 px-6 py-4">
+            <CheckIcon />
+            <p className="text-accent-deep text-sm leading-relaxed">{row.does}</p>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+function DoesNotColumn({ heading, rows }: { heading: string; rows: readonly Row[] }): JSX.Element {
+  return (
+    <div className="border-border bg-surface overflow-hidden rounded-2xl border shadow-sm">
+      <div className="border-border border-b px-6 py-4">
+        <h3 className="font-display text-ink text-base font-bold">{heading}</h3>
+      </div>
+      <ul className="divide-border divide-y">
+        {rows.map((row) => (
+          <li key={row.doesNot} className="flex items-start gap-3 px-6 py-4">
+            <CrossIcon />
+            <p className="text-ink-soft text-sm leading-relaxed">{row.doesNot}</p>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+/** React mock of `Limitations.astro` — the two-column does / doesn't card. */
+function LimitationsMock({ lang = 'en' as Locale }): JSX.Element {
+  const t = strings[lang].limitations;
+  return (
+    <section id="limitations" className="border-border bg-bg border-t px-6 py-20">
+      <div className="mx-auto max-w-5xl">
+        <h2 className="font-display text-ink-strong text-3xl font-extrabold tracking-tight sm:text-4xl">
+          {t.sectionTitle}
+        </h2>
+        <p className="text-ink-soft mt-3 max-w-2xl">{t.sectionLead}</p>
+
+        <div className="mt-10 grid gap-6 sm:grid-cols-2">
+          <DoesColumn heading={t.doesHeading} rows={t.rows} />
+          <DoesNotColumn heading={t.doesNotHeading} rows={t.rows} />
+        </div>
+      </div>
+    </section>
+  );
+}
+
+const meta = {
+  title: 'Marketing/Limitations',
+  component: LimitationsMock,
+  argTypes: {
+    lang: { control: { type: 'inline-radio' }, options: ['en', 'uk'] satisfies Locale[] },
+  },
+} satisfies Meta<typeof LimitationsMock>;
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const English: Story = { args: { lang: 'en' } };
+export const Ukrainian: Story = { args: { lang: 'uk' } };

--- a/apps/marketing/src/components/Privacy.stories.tsx
+++ b/apps/marketing/src/components/Privacy.stories.tsx
@@ -1,0 +1,58 @@
+import type { JSX } from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+
+import { strings, type Locale, localePrivacyHref } from '../i18n';
+
+/** React mock of `Privacy.astro`. */
+function PrivacyMock({ lang = 'en' as Locale }): JSX.Element {
+  const t = strings[lang].privacy;
+  return (
+    <section id="privacy-callout" className="border-border bg-bg border-t px-6 py-20">
+      <div className="mx-auto max-w-3xl">
+        <div className="flex items-start gap-4">
+          <svg
+            className="text-accent mt-1 size-6 shrink-0"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            aria-hidden="true"
+          >
+            <path d="M12 2 4 6v6c0 5 3.5 8.5 8 10 4.5-1.5 8-5 8-10V6l-8-4Z" />
+          </svg>
+          <div>
+            <h2 className="font-display text-ink-strong text-3xl font-extrabold tracking-tight sm:text-4xl">
+              {t.sectionTitle}
+            </h2>
+            <p className="text-ink-soft mt-4 leading-relaxed">{t.sectionLead}</p>
+            <p className="mt-6">
+              <a
+                href={localePrivacyHref(lang)}
+                className="text-accent inline-flex items-center gap-1 text-sm font-semibold hover:underline"
+              >
+                {t.linkLabel}
+                <span aria-hidden="true">→</span>
+              </a>
+            </p>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+const meta = {
+  title: 'Marketing/Privacy',
+  component: PrivacyMock,
+  argTypes: {
+    lang: { control: { type: 'inline-radio' }, options: ['en', 'uk'] satisfies Locale[] },
+  },
+} satisfies Meta<typeof PrivacyMock>;
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const English: Story = { args: { lang: 'en' } };
+export const Ukrainian: Story = { args: { lang: 'uk' } };

--- a/apps/marketing/src/components/Problem.stories.tsx
+++ b/apps/marketing/src/components/Problem.stories.tsx
@@ -1,0 +1,24 @@
+import type { JSX } from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+
+import { strings, type Locale } from '../i18n';
+import { FactsSectionMock } from './_facts-section-mock';
+
+/** React mock of `Problem.astro`. Shell is shared with `Stakes` via `FactsSectionMock`. */
+function ProblemMock({ lang = 'en' as Locale }): JSX.Element {
+  return <FactsSectionMock sectionId="why" t={strings[lang].problem} />;
+}
+
+const meta = {
+  title: 'Marketing/Problem',
+  component: ProblemMock,
+  argTypes: {
+    lang: { control: { type: 'inline-radio' }, options: ['en', 'uk'] satisfies Locale[] },
+  },
+} satisfies Meta<typeof ProblemMock>;
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const English: Story = { args: { lang: 'en' } };
+export const Ukrainian: Story = { args: { lang: 'uk' } };

--- a/apps/marketing/src/components/Stakes.stories.tsx
+++ b/apps/marketing/src/components/Stakes.stories.tsx
@@ -1,0 +1,24 @@
+import type { JSX } from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+
+import { strings, type Locale } from '../i18n';
+import { FactsSectionMock } from './_facts-section-mock';
+
+/** React mock of `Stakes.astro`. Shell is shared with `Problem` via `FactsSectionMock`. */
+function StakesMock({ lang = 'en' as Locale }): JSX.Element {
+  return <FactsSectionMock sectionId="why-it-matters" t={strings[lang].stakes} />;
+}
+
+const meta = {
+  title: 'Marketing/Stakes',
+  component: StakesMock,
+  argTypes: {
+    lang: { control: { type: 'inline-radio' }, options: ['en', 'uk'] satisfies Locale[] },
+  },
+} satisfies Meta<typeof StakesMock>;
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const English: Story = { args: { lang: 'en' } };
+export const Ukrainian: Story = { args: { lang: 'uk' } };

--- a/apps/marketing/src/components/_facts-section-mock.tsx
+++ b/apps/marketing/src/components/_facts-section-mock.tsx
@@ -1,0 +1,51 @@
+import type { JSX } from 'react';
+
+/**
+ * Shared mock shell for the Problem + Stakes story files. The production
+ * `Problem.astro` and `Stakes.astro` components are themselves
+ * near-identical — same Tailwind shell, different i18n slice and
+ * section id — and the React story mocks mirrored that duplication
+ * before being extracted here. Underscored filename + non-`.stories.tsx`
+ * suffix keeps Storybook from picking it up as a story.
+ *
+ * If/when production extracts a shared `FactsSection.astro`, fold this
+ * mock into its sibling `.stories.tsx` and delete the helper.
+ */
+export interface FactsSlice {
+  sectionTitle: string;
+  sectionLead: string;
+  facts: readonly { heading: string; body: string }[];
+  closeLine: string;
+}
+
+export function FactsSectionMock({
+  sectionId,
+  t,
+}: {
+  sectionId: string;
+  t: FactsSlice;
+}): JSX.Element {
+  return (
+    <section id={sectionId} className="border-border bg-bg border-t px-6 py-20">
+      <div className="mx-auto max-w-3xl">
+        <p className="font-display text-accent text-xs font-bold tracking-wider uppercase">
+          {t.sectionTitle}
+        </p>
+        <h2 className="font-display text-ink-strong mt-3 text-3xl font-extrabold tracking-tight sm:text-4xl">
+          {t.sectionLead}
+        </h2>
+
+        <ul className="mt-10 space-y-6">
+          {t.facts.map((fact) => (
+            <li key={fact.heading}>
+              <p className="font-display text-ink-strong text-lg font-bold">{fact.heading}</p>
+              <p className="text-ink-soft mt-1 leading-relaxed">{fact.body}</p>
+            </li>
+          ))}
+        </ul>
+
+        <p className="text-ink-strong mt-10 text-lg font-medium">{t.closeLine}</p>
+      </div>
+    </section>
+  );
+}

--- a/apps/marketing/src/i18n.ts
+++ b/apps/marketing/src/i18n.ts
@@ -323,7 +323,7 @@ const en: Strings = {
     sectionTitle: 'Have feedback?',
     sectionLead:
       'Have a question, an idea, or want to hear from us when Movar launches? Drop a note.',
-    emailLabel: 'Email feedback@movar.fyi',
+    emailLabel: 'Email support@movar.fyi',
   },
   footer: {
     credits: 'Movar community · MIT license',
@@ -497,7 +497,7 @@ const uk: Strings = {
   close: {
     sectionTitle: 'Маєте відгук?',
     sectionLead: 'Маєте запитання, ідею чи хочете дізнатися про запуск? Напишіть.',
-    emailLabel: 'Написати на feedback@movar.fyi',
+    emailLabel: 'Написати на support@movar.fyi',
   },
   footer: {
     credits: 'Спільнота Movar · ліцензія MIT',

--- a/apps/marketing/src/pages/privacy.astro
+++ b/apps/marketing/src/pages/privacy.astro
@@ -3,7 +3,8 @@ import BaseLayout from '../layouts/BaseLayout.astro';
 import Header from '../components/Header.astro';
 import Footer from '../components/Footer.astro';
 
-const lastUpdated = '27 May 2026';
+const effectiveDate = '28 May 2026';
+const lastUpdated = '28 May 2026';
 ---
 
 <BaseLayout
@@ -14,138 +15,192 @@ const lastUpdated = '27 May 2026';
   <Header lang="en" />
   <main class="flex-1 px-6 py-16">
     <article class="mx-auto max-w-3xl">
-      <p class="text-xs uppercase tracking-wide text-ink-faint">Last updated · {lastUpdated}</p>
+      <p class="text-xs uppercase tracking-wide text-ink-faint">
+        Effective · {effectiveDate} · Last updated · {lastUpdated}
+      </p>
       <h1 class="mt-2 font-display text-4xl font-extrabold tracking-tight text-ink-strong sm:text-5xl">
         Privacy policy
       </h1>
 
       <p class="mt-6 text-lg text-ink-soft">
-        Short version: Movar runs entirely on your device. Nothing about your browsing, your queries,
-        or your preferences ever leaves the browser you installed it in.
+        Short version: Movar runs entirely on your device. Nothing about your browsing or your
+        queries ever leaves the browser you installed it in. Your preferences travel through your
+        browser's built-in sync — the boundary is explained below.
       </p>
 
-      <section class="mt-12 space-y-4">
+      <section id="what-movar-stores" class="mt-12 space-y-4">
         <h2 class="font-display text-2xl font-bold text-ink-strong">What Movar stores</h2>
         <p>Movar remembers a few things in your browser:</p>
         <ul class="list-disc space-y-1 pl-6 text-ink-soft">
-          <li>your preferred language (e.g. Ukrainian, English),</li>
-          <li>any sites you've asked Movar not to touch,</li>
-          <li>whether Movar is currently paused,</li>
+          <li>your preferred languages, in order (e.g. Ukrainian, then English);</li>
+          <li>the languages Movar hides on sites that offer a language switcher (Russian is always on this list and can't be removed);</li>
+          <li>any sites you've asked Movar not to touch;</li>
+          <li>whether Movar may modify a page's DOM (off by default);</li>
+          <li>which language Movar's own popup and options page use;</li>
+          <li>whether Movar is currently paused.</li>
         </ul>
         <p class="text-ink-soft">
-          Your preferences sync across your devices via your browser's built-in sync (Chrome Sync,
-          Firefox Sync). The pause state and the corrections log live only on this device. None of
-          it is ever sent to a server of ours — because there is no server.
+          Those preferences sync across your devices via your browser's built-in sync —
+          Chrome Sync stores them in encrypted form on Google's servers, Firefox Sync on
+          Mozilla's. Movar runs no servers of its own; the pause state and the corrections log
+          stay only on this device.
         </p>
       </section>
 
-      <section class="mt-12 space-y-4">
+      <section id="corrections-log" class="mt-12 space-y-4">
         <h2 class="font-display text-2xl font-bold text-ink-strong">Corrections log</h2>
         <p class="text-ink-soft">
           Movar also keeps a local rolling log of the last 1,000 corrections — each entry holds a
           timestamp, the site's domain, which mechanism applied, and the from/to language. The popup
           uses this to show "corrections today" and which languages it has hidden on the current tab.
+          The log is first-in-first-out: when a 1,001st entry arrives, the oldest one is dropped.
+          Uninstalling the extension deletes the log entirely.
         </p>
       </section>
 
-      <section class="mt-12 space-y-4">
+      <section id="what-movar-does-not-store" class="mt-12 space-y-4">
         <h2 class="font-display text-2xl font-bold text-ink-strong">What Movar does <em>not</em> store</h2>
         <ul class="list-disc space-y-1 pl-6 text-ink-soft">
-          <li>your search queries,</li>
+          <li>your search queries;</li>
           <li>
             your browsing history (the corrections log records <em>which domains</em> triggered a
-            correction, never URLs, paths, or what was on the page),
+            correction, never URLs, paths, or what was on the page);
           </li>
-          <li>page contents,</li>
-          <li>any identifier that could distinguish you from another user,</li>
+          <li>page contents;</li>
+          <li>any identifier that could distinguish you from another user;</li>
           <li>any analytics or telemetry transmitted off-device.</li>
         </ul>
       </section>
 
-      <section class="mt-12 space-y-4">
+      <section id="permissions" class="mt-12 space-y-4">
         <h2 class="font-display text-2xl font-bold text-ink-strong">Permissions and why Movar needs them</h2>
-        <dl class="space-y-5 text-ink-soft">
-          <div>
-            <dt class="font-semibold text-ink-strong">
-              To remember your settings
-              <span class="ml-2 font-mono text-xs text-ink-faint">storage</span>
-            </dt>
-            <dd>Save the preferences listed above across browser restarts.</dd>
-          </div>
-          <div>
-            <dt class="font-semibold text-ink-strong">
-              To add a language hint to search requests
-              <span class="ml-2 font-mono text-xs text-ink-faint">declarativeNetRequest</span>
-            </dt>
-            <dd>
-              Add a language parameter to outgoing search-engine requests (Google, Bing, DuckDuckGo,
-              YouTube) so results render in your chosen language.
-            </dd>
-          </div>
-          <div>
-            <dt class="font-semibold text-ink-strong">
-              To know when a pause expires
-              <span class="ml-2 font-mono text-xs text-ink-faint">alarms</span>
-            </dt>
-            <dd>
-              Wake up when a timed pause expires (e.g. "pause for 30 minutes") so Movar can resume
-              on its own.
-            </dd>
-          </div>
-          <div>
-            <dt class="font-semibold text-ink-strong">
-              To recognise the site you're on
-              <span class="ml-2 font-mono text-xs text-ink-faint">tabs</span>
-            </dt>
-            <dd>
-              Read the active tab's URL when you open the popup or options page, so Movar can show
-              whether the current site is exempt and let you toggle it.
-            </dd>
-          </div>
-          <div>
-            <dt class="font-semibold text-ink-strong">
-              To work on the sites you visit
-              <span class="ml-2 font-mono text-xs text-ink-faint">access to all websites</span>
-            </dt>
-            <dd>
-              Movar reads the page you're on just enough to detect its language. Page contents are
-              never transmitted anywhere.
-            </dd>
-          </div>
-        </dl>
+        <ul class="divide-y divide-border overflow-hidden rounded-2xl border border-border bg-surface shadow-sm">
+          <li class="flex items-start gap-4 px-6 py-4">
+            <div class="flex size-10 shrink-0 items-center justify-center rounded-xl bg-accent-soft text-accent-deep">
+              <svg class="size-5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                <ellipse cx="12" cy="5" rx="9" ry="3" />
+                <path d="M3 5V19A9 3 0 0 0 21 19V5" />
+                <path d="M3 12A9 3 0 0 0 21 12" />
+              </svg>
+            </div>
+            <div class="min-w-0 flex-1 space-y-1.5">
+              <h3 class="font-mono text-base font-semibold text-ink-strong">storage</h3>
+              <p class="font-medium text-ink-strong">To remember your settings</p>
+              <p class="text-sm leading-relaxed text-ink-soft">Save the preferences listed above across browser restarts.</p>
+            </div>
+          </li>
+
+          <li class="flex items-start gap-4 px-6 py-4">
+            <div class="flex size-10 shrink-0 items-center justify-center rounded-xl bg-accent-soft text-accent-deep">
+              <svg class="size-5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                <path d="m5 8 6 6" />
+                <path d="m4 14 6-6 2-3" />
+                <path d="M2 5h12" />
+                <path d="M7 2h1" />
+                <path d="m22 22-5-10-5 10" />
+                <path d="M14 18h6" />
+              </svg>
+            </div>
+            <div class="min-w-0 flex-1 space-y-1.5">
+              <h3 class="font-mono text-base font-semibold text-ink-strong">declarativeNetRequest</h3>
+              <p class="font-medium text-ink-strong">To tell sites which languages you prefer</p>
+              <p class="text-sm leading-relaxed text-ink-soft">
+                Replace the <code class="font-mono text-xs">Accept-Language</code> header your browser
+                sends with every top-level and sub-frame request, so sites render in your preferred
+                languages. For the search engines you use (Google, Bing, DuckDuckGo, YouTube), Movar
+                also appends a matching language parameter to the search URL.
+              </p>
+            </div>
+          </li>
+
+          <li class="flex items-start gap-4 px-6 py-4">
+            <div class="flex size-10 shrink-0 items-center justify-center rounded-xl bg-accent-soft text-accent-deep">
+              <svg class="size-5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                <circle cx="12" cy="12" r="10" />
+                <polyline points="12 6 12 12 16 14" />
+              </svg>
+            </div>
+            <div class="min-w-0 flex-1 space-y-1.5">
+              <h3 class="font-mono text-base font-semibold text-ink-strong">alarms</h3>
+              <p class="font-medium text-ink-strong">To know when a pause expires</p>
+              <p class="text-sm leading-relaxed text-ink-soft">
+                Wake up when a timed pause expires (e.g. "pause for 30 minutes") so Movar can resume
+                on its own.
+              </p>
+            </div>
+          </li>
+
+          <li class="flex items-start gap-4 px-6 py-4">
+            <div class="flex size-10 shrink-0 items-center justify-center rounded-xl bg-accent-soft text-accent-deep">
+              <svg class="size-5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                <rect x="2" y="4" width="20" height="16" rx="2" />
+                <path d="M2 8h20" />
+                <path d="M6 4v4" />
+                <path d="M10 4v4" />
+              </svg>
+            </div>
+            <div class="min-w-0 flex-1 space-y-1.5">
+              <h3 class="font-mono text-base font-semibold text-ink-strong">tabs</h3>
+              <p class="font-medium text-ink-strong">To recognise the site you're on</p>
+              <p class="text-sm leading-relaxed text-ink-soft">
+                Read the active tab's URL when you open the popup or options page, so Movar can show
+                whether the current site is exempt and let you toggle it.
+              </p>
+            </div>
+          </li>
+
+          <li class="flex items-start gap-4 px-6 py-4">
+            <div class="flex size-10 shrink-0 items-center justify-center rounded-xl bg-accent-soft text-accent-deep">
+              <svg class="size-5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                <circle cx="12" cy="12" r="10" />
+                <path d="M12 2a14.5 14.5 0 0 0 0 20 14.5 14.5 0 0 0 0-20" />
+                <path d="M2 12h20" />
+              </svg>
+            </div>
+            <div class="min-w-0 flex-1 space-y-1.5">
+              <h3 class="text-base font-semibold text-ink-strong">Access to all websites</h3>
+              <p class="font-medium text-ink-strong">To work on the sites you visit</p>
+              <p class="text-sm leading-relaxed text-ink-soft">
+                Movar reads the page you're on just enough to detect its language. Page contents are
+                never transmitted anywhere.
+              </p>
+            </div>
+          </li>
+        </ul>
       </section>
 
-      <section class="mt-12 space-y-4">
+      <section id="third-parties" class="mt-12 space-y-4">
         <h2 class="font-display text-2xl font-bold text-ink-strong">Third parties</h2>
         <p class="text-ink-soft">
           Movar does not embed any third-party scripts, analytics, ad networks, or remote
           configuration. The extension talks only to the websites you choose to visit, and only to
-          rewrite outgoing URLs as described above.
+          rewrite outgoing requests as described above. The marketing site at movar.fyi is static —
+          it serves these pages and nothing else.
         </p>
       </section>
 
-      <section class="mt-12 space-y-4">
+      <section id="children" class="mt-12 space-y-4">
         <h2 class="font-display text-2xl font-bold text-ink-strong">Children</h2>
         <p class="text-ink-soft">
-          Movar collects no data, so there is nothing to disclose specifically about children's data.
+          Movar is not directed at children under 13. Because the extension collects no personal
+          data and runs entirely on the user's device, it does not knowingly collect any data from
+          children either.
         </p>
       </section>
 
-      <section class="mt-12 space-y-4">
+      <section id="changes" class="mt-12 space-y-4">
         <h2 class="font-display text-2xl font-bold text-ink-strong">Changes to this policy</h2>
         <p class="text-ink-soft">
-          If Movar's behaviour ever changes in a way that affects what data the extension touches,
-          this page will be updated and the "Last updated" date at the top will be bumped.
+          If Movar's behaviour ever changes in a way that affects the data the extension reads or
+          stores, this page will be updated and the "Last updated" date at the top will be bumped.
         </p>
       </section>
 
-      <section class="mt-12 space-y-4">
+      <section id="contact" class="mt-12 space-y-4">
         <h2 class="font-display text-2xl font-bold text-ink-strong">Contact</h2>
         <p class="text-ink-soft">
-          Email <a href="mailto:feedback@movar.fyi" class="text-accent hover:underline">feedback@movar.fyi</a>
-          if something isn't working, or if you have a question or an idea. Movar is open source under
-          the MIT license — the source code will land on GitHub (link will appear in the footer once
-          the repository is public).
+          Email <a href="mailto:support@movar.fyi" class="text-accent hover:underline">support@movar.fyi</a>
+          with privacy questions, bug reports, or ideas. Movar is open source under the MIT license.
         </p>
       </section>
     </article>

--- a/apps/marketing/src/pages/uk/privacy.astro
+++ b/apps/marketing/src/pages/uk/privacy.astro
@@ -3,7 +3,8 @@ import BaseLayout from '../../layouts/BaseLayout.astro';
 import Header from '../../components/Header.astro';
 import Footer from '../../components/Footer.astro';
 
-const lastUpdated = '27 травня 2026';
+const effectiveDate = '28 травня 2026';
+const lastUpdated = '28 травня 2026';
 ---
 
 <BaseLayout
@@ -14,139 +15,194 @@ const lastUpdated = '27 травня 2026';
   <Header lang="uk" />
   <main class="flex-1 px-6 py-16">
     <article class="mx-auto max-w-3xl">
-      <p class="text-xs uppercase tracking-wide text-ink-faint">Оновлено · {lastUpdated}</p>
+      <p class="text-xs uppercase tracking-wide text-ink-faint">
+        Чинна з · {effectiveDate} · Оновлено · {lastUpdated}
+      </p>
       <h1 class="mt-2 font-display text-4xl font-extrabold tracking-tight text-ink-strong sm:text-5xl">
         Політика приватності
       </h1>
 
       <p class="mt-6 text-lg text-ink-soft">
-        Коротко: Movar працює лише у вашому браузері. Жодні дані про ваші перегляди, запити чи
-        налаштування звідти не виходять.
+        Коротко: Movar працює лише у вашому браузері. Жодні дані про ваші перегляди чи запити
+        звідти не виходять. Налаштування йдуть через вбудовану синхронізацію браузера — межу
+        пояснюємо нижче.
       </p>
 
-      <section class="mt-12 space-y-4">
+      <section id="what-movar-stores" class="mt-12 space-y-4">
         <h2 class="font-display text-2xl font-bold text-ink-strong">Що Movar зберігає</h2>
         <p>Movar запамʼятовує у браузері кілька речей:</p>
         <ul class="list-disc space-y-1 pl-6 text-ink-soft">
-          <li>вашу бажану мову (наприклад, українську чи англійську),</li>
-          <li>сайти, на яких ви попросили Movar не втручатися,</li>
-          <li>чи Movar зараз на паузі,</li>
+          <li>ваші бажані мови за пріоритетом (наприклад, спочатку українську, потім англійську);</li>
+          <li>мови, які Movar приховує на сайтах із вбудованим перемикачем мови (російська завжди у цьому списку — її не можна прибрати);</li>
+          <li>сайти, на яких ви попросили Movar не втручатися;</li>
+          <li>чи дозволено Movar змінювати DOM сторінки (за замовчуванням — ні);</li>
+          <li>якою мовою показувати спливне вікно та сторінку налаштувань Movar;</li>
+          <li>чи Movar зараз на паузі.</li>
         </ul>
         <p class="text-ink-soft">
-          Налаштування синхронізуються між вашими пристроями через вбудовану синхронізацію
-          браузера (Chrome Sync, Firefox Sync). Стан паузи та журнал виправлень залишаються лише
-          на цьому пристрої. Жодні з цих даних не передаються на наш сервер — бо в Movar немає
-          сервера.
+          Ці налаштування синхронізуються між вашими пристроями через вбудовану синхронізацію
+          браузера — Chrome Sync зберігає їх у зашифрованому вигляді на серверах Google, Firefox
+          Sync — на серверах Mozilla. У Movar немає власних серверів; стан паузи та журнал
+          виправлень залишаються лише на цьому пристрої.
         </p>
       </section>
 
-      <section class="mt-12 space-y-4">
+      <section id="corrections-log" class="mt-12 space-y-4">
         <h2 class="font-display text-2xl font-bold text-ink-strong">Журнал виправлень</h2>
         <p class="text-ink-soft">
-          Movar також веде локальний список останніх 1 000 виправлень — для кожного: коли, на
+          Movar також веде локальний список останніх 1&nbsp;000 виправлень — для кожного: коли, на
           якому сайті, як саме виправили, з якої мови на яку. Спливне вікно бере звідти лічильник
-          «виправлень сьогодні» і список мов, які приховало на цій вкладці.
+          «виправлень сьогодні» і список мов, які приховало на цій вкладці. Журнал працює за
+          принципом «перший прийшов — перший пішов»: коли надходить 1&nbsp;001-й запис, найдавніший
+          видаляється. Видалення розширення стирає журнал повністю.
         </p>
       </section>
 
-      <section class="mt-12 space-y-4">
+      <section id="what-movar-does-not-store" class="mt-12 space-y-4">
         <h2 class="font-display text-2xl font-bold text-ink-strong">Що Movar <em>не</em> зберігає</h2>
         <ul class="list-disc space-y-1 pl-6 text-ink-soft">
-          <li>ваші пошукові запити,</li>
+          <li>ваші пошукові запити;</li>
           <li>
             історію перегляду (журнал виправлень фіксує лише <em>які домени</em> викликали
-            виправлення — без URL, шляхів чи вмісту сторінок),
+            виправлення — без URL, шляхів чи вмісту сторінок);
           </li>
-          <li>вміст сторінок,</li>
-          <li>будь-які ідентифікатори, що могли б відрізнити вас від іншого користувача,</li>
+          <li>вміст сторінок;</li>
+          <li>будь-які ідентифікатори, що могли б відрізнити вас від іншого користувача;</li>
           <li>жодної аналітики чи телеметрії, що передається за межі пристрою.</li>
         </ul>
       </section>
 
-      <section class="mt-12 space-y-4">
+      <section id="permissions" class="mt-12 space-y-4">
         <h2 class="font-display text-2xl font-bold text-ink-strong">Дозволи та чому вони потрібні</h2>
-        <dl class="space-y-5 text-ink-soft">
-          <div>
-            <dt class="font-semibold text-ink-strong">
-              Щоб запамʼятати ваші налаштування
-              <span class="ml-2 font-mono text-xs text-ink-faint">storage</span>
-            </dt>
-            <dd>Зберігати перелічені вище налаштування між перезапусками браузера.</dd>
-          </div>
-          <div>
-            <dt class="font-semibold text-ink-strong">
-              Щоб додати мовну підказку до пошукових запитів
-              <span class="ml-2 font-mono text-xs text-ink-faint">declarativeNetRequest</span>
-            </dt>
-            <dd>
-              Додавати параметр мови до вихідних запитів до пошукових систем (Google, Bing,
-              DuckDuckGo, YouTube), щоб результати показувались вибраною мовою.
-            </dd>
-          </div>
-          <div>
-            <dt class="font-semibold text-ink-strong">
-              Щоб знати, коли закінчується пауза
-              <span class="ml-2 font-mono text-xs text-ink-faint">alarms</span>
-            </dt>
-            <dd>
-              Нагадати, коли закінчується пауза (наприклад, «призупинити на 30 хвилин»), — щоб
-              Movar увімкнувся знову сам.
-            </dd>
-          </div>
-          <div>
-            <dt class="font-semibold text-ink-strong">
-              Щоб розпізнати сайт, на якому ви зараз
-              <span class="ml-2 font-mono text-xs text-ink-faint">tabs</span>
-            </dt>
-            <dd>
-              Зчитувати URL активної вкладки, коли ви відкриваєте спливне вікно чи сторінку
-              налаштувань — щоб Movar показав, чи цей сайт у списку винятків, і дав вам додати
-              чи прибрати його одним кліком.
-            </dd>
-          </div>
-          <div>
-            <dt class="font-semibold text-ink-strong">
-              Щоб працювати на сайтах, які ви відвідуєте
-              <span class="ml-2 font-mono text-xs text-ink-faint">доступ до всіх сайтів</span>
-            </dt>
-            <dd>
-              Movar читає сторінку, яку ви відкрили, рівно настільки, щоб зрозуміти її мову.
-              Вміст сторінки нікуди не передається.
-            </dd>
-          </div>
-        </dl>
+        <ul class="divide-y divide-border overflow-hidden rounded-2xl border border-border bg-surface shadow-sm">
+          <li class="flex items-start gap-4 px-6 py-4">
+            <div class="flex size-10 shrink-0 items-center justify-center rounded-xl bg-accent-soft text-accent-deep">
+              <svg class="size-5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                <ellipse cx="12" cy="5" rx="9" ry="3" />
+                <path d="M3 5V19A9 3 0 0 0 21 19V5" />
+                <path d="M3 12A9 3 0 0 0 21 12" />
+              </svg>
+            </div>
+            <div class="min-w-0 flex-1 space-y-1.5">
+              <h3 class="font-mono text-base font-semibold text-ink-strong">storage</h3>
+              <p class="font-medium text-ink-strong">Щоб запамʼятати ваші налаштування</p>
+              <p class="text-sm leading-relaxed text-ink-soft">Зберігати перелічені вище налаштування між перезапусками браузера.</p>
+            </div>
+          </li>
+
+          <li class="flex items-start gap-4 px-6 py-4">
+            <div class="flex size-10 shrink-0 items-center justify-center rounded-xl bg-accent-soft text-accent-deep">
+              <svg class="size-5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                <path d="m5 8 6 6" />
+                <path d="m4 14 6-6 2-3" />
+                <path d="M2 5h12" />
+                <path d="M7 2h1" />
+                <path d="m22 22-5-10-5 10" />
+                <path d="M14 18h6" />
+              </svg>
+            </div>
+            <div class="min-w-0 flex-1 space-y-1.5">
+              <h3 class="font-mono text-base font-semibold text-ink-strong">declarativeNetRequest</h3>
+              <p class="font-medium text-ink-strong">Щоб повідомити сайтам, якими мовами ви хочете їх читати</p>
+              <p class="text-sm leading-relaxed text-ink-soft">
+                Замінювати заголовок <code class="font-mono text-xs">Accept-Language</code>, який ваш
+                браузер надсилає з кожним запитом сторінки чи вкладеного фрейму, на ваші бажані мови
+                — щоб сайти одразу віддавали сторінки цими мовами. Для пошукових систем (Google,
+                Bing, DuckDuckGo, YouTube) Movar також додає відповідний мовний параметр у пошуковий
+                URL.
+              </p>
+            </div>
+          </li>
+
+          <li class="flex items-start gap-4 px-6 py-4">
+            <div class="flex size-10 shrink-0 items-center justify-center rounded-xl bg-accent-soft text-accent-deep">
+              <svg class="size-5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                <circle cx="12" cy="12" r="10" />
+                <polyline points="12 6 12 12 16 14" />
+              </svg>
+            </div>
+            <div class="min-w-0 flex-1 space-y-1.5">
+              <h3 class="font-mono text-base font-semibold text-ink-strong">alarms</h3>
+              <p class="font-medium text-ink-strong">Щоб знати, коли закінчується пауза</p>
+              <p class="text-sm leading-relaxed text-ink-soft">
+                Дочекатися, коли спливе таймер паузи (наприклад, «призупинити на 30 хвилин»), щоб
+                Movar поновив роботу сам.
+              </p>
+            </div>
+          </li>
+
+          <li class="flex items-start gap-4 px-6 py-4">
+            <div class="flex size-10 shrink-0 items-center justify-center rounded-xl bg-accent-soft text-accent-deep">
+              <svg class="size-5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                <rect x="2" y="4" width="20" height="16" rx="2" />
+                <path d="M2 8h20" />
+                <path d="M6 4v4" />
+                <path d="M10 4v4" />
+              </svg>
+            </div>
+            <div class="min-w-0 flex-1 space-y-1.5">
+              <h3 class="font-mono text-base font-semibold text-ink-strong">tabs</h3>
+              <p class="font-medium text-ink-strong">Щоб розпізнати сайт, на якому ви зараз</p>
+              <p class="text-sm leading-relaxed text-ink-soft">
+                Зчитувати URL активної вкладки, коли ви відкриваєте спливне вікно чи сторінку
+                налаштувань, — щоб Movar показав, чи цей сайт у списку винятків, і дав вам додати
+                чи прибрати його.
+              </p>
+            </div>
+          </li>
+
+          <li class="flex items-start gap-4 px-6 py-4">
+            <div class="flex size-10 shrink-0 items-center justify-center rounded-xl bg-accent-soft text-accent-deep">
+              <svg class="size-5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                <circle cx="12" cy="12" r="10" />
+                <path d="M12 2a14.5 14.5 0 0 0 0 20 14.5 14.5 0 0 0 0-20" />
+                <path d="M2 12h20" />
+              </svg>
+            </div>
+            <div class="min-w-0 flex-1 space-y-1.5">
+              <h3 class="text-base font-semibold text-ink-strong">Доступ до всіх сайтів</h3>
+              <p class="font-medium text-ink-strong">Щоб працювати на сайтах, які ви відвідуєте</p>
+              <p class="text-sm leading-relaxed text-ink-soft">
+                Movar читає сторінку, яку ви відкрили, рівно настільки, щоб зрозуміти її мову.
+                Вміст сторінки нікуди не передається.
+              </p>
+            </div>
+          </li>
+        </ul>
       </section>
 
-      <section class="mt-12 space-y-4">
+      <section id="third-parties" class="mt-12 space-y-4">
         <h2 class="font-display text-2xl font-bold text-ink-strong">Треті сторони</h2>
         <p class="text-ink-soft">
           Movar не вбудовує жодних сторонніх скриптів, аналітики, рекламних мереж чи віддалених
           конфігурацій. Розширення спілкується лише з сайтами, які ви самі обираєте, і лише для
-          того, щоб переписати вихідні URL у спосіб, описаний вище.
+          того, щоб переписати вихідні запити у спосіб, описаний вище. Маркетинговий сайт
+          movar.fyi — статичний: він віддає ці сторінки і нічого більше.
         </p>
       </section>
 
-      <section class="mt-12 space-y-4">
+      <section id="children" class="mt-12 space-y-4">
         <h2 class="font-display text-2xl font-bold text-ink-strong">Діти</h2>
         <p class="text-ink-soft">
-          Movar не збирає жодних даних, тож немає чого окремо розкривати щодо даних дітей.
+          Movar не призначений для дітей до 13 років. Розширення не збирає жодних персональних
+          даних і працює лише на пристрої користувача, тож і даних про дітей воно не отримує.
         </p>
       </section>
 
-      <section class="mt-12 space-y-4">
+      <section id="changes" class="mt-12 space-y-4">
         <h2 class="font-display text-2xl font-bold text-ink-strong">Зміни в цій політиці</h2>
         <p class="text-ink-soft">
-          Якщо поведінка Movar колись зміниться у спосіб, що стосуватиметься даних, які торкає
-          розширення, цю сторінку буде оновлено, а дату «Оновлено» вгорі — змінено.
+          Якщо поведінка Movar колись зміниться так, що це вплине на дані, які розширення читає
+          чи зберігає, цю сторінку буде оновлено, а дату «Оновлено» вгорі — теж.
         </p>
       </section>
 
-      <section class="mt-12 space-y-4">
+      <section id="contact" class="mt-12 space-y-4">
         <h2 class="font-display text-2xl font-bold text-ink-strong">Звʼязок</h2>
         <p class="text-ink-soft">
-          Напишіть на <a href="mailto:feedback@movar.fyi" class="text-accent hover:underline">feedback@movar.fyi</a>,
-          якщо щось не працює, є питання чи ідея. Movar — відкритий код під ліцензією MIT;
-          репозиторій викладемо на GitHub (посилання зʼявиться у футері, щойно він буде відкритий).
+          Напишіть на <a href="mailto:support@movar.fyi" class="text-accent hover:underline">support@movar.fyi</a>
+          з питаннями про приватність, повідомленнями про помилки чи ідеями. Movar — відкритий код
+          під ліцензією MIT.
         </p>
       </section>
     </article>

--- a/package.json
+++ b/package.json
@@ -16,6 +16,8 @@
     "lint": "pnpm lint:root && nx run-many -t lint",
     "typecheck": "nx run-many -t typecheck",
     "test": "nx run-many -t test",
+    "test:e2e:live": "nx run e2e:test:live",
+    "test:e2e:live:headed": "nx run e2e:test:live:headed",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "publint": "pnpm --workspace-concurrency=1 --filter @movar/shared --filter @movar/rules --filter @movar/lang-detect exec publint",

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,7 +1,9 @@
 /** Movar shared types, defaults, and constants. */
 
-/** Where users can send feedback. Used by the popup, options page, and marketing site. */
-export const FEEDBACK_URL = 'mailto:feedback@movar.fyi?subject=Movar%20feedback';
+/**
+ * Where users can send feedback. Used by the popup, options page, and marketing site.
+ */
+export const FEEDBACK_URL = 'mailto:support@movar.fyi?subject=Movar%20feedback';
 
 /** ISO 639-1 language code, e.g. 'uk', 'en', 'ru'. */
 export type LanguageCode = string;

--- a/packages/ui/.storybook/main.ts
+++ b/packages/ui/.storybook/main.ts
@@ -1,0 +1,40 @@
+import type { StorybookConfig } from '@storybook/react-vite';
+
+import tailwindcss from '@tailwindcss/vite';
+
+/**
+ * Storybook config for @movar/ui — the single canvas where every primitive
+ * gets exercised in isolation. Two integration points worth flagging:
+ *
+ *   - **Vite + Tailwind v4.** Storybook bundles the preview with Vite, and
+ *     the design tokens (`bg-surface`, `text-ui-base`, …) only resolve when
+ *     `@tailwindcss/vite` runs over the preview's CSS. Registered via
+ *     `viteFinal` rather than a sibling `vite.config.ts` so Storybook stays
+ *     the single source of bundler config for the preview.
+ *   - **Stories live next to components.** Story files use the
+ *     `<name>.stories.tsx` sibling pattern so a primitive and its examples
+ *     evolve together. Matches the test-file convention used elsewhere in
+ *     the repo.
+ */
+const config: StorybookConfig = {
+  stories: ['../src/**/*.stories.@(ts|tsx|mdx)'],
+  addons: ['@storybook/addon-docs'],
+  framework: {
+    name: '@storybook/react-vite',
+    options: {},
+  },
+  typescript: {
+    // The package already runs `tsc --noEmit` via Nx; let Storybook trust the
+    // emit. Re-checking inside the dev server doubles the cold-start cost for
+    // a check the typecheck target already enforces.
+    check: false,
+  },
+  async viteFinal(viteConfig) {
+    return {
+      ...viteConfig,
+      plugins: [...(viteConfig.plugins ?? []), ...tailwindcss()],
+    };
+  },
+};
+
+export default config;

--- a/packages/ui/.storybook/preview.css
+++ b/packages/ui/.storybook/preview.css
@@ -1,0 +1,86 @@
+@import 'tailwindcss';
+
+@import '@fontsource/manrope/latin-400.css';
+@import '@fontsource/manrope/cyrillic-400.css';
+@import '@fontsource/manrope/latin-500.css';
+@import '@fontsource/manrope/cyrillic-500.css';
+@import '@fontsource/manrope/latin-600.css';
+@import '@fontsource/manrope/cyrillic-600.css';
+@import '@fontsource/manrope/latin-700.css';
+@import '@fontsource/manrope/cyrillic-700.css';
+@import '@fontsource/manrope/latin-800.css';
+@import '@fontsource/manrope/cyrillic-800.css';
+@import '@fontsource/ibm-plex-mono/latin-400.css';
+@import '@fontsource/ibm-plex-mono/cyrillic-400.css';
+@import '@fontsource/ibm-plex-mono/latin-500.css';
+@import '@fontsource/ibm-plex-mono/cyrillic-500.css';
+@import '@fontsource/ibm-plex-mono/latin-600.css';
+@import '@fontsource/ibm-plex-mono/cyrillic-600.css';
+
+@import '../src/tokens.css';
+
+/*
+ * Story files and the primitive sources both live under `../src/`. Tailwind v4
+ * picks up class names through the Vite module graph, but Storybook's preview
+ * builds via dynamic imports — be explicit so utilities used only by the
+ * components-under-glass also make it into the generated CSS.
+ */
+@source '../src/**/*.tsx';
+
+/*
+ * Mirrors `apps/extension/src/styles/globals.css` and
+ * `apps/marketing/src/styles/global.css` — same `@theme inline` wiring so the
+ * Storybook canvas resolves the semantic utilities (`bg-surface`,
+ * `text-ink-strong`, `text-ui-base`, …) identically to the apps that consume
+ * the primitives.
+ */
+@theme inline {
+  --color-bg: var(--bg);
+  --color-surface: var(--surface);
+  --color-surface-2: var(--surface-2);
+  --color-surface-3: var(--surface-3);
+  --color-border: var(--border);
+  --color-border-strong: var(--border-strong);
+  --color-ink-faint: var(--ink-faint);
+  --color-ink-soft: var(--ink-soft);
+  --color-ink: var(--ink);
+  --color-ink-strong: var(--ink-strong);
+  --color-accent: var(--accent);
+  --color-accent-deep: var(--accent-deep);
+  --color-accent-soft: var(--accent-soft);
+  --color-accent-surface: var(--accent-surface);
+  --color-accent-on: var(--accent-on);
+  --color-danger: var(--danger);
+  --color-danger-deep: var(--danger-deep);
+  --color-danger-soft: var(--danger-soft);
+  --color-danger-surface: var(--danger-surface);
+  --color-danger-on: var(--danger-on);
+
+  --shadow-sm: var(--shadow-sm);
+  --shadow-md: var(--shadow-md);
+  --shadow-lg: var(--shadow-lg);
+
+  --text-ui-micro: var(--text-ui-micro);
+  --text-ui-xs: var(--text-ui-xs);
+  --text-ui-sm: var(--text-ui-sm);
+  --text-ui-base: var(--text-ui-base);
+  --text-ui-md: var(--text-ui-md);
+}
+
+@theme {
+  --font-display: 'Manrope', ui-sans-serif, system-ui, sans-serif;
+  --font-sans: 'Manrope', ui-sans-serif, system-ui, sans-serif;
+  --font-mono: 'IBM Plex Mono', ui-monospace, SFMono-Regular, Menlo, monospace;
+}
+
+/*
+ * Storybook's default canvas paints white and the docs page applies its own
+ * background — neither lets the token-driven `--bg` show through. Override
+ * both so the preview faithfully reflects what consuming apps render.
+ */
+.sb-show-main,
+.docs-story {
+  background: var(--bg) !important;
+  color: var(--ink);
+  font-family: var(--font-sans);
+}

--- a/packages/ui/.storybook/preview.tsx
+++ b/packages/ui/.storybook/preview.tsx
@@ -1,0 +1,37 @@
+import type { Preview } from '@storybook/react';
+
+import './preview.css';
+
+/**
+ * Global preview config for @movar/ui Storybook.
+ *
+ * Dark mode rides the existing `@media (prefers-color-scheme: dark)` flip in
+ * `tokens.css` — no explicit toolbar toggle. Flip your OS theme to preview
+ * the dark surface treatment; this matches how the extension and marketing
+ * site decide their theme too, so what you see in Storybook is what ships.
+ *
+ * `layout: 'centered'` is the default — primitives are small and read better
+ * centered on the canvas than glued to the corner. Stories that compose a
+ * larger surface (forms, full-width buttons) opt out with `layout: 'padded'`.
+ */
+const preview: Preview = {
+  parameters: {
+    layout: 'centered',
+    controls: {
+      matchers: {
+        color: /(background|color)$/i,
+        date: /Date$/i,
+      },
+    },
+    options: {
+      storySort: {
+        order: [
+          'Primitives',
+          ['BrandMark', 'Button', 'IconButton', 'Pill', 'Select', 'Switch', 'Checkbox'],
+        ],
+      },
+    },
+  },
+};
+
+export default preview;

--- a/packages/ui/eslint.config.mjs
+++ b/packages/ui/eslint.config.mjs
@@ -2,4 +2,22 @@
 import { workspaceIgnores, base, quality, tests } from '@movar/eslint-config';
 
 /** @type {import("eslint").Linter.Config[]} */
-export default [workspaceIgnores, ...base, ...quality, ...tests];
+export default [
+  workspaceIgnores,
+  ...base,
+  ...quality,
+  ...tests,
+  // Storybook build artefacts — generated, never lint.
+  { ignores: ['storybook-static/**'] },
+  // Story files behave like tests: example-shaped code where repetition is the
+  // point and a few production-grade hygiene rules just add noise. Layer the
+  // same relaxations the `tests` preset already applies to *.test.tsx, plus a
+  // couple sonarjs/unicorn relaxations specific to the demo-code shape.
+  {
+    files: ['**/*.stories.{ts,tsx}'],
+    rules: {
+      'sonarjs/no-duplicate-string': 'off',
+      'sonarjs/no-identical-functions': 'off',
+    },
+  },
+];

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -12,15 +12,28 @@
   "scripts": {
     "typecheck": "tsc --noEmit",
     "lint": "eslint .",
-    "test": "vitest run --passWithNoTests"
+    "test": "vitest run --passWithNoTests",
+    "storybook": "storybook dev -p ${STORYBOOK_PORT:-6006} --no-open",
+    "build-storybook": "storybook build -o storybook-static"
   },
   "peerDependencies": {
     "react": "^19.0.0"
   },
   "devDependencies": {
+    "@fontsource/ibm-plex-mono": "^5.2.7",
+    "@fontsource/manrope": "^5.2.7",
     "@movar/eslint-config": "workspace:*",
+    "@storybook/addon-docs": "^10.4.1",
+    "@storybook/react": "^10.4.1",
+    "@storybook/react-vite": "^10.4.1",
+    "@tailwindcss/vite": "^4.3.0",
     "@types/react": "^19.2.15",
+    "@types/react-dom": "^19.2.3",
     "eslint": "^9.39.4",
-    "react": "^19.2.6"
+    "react": "^19.2.6",
+    "react-dom": "^19.2.6",
+    "storybook": "^10.4.1",
+    "tailwindcss": "^4.3.0",
+    "vite": "^7.3.3"
   }
 }

--- a/packages/ui/project.json
+++ b/packages/ui/project.json
@@ -18,6 +18,16 @@
       "executor": "nx:run-commands",
       "options": { "command": "vitest run --passWithNoTests", "cwd": "packages/ui" },
       "cache": true
+    },
+    "storybook": {
+      "executor": "nx:run-commands",
+      "options": { "command": "pnpm storybook", "cwd": "packages/ui" }
+    },
+    "build-storybook": {
+      "executor": "nx:run-commands",
+      "options": { "command": "pnpm build-storybook", "cwd": "packages/ui" },
+      "outputs": ["{projectRoot}/storybook-static"],
+      "cache": true
     }
   }
 }

--- a/packages/ui/src/brand-mark.stories.tsx
+++ b/packages/ui/src/brand-mark.stories.tsx
@@ -1,0 +1,47 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import { BrandMark } from './brand-mark';
+
+const meta = {
+  title: 'Primitives/BrandMark',
+  component: BrandMark,
+  tags: ['autodocs'],
+  argTypes: {
+    size: { control: { type: 'number', min: 12, max: 128, step: 1 } },
+    letterColor: { control: 'color' },
+  },
+} satisfies Meta<typeof BrandMark>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+/** Solid rectangle, cutout `r`, accent dot. The default for headers and og. */
+export const Solid: Story = {
+  args: { size: 48, title: 'Movar' },
+};
+
+/** Stroked rectangle, currentColor letter. Use inline with body copy. */
+export const Outline: Story = {
+  args: { size: 48, outline: true, title: 'Movar (outline)' },
+};
+
+/** Decorative (no title) — renders `aria-hidden`. */
+export const Decorative: Story = {
+  args: { size: 64 },
+};
+
+/** Custom letter color override — overrides the `--brand-letter` token. */
+export const CustomLetterColor: Story = {
+  args: { size: 64, letterColor: '#fde68a' },
+};
+
+/** Inline glyph inside a paragraph — picks up surrounding `currentColor`. */
+export const InlineInCopy: Story = {
+  render: (args) => (
+    <p className="text-ink text-ui-base max-w-md">
+      Keep the internet in your language — <BrandMark {...args} /> sets things straight.
+    </p>
+  ),
+  args: { size: 16, outline: true },
+};

--- a/packages/ui/src/button.stories.tsx
+++ b/packages/ui/src/button.stories.tsx
@@ -1,0 +1,49 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import { Button } from './button';
+
+const meta = {
+  title: 'Primitives/Button',
+  component: Button,
+  tags: ['autodocs'],
+  args: { children: 'Add domain' },
+} satisfies Meta<typeof Button>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+/** Solid `ink-strong` bg, `bg` text — the dominant action in a row. */
+export const Primary: Story = {};
+
+/** Bordered, `surface-2` bg — pairs with a primary or stands alone for low-commitment actions. */
+export const Secondary: Story = {
+  args: { variant: 'secondary', children: 'Pause for 1 hour' },
+};
+
+/** `sm` shaves padding and drops to `text-ui-sm` (12px) — popup-dense scale. */
+export const Small: Story = {
+  args: { size: 'sm', children: 'Show all hidden' },
+};
+
+/** Stretches to fill the container. Used by the popup's Resume button and the options page's row CTAs. */
+export const FullWidth: Story = {
+  args: { fullWidth: true, children: 'Resume Movar' },
+  parameters: { layout: 'padded' },
+  decorators: [(Story) => <div className="w-80">{Story()}</div>],
+};
+
+/** Disabled state — dimmed, hover suppressed. Both variants share the same affordance. */
+export const Disabled: Story = {
+  args: { disabled: true, children: 'Loading…' },
+};
+
+/** Side-by-side primary + secondary — the canonical "do this, or that" row. */
+export const Pair: Story = {
+  render: () => (
+    <div className="flex gap-2">
+      <Button>Add domain</Button>
+      <Button variant="secondary">Cancel</Button>
+    </div>
+  ),
+};

--- a/packages/ui/src/checkbox.stories.tsx
+++ b/packages/ui/src/checkbox.stories.tsx
@@ -1,0 +1,61 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { useState } from 'react';
+
+import { Checkbox } from './checkbox';
+
+const meta = {
+  title: 'Primitives/Checkbox',
+  component: Checkbox,
+  tags: ['autodocs'],
+  args: { label: 'Translate untranslated pages' },
+} satisfies Meta<typeof Checkbox>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+/** Default unchecked state. */
+export const Default: Story = {
+  args: { defaultChecked: false },
+};
+
+/** Pre-checked. */
+export const Checked: Story = {
+  args: { defaultChecked: true },
+};
+
+/** Indeterminate (tri-state). DOM property, not attribute — see component JSDoc. */
+export const Indeterminate: Story = {
+  args: { indeterminate: true },
+};
+
+/** Label + description — both are part of the accessible name/description. */
+export const WithDescription: Story = {
+  args: {
+    label: 'Show on hover only',
+    description: 'Keeps the page chrome quiet until you point at it.',
+  },
+};
+
+/** Invalid — sets `aria-invalid` and swaps every accent surface to the danger family. */
+export const Invalid: Story = {
+  args: {
+    label: 'I accept the terms',
+    description: 'Required before continuing.',
+    invalid: true,
+  },
+};
+
+/** Disabled — dimmed, hover suppressed. */
+export const Disabled: Story = {
+  args: { disabled: true, label: 'Translate untranslated pages', defaultChecked: true },
+};
+
+/** Controlled — react to `onCheckedChange`. */
+export const Controlled: Story = {
+  render: (args) => {
+    const [checked, setChecked] = useState(true);
+    return <Checkbox {...args} checked={checked} onCheckedChange={setChecked} />;
+  },
+  args: { label: 'Controlled checkbox' },
+};

--- a/packages/ui/src/icon-button.stories.tsx
+++ b/packages/ui/src/icon-button.stories.tsx
@@ -1,0 +1,37 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { fn } from 'storybook/test';
+
+import { IconButton } from './icon-button';
+
+const meta = {
+  title: 'Primitives/IconButton',
+  component: IconButton,
+  tags: ['autodocs'],
+  args: { label: 'Remove domain', children: '×', onClick: fn() },
+} satisfies Meta<typeof IconButton>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+/** Close glyph — the most common use. `label` feeds aria-label since `×` is presentational. */
+export const Close: Story = {};
+
+/** Up/down arrows for reorderable lists. */
+export const Reorder: Story = {
+  render: () => (
+    <div className="flex gap-1">
+      <IconButton label="Move up" onClick={fn()}>
+        ↑
+      </IconButton>
+      <IconButton label="Move down" onClick={fn()}>
+        ↓
+      </IconButton>
+    </div>
+  ),
+};
+
+/** Disabled — dim, hover surface suppressed. */
+export const Disabled: Story = {
+  args: { disabled: true },
+};

--- a/packages/ui/src/pill.stories.tsx
+++ b/packages/ui/src/pill.stories.tsx
@@ -1,0 +1,73 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { fn } from 'storybook/test';
+
+import { Pill } from './pill';
+
+const meta = {
+  title: 'Primitives/Pill',
+  component: Pill,
+  tags: ['autodocs'],
+  args: { children: 'Active' },
+} satisfies Meta<typeof Pill>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+/** Default — `md` size, `neutral` tone, passive span. */
+export const Default: Story = {};
+
+/** `accent` tone — the "good news" surface. */
+export const Accent: Story = {
+  args: { tone: 'accent', children: 'UA' },
+};
+
+/** `muted` tone — the "off" state. Border + text bump on hover when interactive. */
+export const Muted: Story = {
+  args: { tone: 'muted', children: 'Off' },
+};
+
+/** `sm` size — micro-tag look, font-mono, uppercase, micro type. Pairs with `dot`. */
+export const Small: Story = {
+  args: { size: 'sm', tone: 'accent', dot: true, children: 'Active' },
+};
+
+/** Leading dot — paired with `sm` it becomes the popup status indicator. */
+export const WithDot: Story = {
+  render: () => (
+    <div className="flex gap-2">
+      <Pill size="sm" tone="accent" dot>
+        Active
+      </Pill>
+      <Pill size="sm" tone="neutral" dot>
+        Paused
+      </Pill>
+      <Pill size="sm" tone="muted" dot>
+        Off
+      </Pill>
+    </div>
+  ),
+};
+
+/** Interactive — `onClick` promotes the pill to a button with hover styling and focus ring. */
+export const Interactive: Story = {
+  args: { onClick: fn(), children: 'Click me' },
+};
+
+/** Toggle pattern — `aria-pressed` reflects the on/off state. */
+export const Toggle: Story = {
+  args: {
+    size: 'sm',
+    tone: 'accent',
+    dot: true,
+    onClick: fn(),
+    'aria-pressed': true,
+    'aria-label': 'Movar is active',
+    children: 'Active',
+  },
+};
+
+/** Disabled interactive pill — dim, hover suppressed. */
+export const DisabledInteractive: Story = {
+  args: { onClick: fn(), disabled: true },
+};

--- a/packages/ui/src/select.stories.tsx
+++ b/packages/ui/src/select.stories.tsx
@@ -1,0 +1,75 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { useState } from 'react';
+import { fn } from 'storybook/test';
+
+import { Select, type SelectOption } from './select';
+
+const LANGUAGES: readonly SelectOption[] = [
+  { value: 'uk', label: 'Українська' },
+  { value: 'en', label: 'English' },
+  { value: 'pl', label: 'Polski' },
+  { value: 'de', label: 'Deutsch' },
+];
+
+const meta = {
+  title: 'Primitives/Select',
+  component: Select,
+  tags: ['autodocs'],
+  args: {
+    value: 'uk',
+    onChange: fn(),
+    options: LANGUAGES,
+    'aria-label': 'Preferred language',
+  },
+} satisfies Meta<typeof Select>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+/**
+ * The render functions below thread a real `useState` through the component
+ * so the dropdown actually updates in the canvas. Args are still
+ * Storybook-controlled (placeholder, disabled, invalid) and feed through.
+ */
+
+/** `form` variant — the standard bordered control with the custom SVG chevron. */
+export const Form: Story = {
+  render: (args) => {
+    const [value, setValue] = useState(args.value);
+    return <Select {...args} value={value} onChange={setValue} />;
+  },
+  args: { variant: 'form' },
+};
+
+/** `inline` variant — borderless, transparent, behaves like inline text. Used in footers. */
+export const Inline: Story = {
+  render: (args) => {
+    const [value, setValue] = useState(args.value);
+    return <Select {...args} value={value} onChange={setValue} />;
+  },
+  args: { variant: 'inline' },
+};
+
+/** Placeholder — empty initial value with a "Pick one…" first option. */
+export const WithPlaceholder: Story = {
+  render: (args) => {
+    const [value, setValue] = useState(args.value);
+    return <Select {...args} value={value} onChange={setValue} />;
+  },
+  args: { variant: 'form', value: '', placeholder: 'Pick a language…' },
+};
+
+/** Invalid — `aria-invalid` plus the danger-family border + focus ring. */
+export const Invalid: Story = {
+  render: (args) => {
+    const [value, setValue] = useState(args.value);
+    return <Select {...args} value={value} onChange={setValue} />;
+  },
+  args: { variant: 'form', value: '', placeholder: 'Pick a language…', invalid: true },
+};
+
+/** Disabled — dim, hover suppressed. */
+export const Disabled: Story = {
+  args: { variant: 'form', disabled: true },
+};

--- a/packages/ui/src/switch.stories.tsx
+++ b/packages/ui/src/switch.stories.tsx
@@ -1,0 +1,57 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { useState } from 'react';
+
+import { Switch } from './switch';
+
+const meta = {
+  title: 'Primitives/Switch',
+  component: Switch,
+  tags: ['autodocs'],
+  args: { label: 'Enable Movar' },
+} satisfies Meta<typeof Switch>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+/** Default off. */
+export const Off: Story = {
+  args: { defaultChecked: false },
+};
+
+/** Default on — track recolors to `--accent`, thumb translates 16px. */
+export const On: Story = {
+  args: { defaultChecked: true },
+};
+
+/** Label + description. */
+export const WithDescription: Story = {
+  args: {
+    label: 'Notifications',
+    description: 'Send a system alert when a domain switches state.',
+    defaultChecked: true,
+  },
+};
+
+/** Invalid — track + focus ring switch to the danger family. */
+export const Invalid: Story = {
+  args: {
+    label: 'Accept terms',
+    description: 'Required before saving.',
+    invalid: true,
+  },
+};
+
+/** Disabled — dim, no toggle interaction. */
+export const Disabled: Story = {
+  args: { disabled: true, defaultChecked: true },
+};
+
+/** Controlled — props drive the state, `onCheckedChange` reports it. */
+export const Controlled: Story = {
+  render: (args) => {
+    const [checked, setChecked] = useState(true);
+    return <Switch {...args} checked={checked} onCheckedChange={setChecked} />;
+  },
+  args: { label: 'Controlled switch' },
+};

--- a/packages/ui/tsconfig.json
+++ b/packages/ui/tsconfig.json
@@ -1,5 +1,5 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": { "noEmit": true },
-  "include": ["src"]
+  "include": ["src", ".storybook"]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -63,6 +63,34 @@ importers:
         specifier: ^4.95.0
         version: 4.95.0
 
+  apps/e2e:
+    dependencies:
+      '@movar/lang-detect':
+        specifier: workspace:*
+        version: link:../../packages/lang-detect
+      '@movar/shared':
+        specifier: workspace:*
+        version: link:../../packages/shared
+    devDependencies:
+      '@movar/eslint-config':
+        specifier: workspace:*
+        version: link:../../tooling/eslint-config-movar
+      '@playwright/test':
+        specifier: ^1.49.1
+        version: 1.60.0
+      '@types/chrome':
+        specifier: ^0.0.287
+        version: 0.0.287
+      '@types/node':
+        specifier: ^22.10.5
+        version: 22.19.19
+      eslint:
+        specifier: ^9.39.4
+        version: 9.39.4(jiti@2.6.1)
+      typescript:
+        specifier: ^6.0.3
+        version: 6.0.3
+
   apps/extension:
     dependencies:
       '@fontsource/ibm-plex-mono':
@@ -110,7 +138,7 @@ importers:
         version: 19.2.3(@types/react@19.2.15)
       '@wxt-dev/module-react':
         specifier: ^1.2.2
-        version: 1.2.2(vite@8.0.14(@types/node@25.9.1)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.22.3)(yaml@2.9.0))(wxt@0.20.26(@types/node@25.9.1)(eslint@9.39.4(jiti@2.6.1))(jiti@2.6.1)(rolldown@1.0.2)(rollup@4.60.4)(tsx@4.22.3)(yaml@2.9.0))
+        version: 1.2.2(vite@8.0.14(@types/node@25.9.1)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.22.3)(yaml@2.9.0))(wxt@0.20.26(@types/node@25.9.1)(eslint@9.39.4(jiti@2.6.1))(jiti@2.6.1)(oxc-parser@0.127.0)(rolldown@1.0.2)(rollup@4.60.4)(tsx@4.22.3)(yaml@2.9.0))
       eslint:
         specifier: ^9.39.4
         version: 9.39.4(jiti@2.6.1)
@@ -122,7 +150,7 @@ importers:
         version: 4.3.0
       wxt:
         specifier: ^0.20.26
-        version: 0.20.26(@types/node@25.9.1)(eslint@9.39.4(jiti@2.6.1))(jiti@2.6.1)(rolldown@1.0.2)(rollup@4.60.4)(tsx@4.22.3)(yaml@2.9.0)
+        version: 0.20.26(@types/node@25.9.1)(eslint@9.39.4(jiti@2.6.1))(jiti@2.6.1)(oxc-parser@0.127.0)(rolldown@1.0.2)(rollup@4.60.4)(tsx@4.22.3)(yaml@2.9.0)
 
   apps/marketing:
     dependencies:
@@ -139,21 +167,48 @@ importers:
       '@astrojs/check':
         specifier: ^0.9.4
         version: 0.9.9(prettier@3.8.3)(typescript@6.0.3)
+      '@fontsource/ibm-plex-mono':
+        specifier: ^5.2.7
+        version: 5.2.7
       '@fontsource/manrope':
         specifier: ^5.2.7
         version: 5.2.8
       '@movar/eslint-config':
         specifier: workspace:*
         version: link:../../tooling/eslint-config-movar
+      '@storybook/addon-docs':
+        specifier: ^10.4.1
+        version: 10.4.1(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(esbuild@0.28.0)(rollup@4.60.4)(storybook@10.4.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.1)(@types/react@19.2.15)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(vite@7.3.3(@types/node@25.9.1)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.22.3)(yaml@2.9.0))
+      '@storybook/react':
+        specifier: ^10.4.1
+        version: 10.4.1(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(storybook@10.4.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.1)(@types/react@19.2.15)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(typescript@6.0.3)
+      '@storybook/react-vite':
+        specifier: ^10.4.1
+        version: 10.4.1(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(esbuild@0.28.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(rollup@4.60.4)(storybook@10.4.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.1)(@types/react@19.2.15)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(typescript@6.0.3)(vite@7.3.3(@types/node@25.9.1)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.22.3)(yaml@2.9.0))
       '@tailwindcss/vite':
         specifier: ^4.3.0
-        version: 4.3.0(vite@6.4.2(@types/node@25.9.1)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.22.3)(yaml@2.9.0))
+        version: 4.3.0(vite@7.3.3(@types/node@25.9.1)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.22.3)(yaml@2.9.0))
       '@types/node':
         specifier: ^25.9.1
         version: 25.9.1
+      '@types/react':
+        specifier: ^19.2.15
+        version: 19.2.15
+      '@types/react-dom':
+        specifier: ^19.2.3
+        version: 19.2.3(@types/react@19.2.15)
       eslint:
         specifier: ^9.39.4
         version: 9.39.4(jiti@2.6.1)
+      react:
+        specifier: ^19.2.6
+        version: 19.2.6
+      react-dom:
+        specifier: ^19.2.6
+        version: 19.2.6(react@19.2.6)
+      storybook:
+        specifier: ^10.4.1
+        version: 10.4.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.1)(@types/react@19.2.15)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       tailwindcss:
         specifier: ^4.3.0
         version: 4.3.0
@@ -161,8 +216,8 @@ importers:
         specifier: ^6.0.3
         version: 6.0.3
       vite:
-        specifier: ^6.0.0
-        version: 6.4.2(@types/node@25.9.1)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.22.3)(yaml@2.9.0)
+        specifier: ^7.3.3
+        version: 7.3.3(@types/node@25.9.1)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.22.3)(yaml@2.9.0)
 
   packages/lang-detect:
     devDependencies:
@@ -197,18 +252,51 @@ importers:
 
   packages/ui:
     devDependencies:
+      '@fontsource/ibm-plex-mono':
+        specifier: ^5.2.7
+        version: 5.2.7
+      '@fontsource/manrope':
+        specifier: ^5.2.7
+        version: 5.2.8
       '@movar/eslint-config':
         specifier: workspace:*
         version: link:../../tooling/eslint-config-movar
+      '@storybook/addon-docs':
+        specifier: ^10.4.1
+        version: 10.4.1(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(esbuild@0.28.0)(rollup@4.60.4)(storybook@10.4.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.1)(@types/react@19.2.15)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(vite@7.3.3(@types/node@25.9.1)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.22.3)(yaml@2.9.0))
+      '@storybook/react':
+        specifier: ^10.4.1
+        version: 10.4.1(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(storybook@10.4.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.1)(@types/react@19.2.15)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(typescript@6.0.3)
+      '@storybook/react-vite':
+        specifier: ^10.4.1
+        version: 10.4.1(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(esbuild@0.28.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(rollup@4.60.4)(storybook@10.4.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.1)(@types/react@19.2.15)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(typescript@6.0.3)(vite@7.3.3(@types/node@25.9.1)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.22.3)(yaml@2.9.0))
+      '@tailwindcss/vite':
+        specifier: ^4.3.0
+        version: 4.3.0(vite@7.3.3(@types/node@25.9.1)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.22.3)(yaml@2.9.0))
       '@types/react':
         specifier: ^19.2.15
         version: 19.2.15
+      '@types/react-dom':
+        specifier: ^19.2.3
+        version: 19.2.3(@types/react@19.2.15)
       eslint:
         specifier: ^9.39.4
         version: 9.39.4(jiti@2.6.1)
       react:
         specifier: ^19.2.6
         version: 19.2.6
+      react-dom:
+        specifier: ^19.2.6
+        version: 19.2.6(react@19.2.6)
+      storybook:
+        specifier: ^10.4.1
+        version: 10.4.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.1)(@types/react@19.2.15)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      tailwindcss:
+        specifier: ^4.3.0
+        version: 4.3.0
+      vite:
+        specifier: ^7.3.3
+        version: 7.3.3(@types/node@25.9.1)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.22.3)(yaml@2.9.0)
 
   tooling/eslint-config-movar:
     dependencies:
@@ -250,6 +338,9 @@ packages:
 
   '@1natsu/wait-element@4.2.0':
     resolution: {integrity: sha512-Om0Q+WE9mNrpY4AwMTvkFiYHv8VM7TML3PvOqXy+w6kAjLjKhGYHYX+305+a6J8RVpds9s7IF2Z5aOPYwULFNw==}
+
+  '@adobe/css-tools@4.5.0':
+    resolution: {integrity: sha512-6OzddxPio9UiWTCemp4N8cYLV2ZN1ncRnV1cVGtve7dhPOtRkleRyx32GQCYSwDYgaHU3USMm84tNsvKzRCa1Q==}
 
   '@aklinker1/rollup-plugin-visualizer@5.12.0':
     resolution: {integrity: sha512-X24LvEGw6UFmy0lpGJDmXsMyBD58XmX1bbwsaMLhNoM+UMQfQ3b2RtC+nz4b/NoRK5r6QJSKJHBNVeUdwqybaQ==}
@@ -318,12 +409,50 @@ packages:
     resolution: {integrity: sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/compat-data@7.29.7':
+    resolution: {integrity: sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/core@7.29.7':
+    resolution: {integrity: sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/generator@7.29.7':
+    resolution: {integrity: sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-compilation-targets@7.29.7':
+    resolution: {integrity: sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-globals@7.29.7':
+    resolution: {integrity: sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-module-imports@7.29.7':
+    resolution: {integrity: sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-module-transforms@7.29.7':
+    resolution: {integrity: sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+
   '@babel/helper-string-parser@7.29.7':
     resolution: {integrity: sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-validator-identifier@7.29.7':
     resolution: {integrity: sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-option@7.29.7':
+    resolution: {integrity: sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helpers@7.29.7':
+    resolution: {integrity: sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==}
     engines: {node: '>=6.9.0'}
 
   '@babel/parser@7.29.7':
@@ -337,6 +466,14 @@ packages:
 
   '@babel/runtime@7.29.7':
     resolution: {integrity: sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/template@7.29.7':
+    resolution: {integrity: sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/traverse@7.29.7':
+    resolution: {integrity: sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==}
     engines: {node: '>=6.9.0'}
 
   '@babel/types@7.29.7':
@@ -610,11 +747,17 @@ packages:
   '@emnapi/core@1.4.5':
     resolution: {integrity: sha512-XsLw1dEOpkSX/WucdqUhPWP7hDxSvZiY+fsUC14h+FtQ2Ifni4znbBt8punRX+Uj2JG/uDb8nEHVKvrVlvdZ5Q==}
 
+  '@emnapi/core@1.9.2':
+    resolution: {integrity: sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==}
+
   '@emnapi/runtime@1.10.0':
     resolution: {integrity: sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==}
 
   '@emnapi/runtime@1.4.5':
     resolution: {integrity: sha512-++LApOtY0pEEz1zrd9vy1/zXVaVJJ/EbAF3u0fXIzPJEDtnITsBGbbK0EkM72amhl/R5b+5xx0Y/QhcVOpuulg==}
+
+  '@emnapi/runtime@1.9.2':
+    resolution: {integrity: sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==}
 
   '@emnapi/wasi-threads@1.0.4':
     resolution: {integrity: sha512-PJR+bOmMOPH8AtcTGAyYNiuJ3/Fcoj2XN/gBEWzDIKh254XO+mM9XoXHk5GNEhodxeMznbg7BlRojVbKN+gC6g==}
@@ -1541,6 +1684,15 @@ packages:
     resolution: {integrity: sha512-n5H8QLDJ47QqbCNn5SuFjCRDrOLEZ0h8vAHCK5RL9Ls7Xa8AQLa/YxAc9UjFqoEDM48muwtBGjtMY5cr0PLDCw==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
+  '@joshwooding/vite-plugin-react-docgen-typescript@0.7.0':
+    resolution: {integrity: sha512-qvsTEwEFefhdirGOPnu9Wp6ChfIwy2dBCRuETU3uE+4cC+PFoxMSiiEhxk4lOluA34eARHA0OxqsEUYDqRMgeQ==}
+    peerDependencies:
+      typescript: '>= 4.3.x'
+      vite: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
 
@@ -1565,6 +1717,12 @@ packages:
 
   '@manypkg/get-packages@1.1.3':
     resolution: {integrity: sha512-fo+QhuU3qE/2TQMQmbVMqaQ6EWbMhi4ABWP+O4AM1NqPBuy0OrApV5LO6BrrgnhtAHS2NH6RrVk9OL181tTi8A==}
+
+  '@mdx-js/react@3.1.1':
+    resolution: {integrity: sha512-f++rKLQgUVYDAtECQ6fn/is15GkEH9+nZPM3MS0RcxVqoTfawHvDlSCH7JbMhAM6uJ32v3eXLvLmLvjGu7PTQw==}
+    peerDependencies:
+      '@types/react': '>=16'
+      react: '>=16'
 
   '@napi-rs/wasm-runtime@0.2.4':
     resolution: {integrity: sha512-9zESzOO5aDByvhIAsOy9TbpZ0Ur2AJbUI7UT73kcUTS2mxAMHOBaa1st/jAymNoCtvrit99kkzT1FZuXVcgfIQ==}
@@ -1644,11 +1802,254 @@ packages:
   '@oslojs/encoding@1.1.0':
     resolution: {integrity: sha512-70wQhgYmndg4GCPxPPxPGevRKqTIJ2Nh4OkiMWmDAVYsTQ+Ta7Sq+rPevXyXGdzr30/qZBnyOalCszoMxlyldQ==}
 
+  '@oxc-parser/binding-android-arm-eabi@0.127.0':
+    resolution: {integrity: sha512-0LC7ye4hvqbIKxAzThzvswgHLFu2AURKzYLeSVvLdu2TBOYWQDmHnTqPLeA597BcUCxiLqLsS4CJ5uoI5WYWCQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [android]
+
+  '@oxc-parser/binding-android-arm64@0.127.0':
+    resolution: {integrity: sha512-b5jtVTH6AU5CJXHNdj7Jj9IEiR9yVjjnwHzPJhGyHGPdcsZSzBCkS9GBbV33niRMvKthDwQRFRJfI4a+k4PvYg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
+  '@oxc-parser/binding-darwin-arm64@0.127.0':
+    resolution: {integrity: sha512-obCE8B7ISKkJidjlhv9xRGJPOSDG2Yu6PRga9Ruaz35uintHxbp1Ki/Yc71wx4rj3Edrm0a1kzG1TAwit0wFpg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@oxc-parser/binding-darwin-x64@0.127.0':
+    resolution: {integrity: sha512-JL6Xb5IwPQT8rUzlpsX7E+AgfcdNklXNPFp8pjCQQ5MQOQo5rtEB2ui+3Hgg9Sn7Y9Egj6YOLLiHhLpdAe12Aw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@oxc-parser/binding-freebsd-x64@0.127.0':
+    resolution: {integrity: sha512-SDQ/3MQFw58fqQz3Z1PhSKFF3JoCF4gmlNjziDm8X02tTahCw0qJbd7FGPDKw1i4VTBZene9JPyC3mHtSvi+wA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@oxc-parser/binding-linux-arm-gnueabihf@0.127.0':
+    resolution: {integrity: sha512-Av+D1MIqzV0YMGPT9we2SIZaMKD7Cxs4CvXSx/yxaWHewZjYEjScpOf5igc8IILASViw4WTnjlwUdI1KzVtDHQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxc-parser/binding-linux-arm-musleabihf@0.127.0':
+    resolution: {integrity: sha512-Cs2fdJ8cPpFdeebj6p4dag8A4+56hPvZ0AhQQzlaLswGz1tz7bXt1nETLeorrM9+AMcWFFkqxcXwDGfTVidY8g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxc-parser/binding-linux-arm64-gnu@0.127.0':
+    resolution: {integrity: sha512-qdOfTcT6SY8gsJrrV92uyEUyjqMGPpIB5JZUG6QN5dukYd+7/j0kX6MwK1DgQj39jtUYixxPiaRUiEN1+0CXgQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-parser/binding-linux-arm64-musl@0.127.0':
+    resolution: {integrity: sha512-EoTCZneNFU/P2qrpEM+RHmQwt+CvDkyGESG6qhr7KaegXLZwePfbrkCDfAk8/rhxbDUVGsZILX+2tqPzFtoFWA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxc-parser/binding-linux-ppc64-gnu@0.127.0':
+    resolution: {integrity: sha512-zALjmZYgxFLHjXeudcDF0xFGNydTAtkAeXAr2EuC17ywCyFxcmQra4w0BMde0Yi/re4Bi4iwEoEXtYN7l6eBLQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-parser/binding-linux-riscv64-gnu@0.127.0':
+    resolution: {integrity: sha512-fPP8M6zQLS7Jz7o9d5ArUSuAuSK3e+WCYVrCpdzeCOejidtZExJ9tjhDrAd3HEPqARBCPmdpqxESPFqy44vkBQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-parser/binding-linux-riscv64-musl@0.127.0':
+    resolution: {integrity: sha512-7IcC4Ao02oGpfnjt+X/oF4U2mllo2qoSkw5xxiXNKL9MCTsTiAC6616beOuehdxGcnz1bRoPC1RQ2f1GQDdN+g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxc-parser/binding-linux-s390x-gnu@0.127.0':
+    resolution: {integrity: sha512-pbXIhiNFHoqWeqDNLiJ9JkpHz1IM9k4DXa66x+1GTWMG7iLxtkXgE53iiuKSXwmk3zIYmaPVfBvgcAhS583K4Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-parser/binding-linux-x64-gnu@0.127.0':
+    resolution: {integrity: sha512-MYCguB9RvBvlSd6gbuNI7QwiLoCCAlGnlRJFPrzLI6U1/9wkC/WK6LtBAUln55H1Ctqw45PWmqrobKoMhsYQzQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-parser/binding-linux-x64-musl@0.127.0':
+    resolution: {integrity: sha512-5eY0B/bxf1xIUxb4NOTvOI3KWtBQfPWYyKAzgcrCt0mDibSZygVpO1Pz8bkeiSZ5Jj9+M09dkggG3H8I5d0Uyg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxc-parser/binding-openharmony-arm64@0.127.0':
+    resolution: {integrity: sha512-Gld0ajrFTUXNtdw20fVBuTQx66FA75nIVg+//pPfR3sXkuABB4mTBhl3r9JNzrJpgW//qiwxf0nWXUWGJSL3UQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@oxc-parser/binding-wasm32-wasi@0.127.0':
+    resolution: {integrity: sha512-T6KVD7rhLzFlwGRXMnxUFfkCZD8FHnb968wVXW1mXzgRFc5RNXOBY2mPPDZ77x5Ln76ltLMgtPg0cOkU1NSrEQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [wasm32]
+
+  '@oxc-parser/binding-win32-arm64-msvc@0.127.0':
+    resolution: {integrity: sha512-Ujvw4X+LD1CCGULcsQcvb4YNVoBGqt+JHgNNzGGaCImELiZLk477ifUH53gIbE7EKd933NdTi25JWEr9K2HwXw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@oxc-parser/binding-win32-ia32-msvc@0.127.0':
+    resolution: {integrity: sha512-0cwxKO7KHQQQfo4Uf4B2SQrhgm+cJaP9OvFFhx52Tkg4bezsacu83GB2/In5bC415Ueeym+kXdnge/57rbSfTw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ia32]
+    os: [win32]
+
+  '@oxc-parser/binding-win32-x64-msvc@0.127.0':
+    resolution: {integrity: sha512-rOrnSQSCbhI2kowr9XxE7m9a8oQXnBHjnS6j95LxxAnEZ0+Fz20WlRXG4ondQb+ejjt2KOsa65sE6++L6kUd+w==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
+
+  '@oxc-project/types@0.127.0':
+    resolution: {integrity: sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ==}
+
   '@oxc-project/types@0.132.0':
     resolution: {integrity: sha512-FESMOxil5Se014ui/Eq8fT5uHJo6nIRwH0PfJrZJXs6Gek3ZVFOrpUv3YIZT20m+extU98Hg1Ym72U58rlsxUQ==}
 
+  '@oxc-resolver/binding-android-arm-eabi@11.19.1':
+    resolution: {integrity: sha512-aUs47y+xyXHUKlbhqHUjBABjvycq6YSD7bpxSW7vplUmdzAlJ93yXY6ZR0c1o1x5A/QKbENCvs3+NlY8IpIVzg==}
+    cpu: [arm]
+    os: [android]
+
+  '@oxc-resolver/binding-android-arm64@11.19.1':
+    resolution: {integrity: sha512-oolbkRX+m7Pq2LNjr/kKgYeC7bRDMVTWPgxBGMjSpZi/+UskVo4jsMU3MLheZV55jL6c3rNelPl4oD60ggYmqA==}
+    cpu: [arm64]
+    os: [android]
+
+  '@oxc-resolver/binding-darwin-arm64@11.19.1':
+    resolution: {integrity: sha512-nUC6d2i3R5B12sUW4O646qD5cnMXf2oBGPLIIeaRfU9doJRORAbE2SGv4eW6rMqhD+G7nf2Y8TTJTLiiO3Q/dQ==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@oxc-resolver/binding-darwin-x64@11.19.1':
+    resolution: {integrity: sha512-cV50vE5+uAgNcFa3QY1JOeKDSkM/9ReIcc/9wn4TavhW/itkDGrXhw9jaKnkQnGbjJ198Yh5nbX/Gr2mr4Z5jQ==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@oxc-resolver/binding-freebsd-x64@11.19.1':
+    resolution: {integrity: sha512-xZOQiYGFxtk48PBKff+Zwoym7ScPAIVp4c14lfLxizO2LTTTJe5sx9vQNGrBymrf/vatSPNMD4FgsaaRigPkqw==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@oxc-resolver/binding-linux-arm-gnueabihf@11.19.1':
+    resolution: {integrity: sha512-lXZYWAC6kaGe/ky2su94e9jN9t6M0/6c+GrSlCqL//XO1cxi5lpAhnJYdyrKfm0ZEr/c7RNyAx3P7FSBcBd5+A==}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxc-resolver/binding-linux-arm-musleabihf@11.19.1':
+    resolution: {integrity: sha512-veG1kKsuK5+t2IsO9q0DErYVSw2azvCVvWHnfTOS73WE0STdLLB7Q1bB9WR+yHPQM76ASkFyRbogWo1GR1+WbQ==}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxc-resolver/binding-linux-arm64-gnu@11.19.1':
+    resolution: {integrity: sha512-heV2+jmXyYnUrpUXSPugqWDRpnsQcDm2AX4wzTuvgdlZfoNYO0O3W2AVpJYaDn9AG4JdM6Kxom8+foE7/BcSig==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-resolver/binding-linux-arm64-musl@11.19.1':
+    resolution: {integrity: sha512-jvo2Pjs1c9KPxMuMPIeQsgu0mOJF9rEb3y3TdpsrqwxRM+AN6/nDDwv45n5ZrUnQMsdBy5gIabioMKnQfWo9ew==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxc-resolver/binding-linux-ppc64-gnu@11.19.1':
+    resolution: {integrity: sha512-vLmdNxWCdN7Uo5suays6A/+ywBby2PWBBPXctWPg5V0+eVuzsJxgAn6MMB4mPlshskYbppjpN2Zg83ArHze9gQ==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-resolver/binding-linux-riscv64-gnu@11.19.1':
+    resolution: {integrity: sha512-/b+WgR+VTSBxzgOhDO7TlMXC1ufPIMR6Vj1zN+/x+MnyXGW7prTLzU9eW85Aj7Th7CCEG9ArCbTeqxCzFWdg2w==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-resolver/binding-linux-riscv64-musl@11.19.1':
+    resolution: {integrity: sha512-YlRdeWb9j42p29ROh+h4eg/OQ3dTJlpHSa+84pUM9+p6i3djtPz1q55yLJhgW9XfDch7FN1pQ/Vd6YP+xfRIuw==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxc-resolver/binding-linux-s390x-gnu@11.19.1':
+    resolution: {integrity: sha512-EDpafVOQWF8/MJynsjOGFThcqhRHy417sRyLfQmeiamJ8qVhSKAn2Dn2VVKUGCjVB9C46VGjhNo7nOPUi1x6uA==}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-resolver/binding-linux-x64-gnu@11.19.1':
+    resolution: {integrity: sha512-NxjZe+rqWhr+RT8/Ik+5ptA3oz7tUw361Wa5RWQXKnfqwSSHdHyrw6IdcTfYuml9dM856AlKWZIUXDmA9kkiBQ==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-resolver/binding-linux-x64-musl@11.19.1':
+    resolution: {integrity: sha512-cM/hQwsO3ReJg5kR+SpI69DMfvNCp+A/eVR4b4YClE5bVZwz8rh2Nh05InhwI5HR/9cArbEkzMjcKgTHS6UaNw==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxc-resolver/binding-openharmony-arm64@11.19.1':
+    resolution: {integrity: sha512-QF080IowFB0+9Rh6RcD19bdgh49BpQHUW5TajG1qvWHvmrQznTZZjYlgE2ltLXyKY+qs4F/v5xuX1XS7Is+3qA==}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@oxc-resolver/binding-wasm32-wasi@11.19.1':
+    resolution: {integrity: sha512-w8UCKhX826cP/ZLokXDS6+milN8y4X7zidsAttEdWlVoamTNf6lhBJldaWr3ukTDiye7s4HRcuPEPOXNC432Vg==}
+    engines: {node: '>=14.0.0'}
+    cpu: [wasm32]
+
+  '@oxc-resolver/binding-win32-arm64-msvc@11.19.1':
+    resolution: {integrity: sha512-nJ4AsUVZrVKwnU/QRdzPCCrO0TrabBqgJ8pJhXITdZGYOV28TIYystV1VFLbQ7DtAcaBHpocT5/ZJnF78YJPtQ==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@oxc-resolver/binding-win32-ia32-msvc@11.19.1':
+    resolution: {integrity: sha512-EW+ND5q2Tl+a3pH81l1QbfgbF3HmqgwLfDfVithRFheac8OTcnbXt/JxqD2GbDkb7xYEqy1zNaVFRr3oeG8npA==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@oxc-resolver/binding-win32-x64-msvc@11.19.1':
+    resolution: {integrity: sha512-6hIU3RQu45B+VNTY4Ru8ppFwjVS/S5qwYyGhBotmjxfEKk41I2DlGtRfGJndZ5+6lneE2pwloqunlOyZuX/XAw==}
+    cpu: [x64]
+    os: [win32]
+
   '@package-json/types@0.0.12':
     resolution: {integrity: sha512-uu43FGU34B5VM9mCNjXCwLaGHYjXdNincqKLaraaCW+7S2+SmiBg1Nv8bPnmschrIfZmfKNY9f3fC376MRrObw==}
+
+  '@playwright/test@1.60.0':
+    resolution: {integrity: sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   '@pnpm/config.env-replace@1.1.0':
     resolution: {integrity: sha512-htyl8TWnKL7K/ESFa1oW2UB5lVDxuF5DpM7tBi6Hu2LNL3mWkIzNLG6N4zoCUP1lCKNxWy/3iu8mS8MvToGd6w==}
@@ -1959,6 +2360,87 @@ packages:
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
+  '@storybook/addon-docs@10.4.1':
+    resolution: {integrity: sha512-IYqUdjoZe4VO2LFZlKL/gwy7DsQSWCq6hX+zc1MBmZo04yycDASk1tte57n9pdlW3ajw9yYMF/+lVBi+xQjyvw==}
+    peerDependencies:
+      '@types/react': ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      storybook: ^10.4.1
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@storybook/builder-vite@10.4.1':
+    resolution: {integrity: sha512-/oyQrXoNOqN8SW5hNnYP+I1uvgFxKxWXj/EP6NXYzc5SQwImofgru+D2+6gDhL0+Q//+Hx05DJoQO2omvUJ8bQ==}
+    peerDependencies:
+      storybook: ^10.4.1
+      vite: ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
+
+  '@storybook/csf-plugin@10.4.1':
+    resolution: {integrity: sha512-WdPepGBxDGOUDjYd8KxMtcf+us/2PAcnBczl77XtrnxxHNs0jWesxKkiJ9yiuGrge4BPhDeAj6rxjbBoaHxLBA==}
+    peerDependencies:
+      esbuild: '*'
+      rollup: '*'
+      storybook: ^10.4.1
+      vite: '*'
+      webpack: '*'
+    peerDependenciesMeta:
+      esbuild:
+        optional: true
+      rollup:
+        optional: true
+      vite:
+        optional: true
+      webpack:
+        optional: true
+
+  '@storybook/global@5.0.0':
+    resolution: {integrity: sha512-FcOqPAXACP0I3oJ/ws6/rrPT9WGhu915Cg8D02a9YxLo0DE9zI+a9A5gRGvmQ09fiWPukqI8ZAEoQEdWUKMQdQ==}
+
+  '@storybook/icons@2.0.2':
+    resolution: {integrity: sha512-KZBCpXsshAIjczYNXR/rlxEtCUX/eAbpFNwKi8bcOomrLA4t/SyPz5RF+lVPO2oZBUE4sAkt43mfJUevQDSEEw==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  '@storybook/react-dom-shim@10.4.1':
+    resolution: {integrity: sha512-6QFqfDNH4DMrt7yHKRfpqRopsVUc/Az+sXIdJ39IetYnHUxL3nW4NVaPc6uy/8Qi8urzUyEXL/nn7cpSIP2aPQ==}
+    peerDependencies:
+      '@types/react': ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      '@types/react-dom': ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      storybook: ^10.4.1
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@storybook/react-vite@10.4.1':
+    resolution: {integrity: sha512-zY6OzaXvXqBIUyc5ySE55/LAPQiF+o9ZyhQI978WMu4mY/fL7FpQ+ZVHRUCCgz/wTXtqE9jJwd/N10HI1kD0/Q==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      storybook: ^10.4.1
+      vite: ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
+
+  '@storybook/react@10.4.1':
+    resolution: {integrity: sha512-WuYz4NaUk4gmFAMliSpCbV8w6jP5OY9juBfw1huwzu2S/k5FhnVXwmrUaL0fmf3Bq/7NgkzmBBbZr6I6LuHayQ==}
+    peerDependencies:
+      '@types/react': ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      '@types/react-dom': ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      storybook: ^10.4.1
+      typescript: '>= 4.9.x'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+      typescript:
+        optional: true
+
   '@tailwindcss/node@4.3.0':
     resolution: {integrity: sha512-aFb4gUhFOgdh9AXo4IzBEOzBkkAxm9VigwDJnMIYv3lcfXCJVesNfbEaBl4BNgVRyid92AmdviqwBUBRKSeY3g==}
 
@@ -2053,14 +2535,46 @@ packages:
     peerDependencies:
       vite: ^5.2.0 || ^6 || ^7 || ^8
 
+  '@testing-library/dom@10.4.1':
+    resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
+    engines: {node: '>=18'}
+
+  '@testing-library/jest-dom@6.9.1':
+    resolution: {integrity: sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==}
+    engines: {node: '>=14', npm: '>=6', yarn: '>=1'}
+
+  '@testing-library/user-event@14.6.1':
+    resolution: {integrity: sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==}
+    engines: {node: '>=12', npm: '>=6'}
+    peerDependencies:
+      '@testing-library/dom': '>=7.21.4'
+
   '@tybys/wasm-util@0.10.2':
     resolution: {integrity: sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==}
 
   '@tybys/wasm-util@0.9.0':
     resolution: {integrity: sha512-6+7nlbMVX/PVDCwaIQ8nTOPveOcFLSt8GcXdx8hD0bt39uWxYT88uXzqTd4fTvqta7oeUJqudepapKNt2DYJFw==}
 
+  '@types/aria-query@5.0.4':
+    resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
+
+  '@types/babel__core@7.20.5':
+    resolution: {integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==}
+
+  '@types/babel__generator@7.27.0':
+    resolution: {integrity: sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==}
+
+  '@types/babel__template@7.4.4':
+    resolution: {integrity: sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==}
+
+  '@types/babel__traverse@7.28.0':
+    resolution: {integrity: sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==}
+
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
+  '@types/chrome@0.0.287':
+    resolution: {integrity: sha512-wWhBNPNXZHwycHKNYnexUcpSbrihVZu++0rdp6GEk5ZgAglenLx+RwdEouh6FrHS0XQiOxSd62yaujM1OoQlZQ==}
 
   '@types/chrome@0.1.42':
     resolution: {integrity: sha512-tdT2roFqGecZZDjA9fUEAINb2STxSPifHMDvY6EfRjNRCjdrs/0FwKt5RCIA9MKMd1arAYZZL3nwEkp6ZLZu2w==}
@@ -2070,6 +2584,9 @@ packages:
 
   '@types/deep-eql@4.0.2':
     resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
+
+  '@types/doctrine@0.0.9':
+    resolution: {integrity: sha512-eOIHzCUSH7SMfonMG1LsC2f8vxBFtho6NGBznK41R84YzPuvSBzrhEps33IsQiOW9+VL6NQ9DbjQJznk/S4uRA==}
 
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
@@ -2095,6 +2612,9 @@ packages:
   '@types/mdast@4.0.4':
     resolution: {integrity: sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==}
 
+  '@types/mdx@2.0.13':
+    resolution: {integrity: sha512-+OWZQfAYyio6YkJb3HLxDrvnx6SWWDbC0zVPfBRzUk0/nqoDyf6dNxQi3eArPe8rJ473nobTMQ/8Zk+LxJ+Yuw==}
+
   '@types/minimatch@3.0.5':
     resolution: {integrity: sha512-Klz949h02Gz2uZCMGwDUSDS1YBlTdDDgbWHi+81l29tQALUtvz4rAYi5uoVhE5Lagoq6DeqAUlbrHvW/mXDgdQ==}
 
@@ -2107,6 +2627,9 @@ packages:
   '@types/node@12.20.55':
     resolution: {integrity: sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==}
 
+  '@types/node@22.19.19':
+    resolution: {integrity: sha512-dyh/xO2Fh5bYrfWaaqGrRQQGkNdmYw6AmaAUvYeUMNTWQtvb796ikLdmTchRmOlOiIJ1TDXfWgVx1QkUlQ6Hew==}
+
   '@types/node@25.9.1':
     resolution: {integrity: sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==}
 
@@ -2117,6 +2640,9 @@ packages:
 
   '@types/react@19.2.15':
     resolution: {integrity: sha512-eRwcGNHve+E8qtEQSSRl6urh+rFop4v8gm6O8rGv25CodbvFdLjA1vVQ1KkiFE0w0UPOnb8tDiFKL5lp0rtY5Q==}
+
+  '@types/resolve@1.20.6':
+    resolution: {integrity: sha512-A4STmOXPhMUtHH+S6ymgE2GiBSMqf4oTvcQZMcHzokuTLVYzXTB8ttjcgxOVaAp2lGwEdzZ0J+cRbbeevQj1UQ==}
 
   '@types/unist@3.0.3':
     resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
@@ -2329,6 +2855,9 @@ packages:
       babel-plugin-react-compiler:
         optional: true
 
+  '@vitest/expect@3.2.4':
+    resolution: {integrity: sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==}
+
   '@vitest/expect@4.1.7':
     resolution: {integrity: sha512-1R+tw0ortHEbZDGMymm+pN7/AFQ/RkFFdtd7EN+VBpynKmLbP8A3rpEXdshBJ7+8hQ9zBJh/i1s0yKNtxAnU7w==}
 
@@ -2343,6 +2872,9 @@ packages:
       vite:
         optional: true
 
+  '@vitest/pretty-format@3.2.4':
+    resolution: {integrity: sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==}
+
   '@vitest/pretty-format@4.1.7':
     resolution: {integrity: sha512-umgCarTOYQWIaDMvGDRZij+6b9oVeLIyJzfN+AS88e0ZOU3QTgNNSTtjQOpcvWr3np1N0j4WgZj+sb3oYBDscw==}
 
@@ -2352,8 +2884,14 @@ packages:
   '@vitest/snapshot@4.1.7':
     resolution: {integrity: sha512-ZacLzja+TmJeZ1h14xW2FB/WpeimUD3haBXQPyJqxvo8jQTmfeA8zv58mtjN2C7EHXZDYVcVYdYmAxjkWVvKCw==}
 
+  '@vitest/spy@3.2.4':
+    resolution: {integrity: sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==}
+
   '@vitest/spy@4.1.7':
     resolution: {integrity: sha512-kbkI5LMWakyuTIvs6fUJ5qdIVb1XVKsYJAT4OJ938cHMROYMSfmoQdZy0aaAnjbbc8F61vkoTqz/Az+/HiIu5Q==}
+
+  '@vitest/utils@3.2.4':
+    resolution: {integrity: sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==}
 
   '@vitest/utils@4.1.7':
     resolution: {integrity: sha512-T532WBu791cBxJlCl6SO+J14l81DQx6uQHm1bQbmCDY7nqlEIgkza/UFnSBNaUtSf41unldDFjdOBYEQC4b5Hw==}
@@ -2383,6 +2921,9 @@ packages:
 
   '@vscode/l10n@0.0.18':
     resolution: {integrity: sha512-KYSIHVmslkaCDyw013pphY+d7x1qV8IZupYfeIfzNA+nsaWHbn5uPuQRvdRFsa9zFzGeudPuoGoZ1Op4jrJXIQ==}
+
+  '@webcontainer/env@1.1.1':
+    resolution: {integrity: sha512-6aN99yL695Hi9SuIk1oC88l9o0gmxL1nGWWQ/kNy81HigJ0FoaoTXpytCj6ItzgyCEwA9kF1wixsTuv5cjsgng==}
 
   '@webext-core/fake-browser@1.5.0':
     resolution: {integrity: sha512-dq5LWtr3XjB9B9LSgEZo4JUEmwBGAxa5CHbn7CvCC2jf4SOG0iBD20QSD3dpvcHBXTIHCVbB4bsDVFzlXMnYww==}
@@ -2463,6 +3004,10 @@ packages:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
     engines: {node: '>=8'}
 
+  ansi-styles@5.2.0:
+    resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
+    engines: {node: '>=10'}
+
   ansi-styles@6.2.3:
     resolution: {integrity: sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==}
     engines: {node: '>=12'}
@@ -2476,6 +3021,9 @@ packages:
 
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
+
+  aria-query@5.3.0:
+    resolution: {integrity: sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==}
 
   aria-query@5.3.2:
     resolution: {integrity: sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==}
@@ -2533,6 +3081,10 @@ packages:
 
   ast-types-flow@0.0.8:
     resolution: {integrity: sha512-OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ==}
+
+  ast-types@0.16.1:
+    resolution: {integrity: sha512-6t10qk83GOG8p0vKmaCr8eiilZwO171AvbROMtvvNiwrTly62t+7XkA8RdIIVbpMhCASAsxgAzdRSwh6nw/5Dg==}
+    engines: {node: '>=4'}
 
   astro@5.18.1:
     resolution: {integrity: sha512-m4VWilWZ+Xt6NPoYzC4CgGZim/zQUO7WFL0RHCH0AiEavF1153iC3+me2atDvXpf/yX4PyGUeD8wZLq1cirT3g==}
@@ -2701,6 +3253,10 @@ packages:
   ccount@2.0.1:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
 
+  chai@5.3.3:
+    resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
+    engines: {node: '>=18'}
+
   chai@6.2.2:
     resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
     engines: {node: '>=18'}
@@ -2727,6 +3283,10 @@ packages:
 
   chardet@2.1.1:
     resolution: {integrity: sha512-PsezH1rqdV9VvyNhxxOW32/d75r01NY7TQCmOqomRo15ZSOKbpTFVsfjghxo6JloQUCGnH4k1LGu0R4yCLlWQQ==}
+
+  check-error@2.1.3:
+    resolution: {integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==}
+    engines: {node: '>= 16'}
 
   chokidar@4.0.3:
     resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==}
@@ -2916,6 +3476,9 @@ packages:
     resolution: {integrity: sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==}
     engines: {node: '>= 6'}
 
+  css.escape@1.5.1:
+    resolution: {integrity: sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==}
+
   cssesc@3.0.0:
     resolution: {integrity: sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==}
     engines: {node: '>=4'}
@@ -2976,6 +3539,10 @@ packages:
 
   decode-named-character-reference@1.3.0:
     resolution: {integrity: sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==}
+
+  deep-eql@5.0.2:
+    resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
+    engines: {node: '>=6'}
 
   deep-extend@0.6.0:
     resolution: {integrity: sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==}
@@ -3058,6 +3625,16 @@ packages:
     resolution: {integrity: sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==}
     engines: {node: '>=0.10.0'}
 
+  doctrine@3.0.0:
+    resolution: {integrity: sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==}
+    engines: {node: '>=6.0.0'}
+
+  dom-accessibility-api@0.5.16:
+    resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
+
+  dom-accessibility-api@0.6.3:
+    resolution: {integrity: sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==}
+
   dom-serializer@2.0.0:
     resolution: {integrity: sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==}
 
@@ -3121,6 +3698,10 @@ packages:
 
   emoji-regex@9.2.2:
     resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
+
+  empathic@2.0.1:
+    resolution: {integrity: sha512-YGRs8knHhKHVShLkFET/rWAU8kmHbOV5LwN938RHI0pljAJ1Gf6SzXsSmRaEzcXTtOOmVqJ5+WtQPL5uigY50Q==}
+    engines: {node: '>=14'}
 
   end-of-stream@1.4.5:
     resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
@@ -3513,6 +4094,11 @@ packages:
     resolution: {integrity: sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==}
     engines: {node: '>=6 <7 || >=8'}
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -3538,6 +4124,10 @@ packages:
   generator-function@2.0.1:
     resolution: {integrity: sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g==}
     engines: {node: '>= 0.4'}
+
+  gensync@1.0.0-beta.2:
+    resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
+    engines: {node: '>=6.9.0'}
 
   get-caller-file@2.0.5:
     resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
@@ -3587,6 +4177,10 @@ packages:
 
   glob-to-regexp@0.4.1:
     resolution: {integrity: sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==}
+
+  glob@13.0.6:
+    resolution: {integrity: sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==}
+    engines: {node: 18 || 20 || >=22}
 
   global-directory@4.0.1:
     resolution: {integrity: sha512-wHTUcDUoZ1H5/0iVqEudYW4/kAlN5cZ3j/bXn0Dpbizl9iaUVeWSHqiOjsgk6OW2bkLclbBjzewBz6weQ1zA2Q==}
@@ -3747,6 +4341,10 @@ packages:
   imurmurhash@0.1.4:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
     engines: {node: '>=0.8.19'}
+
+  indent-string@4.0.0:
+    resolution: {integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==}
+    engines: {node: '>=8'}
 
   indent-string@5.0.0:
     resolution: {integrity: sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg==}
@@ -4331,9 +4929,19 @@ packages:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
     hasBin: true
 
+  loupe@3.2.1:
+    resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
+
   lru-cache@11.5.0:
     resolution: {integrity: sha512-5YgH9UJd7wVb9hIouI2adWpgqrrICkt070Dnj8EUY1+B4B2P9eRLPAkAAo6NICA7CEhOIeBHl46u9zSNpNu7zA==}
     engines: {node: 20 || >=22}
+
+  lru-cache@5.1.1:
+    resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
+
+  lz-string@1.5.0:
+    resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
+    hasBin: true
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
@@ -4515,6 +5123,10 @@ packages:
     resolution: {integrity: sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==}
     engines: {node: '>=18'}
 
+  min-indent@1.0.1:
+    resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
+    engines: {node: '>=4'}
+
   miniflare@4.20260526.0:
     resolution: {integrity: sha512-JYQ7jPZZWoaaj9jWHb8Ucp6Cu2SbDVqIsAJhumqdzzLkkfq0pYkDeino/sZfW1ixJWPjv/C44zjm9gVJC2izCA==}
     engines: {node: '>=22.0.0'}
@@ -4533,6 +5145,10 @@ packages:
 
   minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
+
+  minipass@7.1.3:
+    resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
+    engines: {node: '>=16 || 14 >=14.17'}
 
   mlly@1.8.2:
     resolution: {integrity: sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA==}
@@ -4689,6 +5305,10 @@ packages:
   oniguruma-to-es@4.3.6:
     resolution: {integrity: sha512-csuQ9x3Yr0cEIs/Zgx/OEt9iBw9vqIunAPQkx19R/fiMq2oGVTgcMqO/V3Ybqefr1TBvosI6jU539ksaBULJyA==}
 
+  open@10.2.0:
+    resolution: {integrity: sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA==}
+    engines: {node: '>=18'}
+
   open@11.0.0:
     resolution: {integrity: sha512-smsWv2LzFjP03xmvFoJ331ss6h+jixfA4UUV/Bsiyuu4YJPfN+FIQGOIiv4w9/+MoHkfkJ22UIaQWRVFRfH6Vw==}
     engines: {node: '>=20'}
@@ -4715,6 +5335,13 @@ packages:
   own-keys@1.0.1:
     resolution: {integrity: sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg==}
     engines: {node: '>= 0.4'}
+
+  oxc-parser@0.127.0:
+    resolution: {integrity: sha512-bkgD4qHlN7WxLdX8bLXdaU54TtQtAIg/ZBAfm0aje/mo3MRDo3P0hZSgr4U7O3xfX+fQmR5AP04JS/TGcZLcFA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+
+  oxc-resolver@11.19.1:
+    resolution: {integrity: sha512-qE/CIg/spwrTBFt5aKmwe3ifeDdLfA2NESN30E42X/lII5ClF8V7Wt6WIJhcGZjp0/Q+nQ+9vgxGk//xZNX2hg==}
 
   p-filter@2.1.0:
     resolution: {integrity: sha512-ZBxxZ5sL2HghephhpGAQdoskxplTwr7ICaehZwLIlfL6acuVgZPm8yBNuRAFBGEqtD/hmUeq9eqLg2ys9Xr/yw==}
@@ -4804,6 +5431,10 @@ packages:
   path-parse@1.0.7:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
 
+  path-scurry@2.0.2:
+    resolution: {integrity: sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==}
+    engines: {node: 18 || 20 || >=22}
+
   path-to-regexp@6.3.0:
     resolution: {integrity: sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==}
 
@@ -4813,6 +5444,10 @@ packages:
 
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
+  pathval@2.0.1:
+    resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
+    engines: {node: '>= 14.16'}
 
   perfect-debounce@2.1.0:
     resolution: {integrity: sha512-LjgdTytVFXeUgtHZr9WYViYSM/g8MkcTPYDlPa3cDqMirHjKiSZPYd6DoL7pK8AJQr+uWkQvCjHNdiMqsrJs+g==}
@@ -4850,6 +5485,16 @@ packages:
 
   pkg-types@2.3.1:
     resolution: {integrity: sha512-y+ichcgc2LrADuhLNAx8DFjVfgz91pRxfZdI3UDhxHvcVEZsenLO+7XaU5vOp0u/7V/wZ+plyuQxtrDlZJ+yeg==}
+
+  playwright-core@1.60.0:
+    resolution: {integrity: sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.60.0:
+    resolution: {integrity: sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   pluralize@8.0.0:
     resolution: {integrity: sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==}
@@ -4936,6 +5581,10 @@ packages:
     engines: {node: '>=14'}
     hasBin: true
 
+  pretty-format@27.5.1:
+    resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
+    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
+
   prismjs@1.30.0:
     resolution: {integrity: sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw==}
     engines: {node: '>=6'}
@@ -5004,6 +5653,15 @@ packages:
     resolution: {integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==}
     hasBin: true
 
+  react-docgen-typescript@2.4.0:
+    resolution: {integrity: sha512-ZtAp5XTO5HRzQctjPU0ybY0RRCQO19X/8fxn3w7y2VVTUbGHDKULPTL4ky3vB05euSgG5NpALhEhDPvQ56wvXg==}
+    peerDependencies:
+      typescript: '>= 4.3.x'
+
+  react-docgen@8.0.3:
+    resolution: {integrity: sha512-aEZ9qP+/M+58x2qgfSFEWH1BxLyHe5+qkLNJOZQb5iGS017jpbRnoKhNRrXPeA6RfBrZO5wZrT9DMC1UqE1f1w==}
+    engines: {node: ^20.9.0 || >=22}
+
   react-dom@19.2.6:
     resolution: {integrity: sha512-0prMI+hvBbPjsWnxDLxlCGyM8PN6UuWjEUCYmZhO67xIV9Xasa/r/vDnq+Xyq4Lo27g8QSbO5YzARu0D1Sps3g==}
     peerDependencies:
@@ -5011,6 +5669,9 @@ packages:
 
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
+
+  react-is@17.0.2:
+    resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
 
   react@19.2.6:
     resolution: {integrity: sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q==}
@@ -5038,6 +5699,14 @@ packages:
   real-require@0.2.0:
     resolution: {integrity: sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==}
     engines: {node: '>= 12.13.0'}
+
+  recast@0.23.11:
+    resolution: {integrity: sha512-YTUo+Flmw4ZXiWfQKGcwwc11KnoRAYgzAE2E7mXKCjSviTKShtxBsN6YUUBB2gtaBzKzeKunxhUwNHQuRryhWA==}
+    engines: {node: '>= 4'}
+
+  redent@3.0.0:
+    resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
+    engines: {node: '>=8'}
 
   refa@0.12.1:
     resolution: {integrity: sha512-J8rn6v4DBb2nnFqkqwy6/NnTYMcgLA+sLr0iIO41qpv0n+ngb7ksag2tMRl0inb1bbO/esUwzW1vbJi7K0sI0g==}
@@ -5136,6 +5805,11 @@ packages:
   resolve.exports@2.0.3:
     resolution: {integrity: sha512-OcXjMsGdhL4XnbShKpAcSqPMzQoYkYyhbEaeSko47MjRP9NfEQMhZkXL1DoFlt9LWQn4YttrdnV6X2OiyzBi+A==}
     engines: {node: '>=10'}
+
+  resolve@1.22.12:
+    resolution: {integrity: sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==}
+    engines: {node: '>= 0.4'}
+    hasBin: true
 
   resolve@2.0.0-next.7:
     resolution: {integrity: sha512-tqt+NBWwyaMgw3zDsnygx4CByWjQEJHOPMdslYhppaQSJUtL/D4JO9CcBBlhPoI8lz9oJIDXkwXfhF4aWqP8xQ==}
@@ -5403,6 +6077,21 @@ packages:
     resolution: {integrity: sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==}
     engines: {node: '>= 0.4'}
 
+  storybook@10.4.1:
+    resolution: {integrity: sha512-V1Zd2e+gBFufqAQVZ1JR8KLqALsEZ3JYSBnWwQbKa6zCfWWanR6AFMyuOkLt2gZOgGp3h2Riuz88pGNVTQSG0A==}
+    hasBin: true
+    peerDependencies:
+      '@types/react': ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      prettier: ^2 || ^3
+      vite-plus: ^0.1.15
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      prettier:
+        optional: true
+      vite-plus:
+        optional: true
+
   string-width@4.2.3:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
     engines: {node: '>=8'}
@@ -5462,6 +6151,10 @@ packages:
   strip-bom@5.0.0:
     resolution: {integrity: sha512-p+byADHF7SzEcVnLvc/r3uognM1hUhObuHXxJcgLCfD194XAkaLbjq3Wzb0N5G2tgIjH0dgT708Z51QxMeu60A==}
     engines: {node: '>=12'}
+
+  strip-indent@3.0.0:
+    resolution: {integrity: sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==}
+    engines: {node: '>=8'}
 
   strip-indent@4.1.1:
     resolution: {integrity: sha512-SlyRoSkdh1dYP0PzclLE7r0M9sgbFKKMFXpFRUMNuKhQSbC6VQIGzq3E0qsfvGJaUFJPGv6Ws1NZ/haTAjfbMA==}
@@ -5532,6 +6225,9 @@ packages:
   tiny-inflate@1.0.3:
     resolution: {integrity: sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==}
 
+  tiny-invariant@1.3.3:
+    resolution: {integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==}
+
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
 
@@ -5543,8 +6239,16 @@ packages:
     resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
     engines: {node: '>=12.0.0'}
 
+  tinyrainbow@2.0.0:
+    resolution: {integrity: sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==}
+    engines: {node: '>=14.0.0'}
+
   tinyrainbow@3.1.0:
     resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
+    engines: {node: '>=14.0.0'}
+
+  tinyspy@4.0.4:
+    resolution: {integrity: sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==}
     engines: {node: '>=14.0.0'}
 
   tldts-core@7.3.0:
@@ -5589,6 +6293,10 @@ packages:
     engines: {node: '>=18.12'}
     peerDependencies:
       typescript: '>=4.8.4'
+
+  ts-dedent@2.2.0:
+    resolution: {integrity: sha512-q5W7tVM71e2xjHZTlgfTDoPF/SmqKG5hddq9SzR49CH2hayqRKJtQ4mtRlSxKaJlR/+9rEM+mnBHf7I2/BQcpQ==}
+    engines: {node: '>=6.10'}
 
   tsconfck@3.1.6:
     resolution: {integrity: sha512-ks6Vjr/jEw0P1gmOVwutM3B7fWxoWBL2KRDb1JfqGVawBmO5UsvmWOQFGHBPl5yxYz4eERr19E6L7NMv+Fej4w==}
@@ -5677,6 +6385,9 @@ packages:
   uncrypto@0.1.3:
     resolution: {integrity: sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q==}
 
+  undici-types@6.21.0:
+    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
   undici-types@7.24.6:
     resolution: {integrity: sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==}
 
@@ -5747,6 +6458,10 @@ packages:
   unplugin-utils@0.3.1:
     resolution: {integrity: sha512-5lWVjgi6vuHhJ526bI4nlCOmkCIF3nnfXkCMDeMJrtdvxTs6ZFCM8oNufGTsDbKv/tJ/xj8RpvXjRuPBZJuJog==}
     engines: {node: '>=20.19.0'}
+
+  unplugin@2.3.11:
+    resolution: {integrity: sha512-5uKD0nqiYVzlmCRs01Fhs2BdkEgBS3SAVP6ndrBsuK42iC2+JHyxM05Rm9G8+5mkmRtzMZGY8Ct5+mliZxU/Ww==}
+    engines: {node: '>=18.12.0'}
 
   unplugin@3.0.0:
     resolution: {integrity: sha512-0Mqk3AT2TZCXWKdcoaufeXNukv2mTrEZExeXlHIOZXdqYoHHr4n51pymnwV8x2BOVxwXbK2HLlI7usrqMpycdg==}
@@ -5830,6 +6545,11 @@ packages:
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
 
+  use-sync-external-store@1.6.0:
+    resolution: {integrity: sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
@@ -5865,6 +6585,46 @@ packages:
       sass-embedded: '*'
       stylus: '*'
       sugarss: '*'
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  vite@7.3.3:
+    resolution: {integrity: sha512-/4XH147Ui7OGTjg3HbdWe5arnZQSbfuRzdr9Ec7TQi5I7R+ir0Rlc9GIvD4v0XZurELqA035KVXJXpR61xhiTA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^20.19.0 || >=22.12.0
+      jiti: '>=1.21.0'
+      less: ^4.0.0
+      lightningcss: ^1.21.0
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: '>=0.54.8'
+      sugarss: ^5.0.0
       terser: ^5.16.0
       tsx: ^4.8.1
       yaml: ^2.4.2
@@ -6202,6 +6962,10 @@ packages:
       utf-8-validate:
         optional: true
 
+  wsl-utils@0.1.0:
+    resolution: {integrity: sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw==}
+    engines: {node: '>=18'}
+
   wsl-utils@0.3.1:
     resolution: {integrity: sha512-g/eziiSUNBSsdDJtCLB8bdYEUMj4jR7AGeUo96p/3dTafgjHhpF4RiCFPiRILwjQoDXx5MqkBr4fwWtR3Ky4Wg==}
     engines: {node: '>=20'}
@@ -6241,6 +7005,9 @@ packages:
   y18n@5.0.8:
     resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
     engines: {node: '>=10'}
+
+  yallist@3.1.1:
+    resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
 
   yaml-language-server@1.20.0:
     resolution: {integrity: sha512-qhjK/bzSRZ6HtTvgeFvjNPJGWdZ0+x5NREV/9XZWFjIGezew2b4r5JPy66IfOhd5OA7KeFwk1JfmEbnTvev0cA==}
@@ -6328,6 +7095,8 @@ snapshots:
     dependencies:
       defu: 6.1.7
       many-keys-map: 3.0.3
+
+  '@adobe/css-tools@4.5.0': {}
 
   '@aklinker1/rollup-plugin-visualizer@5.12.0(rollup@4.60.4)':
     dependencies:
@@ -6450,9 +7219,72 @@ snapshots:
       js-tokens: 4.0.0
       picocolors: 1.1.1
 
+  '@babel/compat-data@7.29.7': {}
+
+  '@babel/core@7.29.7':
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      '@babel/generator': 7.29.7
+      '@babel/helper-compilation-targets': 7.29.7
+      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.7)
+      '@babel/helpers': 7.29.7
+      '@babel/parser': 7.29.7
+      '@babel/template': 7.29.7
+      '@babel/traverse': 7.29.7
+      '@babel/types': 7.29.7
+      '@jridgewell/remapping': 2.3.5
+      convert-source-map: 2.0.0
+      debug: 4.4.3
+      gensync: 1.0.0-beta.2
+      json5: 2.2.3
+      semver: 6.3.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/generator@7.29.7':
+    dependencies:
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+      jsesc: 3.1.0
+
+  '@babel/helper-compilation-targets@7.29.7':
+    dependencies:
+      '@babel/compat-data': 7.29.7
+      '@babel/helper-validator-option': 7.29.7
+      browserslist: 4.28.2
+      lru-cache: 5.1.1
+      semver: 6.3.1
+
+  '@babel/helper-globals@7.29.7': {}
+
+  '@babel/helper-module-imports@7.29.7':
+    dependencies:
+      '@babel/traverse': 7.29.7
+      '@babel/types': 7.29.7
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-module-transforms@7.29.7(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-module-imports': 7.29.7
+      '@babel/helper-validator-identifier': 7.29.7
+      '@babel/traverse': 7.29.7
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/helper-string-parser@7.29.7': {}
 
   '@babel/helper-validator-identifier@7.29.7': {}
+
+  '@babel/helper-validator-option@7.29.7': {}
+
+  '@babel/helpers@7.29.7':
+    dependencies:
+      '@babel/template': 7.29.7
+      '@babel/types': 7.29.7
 
   '@babel/parser@7.29.7':
     dependencies:
@@ -6461,6 +7293,24 @@ snapshots:
   '@babel/runtime@7.28.2': {}
 
   '@babel/runtime@7.29.7': {}
+
+  '@babel/template@7.29.7':
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
+
+  '@babel/traverse@7.29.7':
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      '@babel/generator': 7.29.7
+      '@babel/helper-globals': 7.29.7
+      '@babel/parser': 7.29.7
+      '@babel/template': 7.29.7
+      '@babel/types': 7.29.7
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
 
   '@babel/types@7.29.7':
     dependencies:
@@ -6835,6 +7685,12 @@ snapshots:
       '@emnapi/wasi-threads': 1.0.4
       tslib: 2.8.1
 
+  '@emnapi/core@1.9.2':
+    dependencies:
+      '@emnapi/wasi-threads': 1.2.1
+      tslib: 2.8.1
+    optional: true
+
   '@emnapi/runtime@1.10.0':
     dependencies:
       tslib: 2.8.1
@@ -6843,6 +7699,11 @@ snapshots:
   '@emnapi/runtime@1.4.5':
     dependencies:
       tslib: 2.8.1
+
+  '@emnapi/runtime@1.9.2':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
 
   '@emnapi/wasi-threads@1.0.4':
     dependencies:
@@ -7377,6 +8238,14 @@ snapshots:
 
   '@jest/diff-sequences@30.0.1': {}
 
+  '@joshwooding/vite-plugin-react-docgen-typescript@0.7.0(typescript@6.0.3)(vite@7.3.3(@types/node@25.9.1)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.22.3)(yaml@2.9.0))':
+    dependencies:
+      glob: 13.0.6
+      react-docgen-typescript: 2.4.0(typescript@6.0.3)
+      vite: 7.3.3(@types/node@25.9.1)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.22.3)(yaml@2.9.0)
+    optionalDependencies:
+      typescript: 6.0.3
+
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -7417,6 +8286,12 @@ snapshots:
       globby: 11.1.0
       read-yaml-file: 1.1.0
 
+  '@mdx-js/react@3.1.1(@types/react@19.2.15)(react@19.2.6)':
+    dependencies:
+      '@types/mdx': 2.0.13
+      '@types/react': 19.2.15
+      react: 19.2.6
+
   '@napi-rs/wasm-runtime@0.2.4':
     dependencies:
       '@emnapi/core': 1.4.5
@@ -7427,6 +8302,13 @@ snapshots:
     dependencies:
       '@emnapi/core': 1.10.0
       '@emnapi/runtime': 1.10.0
+      '@tybys/wasm-util': 0.10.2
+    optional: true
+
+  '@napi-rs/wasm-runtime@1.1.4(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)':
+    dependencies:
+      '@emnapi/core': 1.9.2
+      '@emnapi/runtime': 1.9.2
       '@tybys/wasm-util': 0.10.2
     optional: true
 
@@ -7474,9 +8356,144 @@ snapshots:
 
   '@oslojs/encoding@1.1.0': {}
 
+  '@oxc-parser/binding-android-arm-eabi@0.127.0':
+    optional: true
+
+  '@oxc-parser/binding-android-arm64@0.127.0':
+    optional: true
+
+  '@oxc-parser/binding-darwin-arm64@0.127.0':
+    optional: true
+
+  '@oxc-parser/binding-darwin-x64@0.127.0':
+    optional: true
+
+  '@oxc-parser/binding-freebsd-x64@0.127.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-arm-gnueabihf@0.127.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-arm-musleabihf@0.127.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-arm64-gnu@0.127.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-arm64-musl@0.127.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-ppc64-gnu@0.127.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-riscv64-gnu@0.127.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-riscv64-musl@0.127.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-s390x-gnu@0.127.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-x64-gnu@0.127.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-x64-musl@0.127.0':
+    optional: true
+
+  '@oxc-parser/binding-openharmony-arm64@0.127.0':
+    optional: true
+
+  '@oxc-parser/binding-wasm32-wasi@0.127.0':
+    dependencies:
+      '@emnapi/core': 1.9.2
+      '@emnapi/runtime': 1.9.2
+      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)
+    optional: true
+
+  '@oxc-parser/binding-win32-arm64-msvc@0.127.0':
+    optional: true
+
+  '@oxc-parser/binding-win32-ia32-msvc@0.127.0':
+    optional: true
+
+  '@oxc-parser/binding-win32-x64-msvc@0.127.0':
+    optional: true
+
+  '@oxc-project/types@0.127.0': {}
+
   '@oxc-project/types@0.132.0': {}
 
+  '@oxc-resolver/binding-android-arm-eabi@11.19.1':
+    optional: true
+
+  '@oxc-resolver/binding-android-arm64@11.19.1':
+    optional: true
+
+  '@oxc-resolver/binding-darwin-arm64@11.19.1':
+    optional: true
+
+  '@oxc-resolver/binding-darwin-x64@11.19.1':
+    optional: true
+
+  '@oxc-resolver/binding-freebsd-x64@11.19.1':
+    optional: true
+
+  '@oxc-resolver/binding-linux-arm-gnueabihf@11.19.1':
+    optional: true
+
+  '@oxc-resolver/binding-linux-arm-musleabihf@11.19.1':
+    optional: true
+
+  '@oxc-resolver/binding-linux-arm64-gnu@11.19.1':
+    optional: true
+
+  '@oxc-resolver/binding-linux-arm64-musl@11.19.1':
+    optional: true
+
+  '@oxc-resolver/binding-linux-ppc64-gnu@11.19.1':
+    optional: true
+
+  '@oxc-resolver/binding-linux-riscv64-gnu@11.19.1':
+    optional: true
+
+  '@oxc-resolver/binding-linux-riscv64-musl@11.19.1':
+    optional: true
+
+  '@oxc-resolver/binding-linux-s390x-gnu@11.19.1':
+    optional: true
+
+  '@oxc-resolver/binding-linux-x64-gnu@11.19.1':
+    optional: true
+
+  '@oxc-resolver/binding-linux-x64-musl@11.19.1':
+    optional: true
+
+  '@oxc-resolver/binding-openharmony-arm64@11.19.1':
+    optional: true
+
+  '@oxc-resolver/binding-wasm32-wasi@11.19.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
+    dependencies:
+      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+    transitivePeerDependencies:
+      - '@emnapi/core'
+      - '@emnapi/runtime'
+    optional: true
+
+  '@oxc-resolver/binding-win32-arm64-msvc@11.19.1':
+    optional: true
+
+  '@oxc-resolver/binding-win32-ia32-msvc@11.19.1':
+    optional: true
+
+  '@oxc-resolver/binding-win32-x64-msvc@11.19.1':
+    optional: true
+
   '@package-json/types@0.0.12': {}
+
+  '@playwright/test@1.60.0':
+    dependencies:
+      playwright: 1.60.0
 
   '@pnpm/config.env-replace@1.1.0': {}
 
@@ -7683,6 +8700,101 @@ snapshots:
 
   '@standard-schema/spec@1.1.0': {}
 
+  '@storybook/addon-docs@10.4.1(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(esbuild@0.28.0)(rollup@4.60.4)(storybook@10.4.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.1)(@types/react@19.2.15)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(vite@7.3.3(@types/node@25.9.1)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.22.3)(yaml@2.9.0))':
+    dependencies:
+      '@mdx-js/react': 3.1.1(@types/react@19.2.15)(react@19.2.6)
+      '@storybook/csf-plugin': 10.4.1(esbuild@0.28.0)(rollup@4.60.4)(storybook@10.4.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.1)(@types/react@19.2.15)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(vite@7.3.3(@types/node@25.9.1)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.22.3)(yaml@2.9.0))
+      '@storybook/icons': 2.0.2(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@storybook/react-dom-shim': 10.4.1(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(storybook@10.4.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.1)(@types/react@19.2.15)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
+      storybook: 10.4.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.1)(@types/react@19.2.15)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      ts-dedent: 2.2.0
+    optionalDependencies:
+      '@types/react': 19.2.15
+    transitivePeerDependencies:
+      - '@types/react-dom'
+      - esbuild
+      - rollup
+      - vite
+      - webpack
+
+  '@storybook/builder-vite@10.4.1(esbuild@0.28.0)(rollup@4.60.4)(storybook@10.4.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.1)(@types/react@19.2.15)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(vite@7.3.3(@types/node@25.9.1)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.22.3)(yaml@2.9.0))':
+    dependencies:
+      '@storybook/csf-plugin': 10.4.1(esbuild@0.28.0)(rollup@4.60.4)(storybook@10.4.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.1)(@types/react@19.2.15)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(vite@7.3.3(@types/node@25.9.1)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.22.3)(yaml@2.9.0))
+      storybook: 10.4.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.1)(@types/react@19.2.15)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      ts-dedent: 2.2.0
+      vite: 7.3.3(@types/node@25.9.1)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.22.3)(yaml@2.9.0)
+    transitivePeerDependencies:
+      - esbuild
+      - rollup
+      - webpack
+
+  '@storybook/csf-plugin@10.4.1(esbuild@0.28.0)(rollup@4.60.4)(storybook@10.4.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.1)(@types/react@19.2.15)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(vite@7.3.3(@types/node@25.9.1)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.22.3)(yaml@2.9.0))':
+    dependencies:
+      storybook: 10.4.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.1)(@types/react@19.2.15)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      unplugin: 2.3.11
+    optionalDependencies:
+      esbuild: 0.28.0
+      rollup: 4.60.4
+      vite: 7.3.3(@types/node@25.9.1)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.22.3)(yaml@2.9.0)
+
+  '@storybook/global@5.0.0': {}
+
+  '@storybook/icons@2.0.2(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+    dependencies:
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
+
+  '@storybook/react-dom-shim@10.4.1(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(storybook@10.4.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.1)(@types/react@19.2.15)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))':
+    dependencies:
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
+      storybook: 10.4.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.1)(@types/react@19.2.15)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+    optionalDependencies:
+      '@types/react': 19.2.15
+      '@types/react-dom': 19.2.3(@types/react@19.2.15)
+
+  '@storybook/react-vite@10.4.1(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(esbuild@0.28.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(rollup@4.60.4)(storybook@10.4.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.1)(@types/react@19.2.15)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(typescript@6.0.3)(vite@7.3.3(@types/node@25.9.1)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.22.3)(yaml@2.9.0))':
+    dependencies:
+      '@joshwooding/vite-plugin-react-docgen-typescript': 0.7.0(typescript@6.0.3)(vite@7.3.3(@types/node@25.9.1)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.22.3)(yaml@2.9.0))
+      '@rollup/pluginutils': 5.3.0(rollup@4.60.4)
+      '@storybook/builder-vite': 10.4.1(esbuild@0.28.0)(rollup@4.60.4)(storybook@10.4.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.1)(@types/react@19.2.15)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(vite@7.3.3(@types/node@25.9.1)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.22.3)(yaml@2.9.0))
+      '@storybook/react': 10.4.1(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(storybook@10.4.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.1)(@types/react@19.2.15)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(typescript@6.0.3)
+      empathic: 2.0.1
+      magic-string: 0.30.21
+      react: 19.2.6
+      react-docgen: 8.0.3
+      react-dom: 19.2.6(react@19.2.6)
+      resolve: 1.22.12
+      storybook: 10.4.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.1)(@types/react@19.2.15)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      tsconfig-paths: 4.2.0
+      vite: 7.3.3(@types/node@25.9.1)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.22.3)(yaml@2.9.0)
+    transitivePeerDependencies:
+      - '@types/react'
+      - '@types/react-dom'
+      - esbuild
+      - rollup
+      - supports-color
+      - typescript
+      - webpack
+
+  '@storybook/react@10.4.1(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(storybook@10.4.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.1)(@types/react@19.2.15)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(typescript@6.0.3)':
+    dependencies:
+      '@storybook/global': 5.0.0
+      '@storybook/react-dom-shim': 10.4.1(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(storybook@10.4.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.1)(@types/react@19.2.15)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))
+      react: 19.2.6
+      react-docgen: 8.0.3
+      react-docgen-typescript: 2.4.0(typescript@6.0.3)
+      react-dom: 19.2.6(react@19.2.6)
+      storybook: 10.4.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.1)(@types/react@19.2.15)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+    optionalDependencies:
+      '@types/react': 19.2.15
+      '@types/react-dom': 19.2.3(@types/react@19.2.15)
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
+
   '@tailwindcss/node@4.3.0':
     dependencies:
       '@jridgewell/remapping': 2.3.5
@@ -7744,12 +8856,12 @@ snapshots:
       '@tailwindcss/oxide-win32-arm64-msvc': 4.3.0
       '@tailwindcss/oxide-win32-x64-msvc': 4.3.0
 
-  '@tailwindcss/vite@4.3.0(vite@6.4.2(@types/node@25.9.1)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.22.3)(yaml@2.9.0))':
+  '@tailwindcss/vite@4.3.0(vite@7.3.3(@types/node@25.9.1)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.22.3)(yaml@2.9.0))':
     dependencies:
       '@tailwindcss/node': 4.3.0
       '@tailwindcss/oxide': 4.3.0
       tailwindcss: 4.3.0
-      vite: 6.4.2(@types/node@25.9.1)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.22.3)(yaml@2.9.0)
+      vite: 7.3.3(@types/node@25.9.1)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.22.3)(yaml@2.9.0)
 
   '@tailwindcss/vite@4.3.0(vite@8.0.14(@types/node@25.9.1)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.22.3)(yaml@2.9.0))':
     dependencies:
@@ -7757,6 +8869,30 @@ snapshots:
       '@tailwindcss/oxide': 4.3.0
       tailwindcss: 4.3.0
       vite: 8.0.14(@types/node@25.9.1)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.22.3)(yaml@2.9.0)
+
+  '@testing-library/dom@10.4.1':
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      '@babel/runtime': 7.29.7
+      '@types/aria-query': 5.0.4
+      aria-query: 5.3.0
+      dom-accessibility-api: 0.5.16
+      lz-string: 1.5.0
+      picocolors: 1.1.1
+      pretty-format: 27.5.1
+
+  '@testing-library/jest-dom@6.9.1':
+    dependencies:
+      '@adobe/css-tools': 4.5.0
+      aria-query: 5.3.2
+      css.escape: 1.5.1
+      dom-accessibility-api: 0.6.3
+      picocolors: 1.1.1
+      redent: 3.0.0
+
+  '@testing-library/user-event@14.6.1(@testing-library/dom@10.4.1)':
+    dependencies:
+      '@testing-library/dom': 10.4.1
 
   '@tybys/wasm-util@0.10.2':
     dependencies:
@@ -7767,10 +8903,38 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
+  '@types/aria-query@5.0.4': {}
+
+  '@types/babel__core@7.20.5':
+    dependencies:
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
+      '@types/babel__generator': 7.27.0
+      '@types/babel__template': 7.4.4
+      '@types/babel__traverse': 7.28.0
+
+  '@types/babel__generator@7.27.0':
+    dependencies:
+      '@babel/types': 7.29.7
+
+  '@types/babel__template@7.4.4':
+    dependencies:
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
+
+  '@types/babel__traverse@7.28.0':
+    dependencies:
+      '@babel/types': 7.29.7
+
   '@types/chai@5.2.3':
     dependencies:
       '@types/deep-eql': 4.0.2
       assertion-error: 2.0.1
+
+  '@types/chrome@0.0.287':
+    dependencies:
+      '@types/filesystem': 0.0.36
+      '@types/har-format': 1.2.16
 
   '@types/chrome@0.1.42':
     dependencies:
@@ -7782,6 +8946,8 @@ snapshots:
       '@types/ms': 2.1.0
 
   '@types/deep-eql@4.0.2': {}
+
+  '@types/doctrine@0.0.9': {}
 
   '@types/estree@1.0.8': {}
 
@@ -7805,6 +8971,8 @@ snapshots:
     dependencies:
       '@types/unist': 3.0.3
 
+  '@types/mdx@2.0.13': {}
+
   '@types/minimatch@3.0.5': {}
 
   '@types/ms@2.1.0': {}
@@ -7814,6 +8982,10 @@ snapshots:
       '@types/unist': 3.0.3
 
   '@types/node@12.20.55': {}
+
+  '@types/node@22.19.19':
+    dependencies:
+      undici-types: 6.21.0
 
   '@types/node@25.9.1':
     dependencies:
@@ -7826,6 +8998,8 @@ snapshots:
   '@types/react@19.2.15':
     dependencies:
       csstype: 3.2.3
+
+  '@types/resolve@1.20.6': {}
 
   '@types/unist@3.0.3': {}
 
@@ -8005,6 +9179,14 @@ snapshots:
       '@rolldown/pluginutils': 1.0.1
       vite: 8.0.14(@types/node@25.9.1)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.22.3)(yaml@2.9.0)
 
+  '@vitest/expect@3.2.4':
+    dependencies:
+      '@types/chai': 5.2.3
+      '@vitest/spy': 3.2.4
+      '@vitest/utils': 3.2.4
+      chai: 5.3.3
+      tinyrainbow: 2.0.0
+
   '@vitest/expect@4.1.7':
     dependencies:
       '@standard-schema/spec': 1.1.0
@@ -8022,6 +9204,10 @@ snapshots:
     optionalDependencies:
       vite: 8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.22.3)(yaml@2.9.0)
 
+  '@vitest/pretty-format@3.2.4':
+    dependencies:
+      tinyrainbow: 2.0.0
+
   '@vitest/pretty-format@4.1.7':
     dependencies:
       tinyrainbow: 3.1.0
@@ -8038,7 +9224,17 @@ snapshots:
       magic-string: 0.30.21
       pathe: 2.0.3
 
+  '@vitest/spy@3.2.4':
+    dependencies:
+      tinyspy: 4.0.4
+
   '@vitest/spy@4.1.7': {}
+
+  '@vitest/utils@3.2.4':
+    dependencies:
+      '@vitest/pretty-format': 3.2.4
+      loupe: 3.2.1
+      tinyrainbow: 2.0.0
 
   '@vitest/utils@4.1.7':
     dependencies:
@@ -8096,6 +9292,8 @@ snapshots:
 
   '@vscode/l10n@0.0.18': {}
 
+  '@webcontainer/env@1.1.1': {}
+
   '@webext-core/fake-browser@1.5.0':
     dependencies:
       '@types/webextension-polyfill': 0.10.7
@@ -8112,11 +9310,11 @@ snapshots:
       '@types/filesystem': 0.0.36
       '@types/har-format': 1.2.16
 
-  '@wxt-dev/module-react@1.2.2(vite@8.0.14(@types/node@25.9.1)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.22.3)(yaml@2.9.0))(wxt@0.20.26(@types/node@25.9.1)(eslint@9.39.4(jiti@2.6.1))(jiti@2.6.1)(rolldown@1.0.2)(rollup@4.60.4)(tsx@4.22.3)(yaml@2.9.0))':
+  '@wxt-dev/module-react@1.2.2(vite@8.0.14(@types/node@25.9.1)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.22.3)(yaml@2.9.0))(wxt@0.20.26(@types/node@25.9.1)(eslint@9.39.4(jiti@2.6.1))(jiti@2.6.1)(oxc-parser@0.127.0)(rolldown@1.0.2)(rollup@4.60.4)(tsx@4.22.3)(yaml@2.9.0))':
     dependencies:
       '@vitejs/plugin-react': 6.0.2(vite@8.0.14(@types/node@25.9.1)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.22.3)(yaml@2.9.0))
       vite: 8.0.14(@types/node@25.9.1)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.22.3)(yaml@2.9.0)
-      wxt: 0.20.26(@types/node@25.9.1)(eslint@9.39.4(jiti@2.6.1))(jiti@2.6.1)(rolldown@1.0.2)(rollup@4.60.4)(tsx@4.22.3)(yaml@2.9.0)
+      wxt: 0.20.26(@types/node@25.9.1)(eslint@9.39.4(jiti@2.6.1))(jiti@2.6.1)(oxc-parser@0.127.0)(rolldown@1.0.2)(rollup@4.60.4)(tsx@4.22.3)(yaml@2.9.0)
     transitivePeerDependencies:
       - '@rolldown/plugin-babel'
       - babel-plugin-react-compiler
@@ -8177,6 +9375,8 @@ snapshots:
     dependencies:
       color-convert: 2.0.1
 
+  ansi-styles@5.2.0: {}
+
   ansi-styles@6.2.3: {}
 
   anymatch@3.1.3:
@@ -8189,6 +9389,10 @@ snapshots:
       sprintf-js: 1.0.3
 
   argparse@2.0.1: {}
+
+  aria-query@5.3.0:
+    dependencies:
+      dequal: 2.0.3
 
   aria-query@5.3.2: {}
 
@@ -8262,6 +9466,10 @@ snapshots:
   assertion-error@2.0.1: {}
 
   ast-types-flow@0.0.8: {}
+
+  ast-types@0.16.1:
+    dependencies:
+      tslib: 2.8.1
 
   astro@5.18.1(@types/node@25.9.1)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.60.4)(tsx@4.22.3)(typescript@6.0.3)(yaml@2.9.0):
     dependencies:
@@ -8527,6 +9735,14 @@ snapshots:
 
   ccount@2.0.1: {}
 
+  chai@5.3.3:
+    dependencies:
+      assertion-error: 2.0.1
+      check-error: 2.1.3
+      deep-eql: 5.0.2
+      loupe: 3.2.1
+      pathval: 2.0.1
+
   chai@6.2.2: {}
 
   chalk@4.1.2:
@@ -8545,6 +9761,8 @@ snapshots:
   character-entities@2.0.2: {}
 
   chardet@2.1.1: {}
+
+  check-error@2.1.3: {}
 
   chokidar@4.0.3:
     dependencies:
@@ -8731,6 +9949,8 @@ snapshots:
 
   css-what@6.2.2: {}
 
+  css.escape@1.5.1: {}
+
   cssesc@3.0.0: {}
 
   csso@5.0.5:
@@ -8783,6 +10003,8 @@ snapshots:
   decode-named-character-reference@1.3.0:
     dependencies:
       character-entities: 2.0.2
+
+  deep-eql@5.0.2: {}
 
   deep-extend@0.6.0: {}
 
@@ -8849,6 +10071,14 @@ snapshots:
     dependencies:
       esutils: 2.0.3
 
+  doctrine@3.0.0:
+    dependencies:
+      esutils: 2.0.3
+
+  dom-accessibility-api@0.5.16: {}
+
+  dom-accessibility-api@0.6.3: {}
+
   dom-serializer@2.0.0:
     dependencies:
       domelementtype: 2.3.0
@@ -8909,6 +10139,8 @@ snapshots:
   emoji-regex@8.0.0: {}
 
   emoji-regex@9.2.2: {}
+
+  empathic@2.0.1: {}
 
   end-of-stream@1.4.5:
     dependencies:
@@ -9509,6 +10741,9 @@ snapshots:
       jsonfile: 4.0.0
       universalify: 0.1.2
 
+  fsevents@2.3.2:
+    optional: true
+
   fsevents@2.3.3:
     optional: true
 
@@ -9537,6 +10772,8 @@ snapshots:
       winreg: 0.0.12
 
   generator-function@2.0.1: {}
+
+  gensync@1.0.0-beta.2: {}
 
   get-caller-file@2.0.5: {}
 
@@ -9593,6 +10830,12 @@ snapshots:
       is-glob: 4.0.3
 
   glob-to-regexp@0.4.1: {}
+
+  glob@13.0.6:
+    dependencies:
+      minimatch: 10.2.5
+      minipass: 7.1.3
+      path-scurry: 2.0.2
 
   global-directory@4.0.1:
     dependencies:
@@ -9800,6 +11043,8 @@ snapshots:
   import-meta-resolve@4.2.0: {}
 
   imurmurhash@0.1.4: {}
+
+  indent-string@4.0.0: {}
 
   indent-string@5.0.0: {}
 
@@ -10329,7 +11574,15 @@ snapshots:
     dependencies:
       js-tokens: 4.0.0
 
+  loupe@3.2.1: {}
+
   lru-cache@11.5.0: {}
+
+  lru-cache@5.1.1:
+    dependencies:
+      yallist: 3.1.1
+
+  lz-string@1.5.0: {}
 
   magic-string@0.30.21:
     dependencies:
@@ -10685,6 +11938,8 @@ snapshots:
 
   mimic-function@5.0.1: {}
 
+  min-indent@1.0.1: {}
+
   miniflare@4.20260526.0:
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
@@ -10710,6 +11965,8 @@ snapshots:
       brace-expansion: 1.1.14
 
   minimist@1.2.8: {}
+
+  minipass@7.1.3: {}
 
   mlly@1.8.2:
     dependencies:
@@ -10985,6 +12242,13 @@ snapshots:
       regex: 6.1.0
       regex-recursion: 6.0.2
 
+  open@10.2.0:
+    dependencies:
+      default-browser: 5.5.0
+      define-lazy-prop: 3.0.0
+      is-inside-container: 1.0.0
+      wsl-utils: 0.1.0
+
   open@11.0.0:
     dependencies:
       default-browser: 5.5.0
@@ -11029,6 +12293,57 @@ snapshots:
       get-intrinsic: 1.3.0
       object-keys: 1.1.1
       safe-push-apply: 1.0.0
+
+  oxc-parser@0.127.0:
+    dependencies:
+      '@oxc-project/types': 0.127.0
+    optionalDependencies:
+      '@oxc-parser/binding-android-arm-eabi': 0.127.0
+      '@oxc-parser/binding-android-arm64': 0.127.0
+      '@oxc-parser/binding-darwin-arm64': 0.127.0
+      '@oxc-parser/binding-darwin-x64': 0.127.0
+      '@oxc-parser/binding-freebsd-x64': 0.127.0
+      '@oxc-parser/binding-linux-arm-gnueabihf': 0.127.0
+      '@oxc-parser/binding-linux-arm-musleabihf': 0.127.0
+      '@oxc-parser/binding-linux-arm64-gnu': 0.127.0
+      '@oxc-parser/binding-linux-arm64-musl': 0.127.0
+      '@oxc-parser/binding-linux-ppc64-gnu': 0.127.0
+      '@oxc-parser/binding-linux-riscv64-gnu': 0.127.0
+      '@oxc-parser/binding-linux-riscv64-musl': 0.127.0
+      '@oxc-parser/binding-linux-s390x-gnu': 0.127.0
+      '@oxc-parser/binding-linux-x64-gnu': 0.127.0
+      '@oxc-parser/binding-linux-x64-musl': 0.127.0
+      '@oxc-parser/binding-openharmony-arm64': 0.127.0
+      '@oxc-parser/binding-wasm32-wasi': 0.127.0
+      '@oxc-parser/binding-win32-arm64-msvc': 0.127.0
+      '@oxc-parser/binding-win32-ia32-msvc': 0.127.0
+      '@oxc-parser/binding-win32-x64-msvc': 0.127.0
+
+  oxc-resolver@11.19.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0):
+    optionalDependencies:
+      '@oxc-resolver/binding-android-arm-eabi': 11.19.1
+      '@oxc-resolver/binding-android-arm64': 11.19.1
+      '@oxc-resolver/binding-darwin-arm64': 11.19.1
+      '@oxc-resolver/binding-darwin-x64': 11.19.1
+      '@oxc-resolver/binding-freebsd-x64': 11.19.1
+      '@oxc-resolver/binding-linux-arm-gnueabihf': 11.19.1
+      '@oxc-resolver/binding-linux-arm-musleabihf': 11.19.1
+      '@oxc-resolver/binding-linux-arm64-gnu': 11.19.1
+      '@oxc-resolver/binding-linux-arm64-musl': 11.19.1
+      '@oxc-resolver/binding-linux-ppc64-gnu': 11.19.1
+      '@oxc-resolver/binding-linux-riscv64-gnu': 11.19.1
+      '@oxc-resolver/binding-linux-riscv64-musl': 11.19.1
+      '@oxc-resolver/binding-linux-s390x-gnu': 11.19.1
+      '@oxc-resolver/binding-linux-x64-gnu': 11.19.1
+      '@oxc-resolver/binding-linux-x64-musl': 11.19.1
+      '@oxc-resolver/binding-openharmony-arm64': 11.19.1
+      '@oxc-resolver/binding-wasm32-wasi': 11.19.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+      '@oxc-resolver/binding-win32-arm64-msvc': 11.19.1
+      '@oxc-resolver/binding-win32-ia32-msvc': 11.19.1
+      '@oxc-resolver/binding-win32-x64-msvc': 11.19.1
+    transitivePeerDependencies:
+      - '@emnapi/core'
+      - '@emnapi/runtime'
 
   p-filter@2.1.0:
     dependencies:
@@ -11124,11 +12439,18 @@ snapshots:
 
   path-parse@1.0.7: {}
 
+  path-scurry@2.0.2:
+    dependencies:
+      lru-cache: 11.5.0
+      minipass: 7.1.3
+
   path-to-regexp@6.3.0: {}
 
   path-type@4.0.0: {}
 
   pathe@2.0.3: {}
+
+  pathval@2.0.1: {}
 
   perfect-debounce@2.1.0: {}
 
@@ -11174,6 +12496,14 @@ snapshots:
       exsolve: 1.0.8
       pathe: 2.0.3
 
+  playwright-core@1.60.0: {}
+
+  playwright@1.60.0:
+    dependencies:
+      playwright-core: 1.60.0
+    optionalDependencies:
+      fsevents: 2.3.2
+
   pluralize@8.0.0: {}
 
   possible-typed-array-names@1.1.0: {}
@@ -11195,6 +12525,12 @@ snapshots:
   prettier@2.8.8: {}
 
   prettier@3.8.3: {}
+
+  pretty-format@27.5.1:
+    dependencies:
+      ansi-regex: 5.0.1
+      ansi-styles: 5.2.0
+      react-is: 17.0.2
 
   prismjs@1.30.0: {}
 
@@ -11268,12 +12604,33 @@ snapshots:
       minimist: 1.2.8
       strip-json-comments: 2.0.1
 
+  react-docgen-typescript@2.4.0(typescript@6.0.3):
+    dependencies:
+      typescript: 6.0.3
+
+  react-docgen@8.0.3:
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/traverse': 7.29.7
+      '@babel/types': 7.29.7
+      '@types/babel__core': 7.20.5
+      '@types/babel__traverse': 7.28.0
+      '@types/doctrine': 0.0.9
+      '@types/resolve': 1.20.6
+      doctrine: 3.0.0
+      resolve: 1.22.12
+      strip-indent: 4.1.1
+    transitivePeerDependencies:
+      - supports-color
+
   react-dom@19.2.6(react@19.2.6):
     dependencies:
       react: 19.2.6
       scheduler: 0.27.0
 
   react-is@16.13.1: {}
+
+  react-is@17.0.2: {}
 
   react@19.2.6: {}
 
@@ -11305,6 +12662,19 @@ snapshots:
   readdirp@5.0.0: {}
 
   real-require@0.2.0: {}
+
+  recast@0.23.11:
+    dependencies:
+      ast-types: 0.16.1
+      esprima: 4.0.1
+      source-map: 0.6.1
+      tiny-invariant: 1.3.3
+      tslib: 2.8.1
+
+  redent@3.0.0:
+    dependencies:
+      indent-string: 4.0.0
+      strip-indent: 3.0.0
 
   refa@0.12.1:
     dependencies:
@@ -11440,6 +12810,13 @@ snapshots:
   resolve-pkg-maps@1.0.0: {}
 
   resolve.exports@2.0.3: {}
+
+  resolve@1.22.12:
+    dependencies:
+      es-errors: 1.3.0
+      is-core-module: 2.16.2
+      path-parse: 1.0.7
+      supports-preserve-symlinks-flag: 1.0.0
 
   resolve@2.0.0-next.7:
     dependencies:
@@ -11792,6 +13169,35 @@ snapshots:
       es-errors: 1.3.0
       internal-slot: 1.1.0
 
+  storybook@10.4.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.1)(@types/react@19.2.15)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
+    dependencies:
+      '@storybook/global': 5.0.0
+      '@storybook/icons': 2.0.2(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@testing-library/jest-dom': 6.9.1
+      '@testing-library/user-event': 14.6.1(@testing-library/dom@10.4.1)
+      '@vitest/expect': 3.2.4
+      '@vitest/spy': 3.2.4
+      '@webcontainer/env': 1.1.1
+      esbuild: 0.27.7
+      open: 10.2.0
+      oxc-parser: 0.127.0
+      oxc-resolver: 11.19.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+      recast: 0.23.11
+      semver: 7.8.1
+      use-sync-external-store: 1.6.0(react@19.2.6)
+      ws: 8.20.1
+    optionalDependencies:
+      '@types/react': 19.2.15
+      prettier: 3.8.3
+    transitivePeerDependencies:
+      - '@emnapi/core'
+      - '@emnapi/runtime'
+      - '@testing-library/dom'
+      - bufferutil
+      - react
+      - react-dom
+      - utf-8-validate
+
   string-width@4.2.3:
     dependencies:
       emoji-regex: 8.0.0
@@ -11884,6 +13290,10 @@ snapshots:
 
   strip-bom@5.0.0: {}
 
+  strip-indent@3.0.0:
+    dependencies:
+      min-indent: 1.0.1
+
   strip-indent@4.1.1: {}
 
   strip-json-comments@2.0.1: {}
@@ -11944,6 +13354,8 @@ snapshots:
 
   tiny-inflate@1.0.3: {}
 
+  tiny-invariant@1.3.3: {}
+
   tinybench@2.9.0: {}
 
   tinyexec@1.2.2: {}
@@ -11953,7 +13365,11 @@ snapshots:
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
 
+  tinyrainbow@2.0.0: {}
+
   tinyrainbow@3.1.0: {}
+
+  tinyspy@4.0.4: {}
 
   tldts-core@7.3.0: {}
 
@@ -11986,6 +13402,8 @@ snapshots:
   ts-api-utils@2.5.0(typescript@6.0.3):
     dependencies:
       typescript: 6.0.3
+
+  ts-dedent@2.2.0: {}
 
   tsconfck@3.1.6(typescript@6.0.3):
     optionalDependencies:
@@ -12082,6 +13500,8 @@ snapshots:
 
   uncrypto@0.1.3: {}
 
+  undici-types@6.21.0: {}
+
   undici-types@7.24.6: {}
 
   undici@7.24.8: {}
@@ -12108,7 +13528,7 @@ snapshots:
       ofetch: 1.5.1
       ohash: 2.0.11
 
-  unimport@6.3.0(rolldown@1.0.2):
+  unimport@6.3.0(oxc-parser@0.127.0)(rolldown@1.0.2):
     dependencies:
       acorn: 8.16.0
       escape-string-regexp: 5.0.0
@@ -12125,6 +13545,7 @@ snapshots:
       unplugin: 3.0.0
       unplugin-utils: 0.3.1
     optionalDependencies:
+      oxc-parser: 0.127.0
       rolldown: 1.0.2
 
   unist-util-find-after@5.0.0:
@@ -12177,6 +13598,13 @@ snapshots:
     dependencies:
       pathe: 2.0.3
       picomatch: 4.0.4
+
+  unplugin@2.3.11:
+    dependencies:
+      '@jridgewell/remapping': 2.3.5
+      acorn: 8.16.0
+      picomatch: 4.0.4
+      webpack-virtual-modules: 0.6.2
 
   unplugin@3.0.0:
     dependencies:
@@ -12245,6 +13673,10 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
+  use-sync-external-store@1.6.0(react@19.2.6):
+    dependencies:
+      react: 19.2.6
+
   util-deprecate@1.0.2: {}
 
   uuid@8.3.2: {}
@@ -12288,6 +13720,22 @@ snapshots:
   vite@6.4.2(@types/node@25.9.1)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.22.3)(yaml@2.9.0):
     dependencies:
       esbuild: 0.25.12
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+      postcss: 8.5.15
+      rollup: 4.60.4
+      tinyglobby: 0.2.16
+    optionalDependencies:
+      '@types/node': 25.9.1
+      fsevents: 2.3.3
+      jiti: 2.6.1
+      lightningcss: 1.32.0
+      tsx: 4.22.3
+      yaml: 2.9.0
+
+  vite@7.3.3(@types/node@25.9.1)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.22.3)(yaml@2.9.0):
+    dependencies:
+      esbuild: 0.27.7
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
       postcss: 8.5.15
@@ -12630,12 +14078,16 @@ snapshots:
 
   ws@8.20.1: {}
 
+  wsl-utils@0.1.0:
+    dependencies:
+      is-wsl: 3.1.1
+
   wsl-utils@0.3.1:
     dependencies:
       is-wsl: 3.1.1
       powershell-utils: 0.1.0
 
-  wxt@0.20.26(@types/node@25.9.1)(eslint@9.39.4(jiti@2.6.1))(jiti@2.6.1)(rolldown@1.0.2)(rollup@4.60.4)(tsx@4.22.3)(yaml@2.9.0):
+  wxt@0.20.26(@types/node@25.9.1)(eslint@9.39.4(jiti@2.6.1))(jiti@2.6.1)(oxc-parser@0.127.0)(rolldown@1.0.2)(rollup@4.60.4)(tsx@4.22.3)(yaml@2.9.0):
     dependencies:
       '@1natsu/wait-element': 4.2.0
       '@aklinker1/rollup-plugin-visualizer': 5.12.0(rollup@4.60.4)
@@ -12675,7 +14127,7 @@ snapshots:
       publish-browser-extension: 4.0.5
       scule: 1.3.0
       tinyglobby: 0.2.16
-      unimport: 6.3.0(rolldown@1.0.2)
+      unimport: 6.3.0(oxc-parser@0.127.0)(rolldown@1.0.2)
       vite: 8.0.14(@types/node@25.9.1)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.22.3)(yaml@2.9.0)
       vite-node: 6.0.0(@types/node@25.9.1)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.22.3)(yaml@2.9.0)
       web-ext-run: 0.2.4
@@ -12715,6 +14167,8 @@ snapshots:
   xxhash-wasm@1.1.0: {}
 
   y18n@5.0.8: {}
+
+  yallist@3.1.1: {}
 
   yaml-language-server@1.20.0:
     dependencies:

--- a/process-compose.yaml
+++ b/process-compose.yaml
@@ -7,6 +7,8 @@ version: '0.5'
 #   - `extension` runs WXT in Chromium dev mode (launches a browser).
 #   - `extension-firefox` is the same for Firefox, disabled by default.
 #   - `marketing` runs the Astro dev server on :4321.
+#   - `storybook` runs the @movar/ui Storybook on :6006.
+#   - `marketing-storybook` runs the @movar/marketing Storybook on :6007.
 
 processes:
   extension:
@@ -34,6 +36,40 @@ processes:
       period_seconds: 3
       timeout_seconds: 3
       failure_threshold: 30
+    availability:
+      restart: on_failure
+      backoff_seconds: 3
+
+  storybook:
+    namespace: app
+    command: pnpm --filter @movar/ui storybook
+    # Storybook's first boot compiles every story file via Vite — slower than
+    # WXT/Astro's lazy entry-only build. Give the readiness probe a longer
+    # warm-up before it starts polling, and a generous failure budget so a
+    # cold install doesn't restart-loop the process.
+    readiness_probe:
+      exec:
+        command: bash -c 'curl -sf http://127.0.0.1:${STORYBOOK_PORT:-6006}/ >/dev/null'
+      initial_delay_seconds: 8
+      period_seconds: 3
+      timeout_seconds: 3
+      failure_threshold: 60
+    availability:
+      restart: on_failure
+      backoff_seconds: 3
+
+  marketing-storybook:
+    namespace: app
+    command: pnpm --filter @movar/marketing storybook
+    # Same cold-start cost as the @movar/ui Storybook above — Vite has to
+    # compile every story file before the readiness probe can succeed.
+    readiness_probe:
+      exec:
+        command: bash -c 'curl -sf http://127.0.0.1:${MARKETING_STORYBOOK_PORT:-6007}/ >/dev/null'
+      initial_delay_seconds: 8
+      period_seconds: 3
+      timeout_seconds: 3
+      failure_threshold: 60
     availability:
       restart: on_failure
       backoff_seconds: 3


### PR DESCRIPTION
Branch-WIP commit consolidating several in-flight changes; per-concern split deferred. Each block is self-contained.

UA-language exonyms (the branch's headline change)
- apps/extension/src/lib/lang-codes.ts: add Ukrainian-language exonyms for ru/pl/de/fr/es/it — bare adjective ("російська"), "X мова" phrase, and adverbial "по-Xи" forms. Without these, CS-Cart/OpenCart UA templates that ship only `title="Російська мова"` on the switch link slip past the picker entirely.
- apps/extension/src/lib/lang-codes.test.ts: 3 new specs covering each exonym shape.
- apps/extension/src/lib/picker.test.ts: regression test for a UA picker where the Russian link's only language signal is the title attribute.

Storybook (component lab for @movar/ui and @movar/marketing)
- packages/ui: add storybook + build-storybook scripts, @storybook/react
  + react-vite + addon-docs + tailwind v4 + fontsource devDeps, .storybook/{main.ts,preview.css,preview.tsx}, and stories for brand-mark, button, checkbox, icon-button, pill, select, switch. project.json gets matching `storybook` and `build-storybook` targets (the latter cached with storybook-static as output). tsconfig.json includes .storybook; eslint.config.mjs ignores storybook-static and relaxes sonarjs duplication rules on *.stories.{ts,tsx}.
- apps/marketing: add storybook + build-storybook scripts and the same Storybook+React+Tailwind devDep set; .storybook/{main.ts,preview.css, preview.tsx}; component stories for BeforeAfter, Close, DownloadButtons, Examples, Footer, Header, Hero, HowItWorks, Limitations, Privacy, Problem, Stakes. vite bumped 6→7 for storybook compat.
- process-compose.yaml: two new processes (`storybook` on :6006, `marketing-storybook` on :6007) with extended readiness probes (initial_delay 8s, 60-failure budget) to absorb Vite cold-start cost.
- .claude/launch.json: `ui-storybook` and `marketing-storybook` launch configs on :6006/:6007.

E2E app scaffold
- apps/e2e/: new Playwright-based live-site harness. README, package.json, project.json, playwright.config.ts, tsconfig.json, eslint.config.mjs; src/fixtures/{extension,lang-detect,movar-state}.ts; src/sites/ registry (001, bing, duckduckgo, electrica-shop, google, uamade, youtube + index/types); src/tests/sites.spec.ts.
- package.json (root): `test:e2e:live` and `test:e2e:live:headed` scripts proxy to `nx run e2e:test:live[:headed]`.

Privacy refresh + support@ email
- apps/marketing/src/pages/privacy.astro, apps/marketing/src/pages/uk/privacy.astro: surface an Effective date alongside Last updated (both 28 May 2026) and substantial content refresh to the policy body.
- apps/marketing/src/i18n.ts, packages/shared/src/index.ts: switch the feedback mailbox from feedback@ to support@movar.fyi (label + URL).

Extension store assets
- apps/extension/store-assets/REQUIREMENTS.md: spec for the asset set required for Chrome/Edge/Firefox listings.
- apps/extension/store-assets/copy/{description.en,summary.en, teaser-roadmap}.md: store-listing copy.
- apps/extension/store-assets/storyboards/{README.md,news,picker,serp, site-after,site-before}.html: static storyboards for capturing screenshots — served via the new `preview:storyboards` script and the `storyboards` launch config on :4324.
- apps/extension/package.json, .claude/launch.json: wiring for the storyboards static server.

Misc
- pnpm-lock.yaml: regenerated to pick up the new Storybook/React/Vite devDeps.