### PR TITLE
chore: add build:dist npm script

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "format:check": "prettier --check .",
     "publint": "pnpm --workspace-concurrency=1 --filter @movar/shared --filter @movar/rules --filter @movar/lang-detect exec publint",
     "validate": "pnpm typecheck && pnpm lint && pnpm test && pnpm publint",
+    "build:dist": "bash scripts/build-dist.sh",
     "verify:release": "bash scripts/verify-release.sh",
     "pack:amo-source": "bash scripts/pack-amo-source.sh",
     "metrics": "mkdir -p .metrics; fallow --format markdown --score --save-snapshot > .metrics/fallow.md; fallow --format json --score > .metrics/fallow.json; tsx scripts/fallow-targets.mts",


### PR DESCRIPTION
## Summary
- Adds `\"build:dist\": \"bash scripts/build-dist.sh\"` to root [package.json](package.json) so contributors can run `pnpm build:dist` instead of remembering the bash path.
- The script itself shipped in [#21](https://github.com/rejifald/movar/pull/21); only the package.json alias was missed.

## Test plan
- [x] `pnpm run` lists `build:dist → bash scripts/build-dist.sh`
- [ ] CI green