### PR TITLE
feat(extension): extend content filter to channels, playlists, shorts, mobile

### DIFF
--- a/apps/extension/src/lib/content-filter.test.ts
+++ b/apps/extension/src/lib/content-filter.test.ts
@@ -7,7 +7,7 @@ import {
   revealAllBlurred,
   GOOGLE_SERP_SELECTORS,
   YT_GRID_SELECTORS,
-  type ContentFilter,
+  type SiteContentFilter,
 } from './content-filter';
 import { setContentLocale } from './i18n/content';
 
@@ -15,7 +15,7 @@ function setBody(html: string): void {
   document.body.innerHTML = html;
 }
 
-let YT: ContentFilter;
+let YT: SiteContentFilter;
 
 beforeAll(() => {
   // Resolve at suite start so a regression in getFilterForHost surfaces as
@@ -433,11 +433,15 @@ describe('clearAllContentMarks', () => {
 });
 
 describe('applyContentFilter — custom filter shape', () => {
-  it('works with a different filter (selectors are data, not hard-coded)', () => {
-    const custom: ContentFilter = {
-      cardSelectors: ['.result-card'],
-      titleSelector: '.title',
-      channelSelector: '.author',
+  it('works with a different filter (shapes are data, not hard-coded)', () => {
+    const custom: SiteContentFilter = {
+      shapes: [
+        {
+          kind: 'video',
+          selector: '.result-card',
+          textSelectors: ['.title', '.author'],
+        },
+      ],
     };
     setBody(`
       <div class="result-card">
@@ -447,8 +451,407 @@ describe('applyContentFilter — custom filter shape', () => {
     `);
     const blurred = applyContentFilter(custom, ['ru']);
     expect(blurred).toHaveLength(1);
+    expect(blurred[0]?.kind).toBe('video');
     expect(document.querySelector('.result-card')?.getAttribute('data-movar-content-blurred')).toBe(
       'ru',
     );
+  });
+});
+
+describe('applyContentFilter — hideMode dispatch', () => {
+  it("hideMode: 'hide' sets display:none + HIDDEN_ATTR, no curtain attached", () => {
+    const filter: SiteContentFilter = {
+      shapes: [
+        {
+          kind: 'channel',
+          selector: '.channel-card',
+          textSelectors: ['.name', '.description'],
+          hideMode: 'hide',
+        },
+      ],
+    };
+    setBody(`
+      <div class="channel-card">
+        <div class="name">Русский канал</div>
+        <div class="description">Всё о программировании на русском языке</div>
+      </div>
+    `);
+    const hits = applyContentFilter(filter, ['ru']);
+    expect(hits).toHaveLength(1);
+    expect(hits[0]?.kind).toBe('channel');
+    const card = document.querySelector<HTMLElement>('.channel-card')!;
+    expect(card.style.display).toBe('none');
+    expect(card.getAttribute('data-movar-hidden')).toMatch(/^content-filter:channel:ru$/);
+    // No curtain — hide mode is flat.
+    expect(card.querySelector('[data-movar-curtain]')).toBeNull();
+  });
+
+  it("hideMode: 'blur' is the default when omitted", () => {
+    const filter: SiteContentFilter = {
+      shapes: [
+        {
+          kind: 'video',
+          selector: '.video-card',
+          textSelectors: ['.title'],
+        },
+      ],
+    };
+    setBody(`<div class="video-card"><div class="title">Всё о программировании</div></div>`);
+    applyContentFilter(filter, ['ru']);
+    const card = document.querySelector<HTMLElement>('.video-card')!;
+    expect(card.getAttribute('data-movar-content-blurred')).toBe('ru');
+    expect(card.querySelector('[data-movar-curtain]')).not.toBeNull();
+  });
+
+  it('a hidden card is not re-scanned on the next pass', () => {
+    const filter: SiteContentFilter = {
+      shapes: [
+        {
+          kind: 'channel',
+          selector: '.channel-card',
+          textSelectors: ['.description'],
+          hideMode: 'hide',
+        },
+      ],
+    };
+    setBody(
+      `<div class="channel-card"><div class="description">Всё о программировании</div></div>`,
+    );
+    expect(applyContentFilter(filter, ['ru'])).toHaveLength(1);
+    expect(applyContentFilter(filter, ['ru'])).toHaveLength(0);
+  });
+});
+
+describe('applyContentFilter — multi-shape iteration', () => {
+  it('scans every shape and aggregates hits across them', () => {
+    const filter: SiteContentFilter = {
+      shapes: [
+        {
+          kind: 'video',
+          selector: '.video',
+          textSelectors: ['.title'],
+        },
+        {
+          kind: 'channel',
+          selector: '.channel',
+          textSelectors: ['.description'],
+          hideMode: 'hide',
+        },
+      ],
+    };
+    setBody(`
+      <div class="video"><div class="title">Всё о программировании на русском</div></div>
+      <div class="channel"><div class="description">Русский канал про программирование</div></div>
+      <div class="video"><div class="title">Як писати тести українською мовою</div></div>
+    `);
+    const hits = applyContentFilter(filter, ['ru']);
+    const kinds = hits.map((h) => h.kind).sort();
+    expect(kinds).toEqual(['channel', 'video']);
+  });
+
+  it('reads text from EVERY textSelector match inside a card (not just the first)', () => {
+    // A shelf-like card with many child titles — the joined text should
+    // accumulate enough Cyrillic to classify, where any single title alone
+    // would be too short.
+    const filter: SiteContentFilter = {
+      shapes: [
+        {
+          kind: 'shorts-shelf',
+          selector: '.shelf',
+          textSelectors: ['.item-title'],
+          hideMode: 'hide',
+        },
+      ],
+    };
+    setBody(`
+      <div class="shelf">
+        <div class="item-title">Привет</div>
+        <div class="item-title">Хочу</div>
+        <div class="item-title">Сейчас</div>
+        <div class="item-title">Здравствуйте</div>
+      </div>
+    `);
+    const hits = applyContentFilter(filter, ['ru']);
+    expect(hits).toHaveLength(1);
+    expect(hits[0]?.kind).toBe('shorts-shelf');
+  });
+
+  it('does not double-count text when textSelectors overlap (fallback-chain pair)', () => {
+    // Pin the regression: with overlapping selectors that both match nested
+    // elements (a wrapper + a child), only the outer one contributes text.
+    // Without this dedup, `тест` + `канал` + `канал` (double-counted via the
+    // <a> inside the <div id="text">) would tip past MIN_CYRILLIC_FOR_FALLBACK
+    // and false-positive blur the card.
+    const filter: SiteContentFilter = {
+      shapes: [
+        {
+          kind: 'video',
+          selector: '.card',
+          textSelectors: ['.outer [data-channel]', '.outer a'],
+        },
+      ],
+    };
+    setBody(`
+      <div class="card">
+        <div class="outer">
+          <div data-channel><a>канал</a></div>
+        </div>
+      </div>
+    `);
+    // "канал" = 5 Cyrillic chars, below MIN_CYRILLIC_FOR_FALLBACK. With
+    // double-count it'd be 10 and would classify as ru.
+    expect(applyContentFilter(filter, ['ru'])).toHaveLength(0);
+  });
+
+  it('appliesTo predicate gates the shape', () => {
+    const filter: SiteContentFilter = {
+      shapes: [
+        {
+          kind: 'post',
+          selector: '.post',
+          textSelectors: ['.body'],
+          // Predicate returns false → shape is skipped.
+          appliesTo: () => false,
+        },
+      ],
+    };
+    setBody(`<div class="post"><div class="body">Всё о программировании на русском</div></div>`);
+    expect(applyContentFilter(filter, ['ru'])).toHaveLength(0);
+  });
+});
+
+// ─── YouTube non-video shapes ────────────────────────────────────────────
+
+describe('applyContentFilter — YouTube channel cards', () => {
+  it('hides a channel card with a Russian description (display:none, no curtain)', () => {
+    setBody(`
+      <ytd-channel-renderer id="ch">
+        <div id="channel-title">Сегодня</div>
+        <yt-formatted-string id="description">Канал о русской культуре и истории — выпуски каждую неделю.</yt-formatted-string>
+      </ytd-channel-renderer>
+    `);
+    const hits = applyContentFilter(YT, ['ru']);
+    expect(hits).toHaveLength(1);
+    expect(hits[0]?.kind).toBe('channel');
+    const card = document.querySelector<HTMLElement>('#ch')!;
+    expect(card.style.display).toBe('none');
+    expect(card.getAttribute('data-movar-hidden')).toMatch(/^content-filter:channel:ru$/);
+    expect(card.querySelector('[data-movar-curtain]')).toBeNull();
+  });
+
+  it('does NOT hide a Ukrainian-distinctive channel description', () => {
+    setBody(`
+      <ytd-channel-renderer id="ch">
+        <div id="channel-title">Сьогодні</div>
+        <yt-formatted-string id="description">Канал про українську культуру та історію — випуски щотижня.</yt-formatted-string>
+      </ytd-channel-renderer>
+    `);
+    expect(applyContentFilter(YT, ['ru'])).toHaveLength(0);
+    expect(document.querySelector<HTMLElement>('#ch')!.style.display).toBe('');
+  });
+
+  it('also handles ytd-mini-channel-renderer', () => {
+    setBody(`
+      <ytd-mini-channel-renderer id="mch">
+        <div id="channel-title">Русский канал</div>
+        <yt-formatted-string id="description">Всё про программирование на русском</yt-formatted-string>
+      </ytd-mini-channel-renderer>
+    `);
+    const hits = applyContentFilter(YT, ['ru']);
+    expect(hits).toHaveLength(1);
+    expect(hits[0]?.kind).toBe('channel');
+  });
+
+  it('idempotent — a hidden channel is not re-scanned', () => {
+    setBody(`
+      <ytd-channel-renderer>
+        <yt-formatted-string id="description">Полностью на русском языке про программирование</yt-formatted-string>
+      </ytd-channel-renderer>
+    `);
+    expect(applyContentFilter(YT, ['ru'])).toHaveLength(1);
+    expect(applyContentFilter(YT, ['ru'])).toHaveLength(0);
+  });
+});
+
+describe('applyContentFilter — YouTube playlist / mix / radio', () => {
+  it('blurs a playlist with a Russian title', () => {
+    setBody(`
+      <ytd-playlist-renderer id="pl">
+        <a id="video-title">Всё о программировании — плейлист</a>
+        <ytd-channel-name><a>Какой-то Канал</a></ytd-channel-name>
+      </ytd-playlist-renderer>
+    `);
+    const hits = applyContentFilter(YT, ['ru']);
+    expect(hits).toHaveLength(1);
+    expect(hits[0]?.kind).toBe('playlist');
+    const card = document.querySelector<HTMLElement>('#pl')!;
+    expect(card.getAttribute('data-movar-content-blurred')).toBe('ru');
+    expect(card.querySelector('[data-movar-curtain]')).not.toBeNull();
+  });
+
+  it('blurs a radio/mix renderer with Russian text', () => {
+    setBody(`
+      <ytd-radio-renderer id="rad">
+        <a id="video-title">Микс — всё о программировании</a>
+        <ytd-channel-name><a>YouTube</a></ytd-channel-name>
+      </ytd-radio-renderer>
+    `);
+    const hits = applyContentFilter(YT, ['ru']);
+    expect(hits).toHaveLength(1);
+    expect(hits[0]?.kind).toBe('playlist');
+  });
+
+  it('blurs ytd-compact-radio-renderer too', () => {
+    setBody(`
+      <ytd-compact-radio-renderer id="crad">
+        <a id="video-title">Микс — всё о программировании</a>
+        <ytd-channel-name><a>YouTube</a></ytd-channel-name>
+      </ytd-compact-radio-renderer>
+    `);
+    expect(applyContentFilter(YT, ['ru'])).toHaveLength(1);
+  });
+
+  it('does NOT blur a Ukrainian-distinctive playlist', () => {
+    setBody(`
+      <ytd-playlist-renderer>
+        <a id="video-title">Все про програмування — плейлист українською</a>
+        <ytd-channel-name><a>Якийсь канал</a></ytd-channel-name>
+      </ytd-playlist-renderer>
+    `);
+    expect(applyContentFilter(YT, ['ru'])).toHaveLength(0);
+  });
+});
+
+describe('applyContentFilter — YouTube movies', () => {
+  it('blurs a movie card with a Russian title', () => {
+    setBody(`
+      <ytd-movie-renderer id="mv">
+        <a id="video-title">Всё, что нужно знать о программировании — документальный фильм</a>
+        <ytd-channel-name><a>Канал</a></ytd-channel-name>
+      </ytd-movie-renderer>
+    `);
+    const hits = applyContentFilter(YT, ['ru']);
+    expect(hits).toHaveLength(1);
+    expect(hits[0]?.kind).toBe('video');
+  });
+});
+
+describe('applyContentFilter — YouTube shorts shelf', () => {
+  it('hides a shorts shelf where every child title is Russian-leaning', () => {
+    // Individually these titles wouldn't classify — each is below
+    // MIN_CYRILLIC_FOR_FALLBACK = 10. Together they cross the bound and
+    // the shelf collapses as a unit.
+    setBody(`
+      <ytd-reel-shelf-renderer id="shelf">
+        <ytd-reel-item-renderer><a id="video-title">Привет</a></ytd-reel-item-renderer>
+        <ytd-reel-item-renderer><a id="video-title">Хочу</a></ytd-reel-item-renderer>
+        <ytd-reel-item-renderer><a id="video-title">Сейчас</a></ytd-reel-item-renderer>
+        <ytd-reel-item-renderer><a id="video-title">Здравствуйте</a></ytd-reel-item-renderer>
+      </ytd-reel-shelf-renderer>
+    `);
+    const hits = applyContentFilter(YT, ['ru']);
+    expect(hits).toHaveLength(1);
+    expect(hits[0]?.kind).toBe('shorts-shelf');
+    const shelf = document.querySelector<HTMLElement>('#shelf')!;
+    expect(shelf.style.display).toBe('none');
+    expect(shelf.getAttribute('data-movar-hidden')).toMatch(/^content-filter:shorts-shelf:ru$/);
+  });
+
+  it('does NOT hide a shelf whose titles carry Ukrainian distinctives', () => {
+    setBody(`
+      <ytd-reel-shelf-renderer id="shelf">
+        <ytd-reel-item-renderer><a id="video-title">Привіт усім</a></ytd-reel-item-renderer>
+        <ytd-reel-item-renderer><a id="video-title">Сьогодні</a></ytd-reel-item-renderer>
+        <ytd-reel-item-renderer><a id="video-title">Як справи</a></ytd-reel-item-renderer>
+      </ytd-reel-shelf-renderer>
+    `);
+    expect(applyContentFilter(YT, ['ru'])).toHaveLength(0);
+    expect(document.querySelector<HTMLElement>('#shelf')!.style.display).toBe('');
+  });
+
+  it('leaves a mixed-evidence shelf alone (detector returns unknown on ties)', () => {
+    // One UA-distinctive `і` against one RU-distinctive `ё` → ukScore === ruScore === 1
+    // → detectCyrillicLanguage returns 'unknown' → shelf left alone. This is
+    // the safety net: a shelf the user might want to keep is left alone.
+    setBody(`
+      <ytd-reel-shelf-renderer id="shelf">
+        <ytd-reel-item-renderer><a id="video-title">Сьогодні</a></ytd-reel-item-renderer>
+        <ytd-reel-item-renderer><a id="video-title">Это всё</a></ytd-reel-item-renderer>
+      </ytd-reel-shelf-renderer>
+    `);
+    expect(applyContentFilter(YT, ['ru'])).toHaveLength(0);
+  });
+
+  it('idempotent — a hidden shelf is not re-scanned on the next pass', () => {
+    setBody(`
+      <ytd-reel-shelf-renderer>
+        <ytd-reel-item-renderer><a id="video-title">Привет</a></ytd-reel-item-renderer>
+        <ytd-reel-item-renderer><a id="video-title">Хочу</a></ytd-reel-item-renderer>
+        <ytd-reel-item-renderer><a id="video-title">Сейчас</a></ytd-reel-item-renderer>
+        <ytd-reel-item-renderer><a id="video-title">Здравствуйте</a></ytd-reel-item-renderer>
+      </ytd-reel-shelf-renderer>
+    `);
+    expect(applyContentFilter(YT, ['ru'])).toHaveLength(1);
+    expect(applyContentFilter(YT, ['ru'])).toHaveLength(0);
+  });
+
+  it('does not classify a shelf that has no child titles yet (lazy load)', () => {
+    setBody(`<ytd-reel-shelf-renderer></ytd-reel-shelf-renderer>`);
+    expect(applyContentFilter(YT, ['ru'])).toHaveLength(0);
+    // Importantly: NOT marked checked, so the next mutation pass can re-scan
+    // once child shorts hydrate in.
+    const shelf = document.querySelector<HTMLElement>('ytd-reel-shelf-renderer')!;
+    expect(Object.hasOwn(shelf.dataset, 'movarContentChecked')).toBe(false);
+  });
+});
+
+// ─── Mobile (m.youtube.com) selectors ─────────────────────────────────────
+
+describe('applyContentFilter — YouTube mobile (ytm-*) selectors', () => {
+  it('blurs a ytm-video-with-context-renderer with a Russian title', () => {
+    setBody(`
+      <ytm-video-with-context-renderer id="mv">
+        <a id="video-title">Всё о программировании на русском языке</a>
+      </ytm-video-with-context-renderer>
+    `);
+    const hits = applyContentFilter(YT, ['ru']);
+    expect(hits).toHaveLength(1);
+    expect(hits[0]?.kind).toBe('video');
+    expect(
+      document.querySelector<HTMLElement>('#mv')!.getAttribute('data-movar-content-blurred'),
+    ).toBe('ru');
+  });
+
+  it('blurs a ytm-compact-video-renderer with a Russian title', () => {
+    setBody(`
+      <ytm-compact-video-renderer id="cv">
+        <a id="video-title">Всё о программировании на русском</a>
+      </ytm-compact-video-renderer>
+    `);
+    expect(applyContentFilter(YT, ['ru'])).toHaveLength(1);
+  });
+
+  it('blurs a ytm-rich-item-renderer', () => {
+    setBody(`
+      <ytm-rich-item-renderer id="ri">
+        <a id="video-title">Совершенно русскоязычный контент про программирование</a>
+      </ytm-rich-item-renderer>
+    `);
+    expect(applyContentFilter(YT, ['ru'])).toHaveLength(1);
+  });
+
+  it('hides a ytm-reel-shelf-renderer of Russian shorts', () => {
+    setBody(`
+      <ytm-reel-shelf-renderer id="shelf">
+        <a id="video-title">Привет</a>
+        <a id="video-title">Хочу</a>
+        <a id="video-title">Сейчас</a>
+        <a id="video-title">Здравствуйте</a>
+      </ytm-reel-shelf-renderer>
+    `);
+    const hits = applyContentFilter(YT, ['ru']);
+    expect(hits).toHaveLength(1);
+    expect(hits[0]?.kind).toBe('shorts-shelf');
+    expect(document.querySelector<HTMLElement>('#shelf')!.style.display).toBe('none');
   });
 });

--- a/apps/extension/src/lib/content-filter.ts
+++ b/apps/extension/src/lib/content-filter.ts
@@ -78,56 +78,192 @@ export function filterContentByLanguage(
   return { hiddenNodes };
 }
 
-// ─── Blur-based filter (YouTube grids) ───────────────────────────────────
+// ─── Shape-based filter (YouTube, social feeds) ──────────────────────────
 
 const CHECKED_ATTR = 'data-movar-content-checked';
 const BLURRED_ATTR = 'data-movar-content-blurred';
 const REVEALED_ATTR = 'data-movar-revealed';
 
-export interface ContentFilter {
-  /** Card-level selectors — any matching element is a candidate to blur. */
-  cardSelectors: readonly string[];
-  /** Selector inside a card that holds the title text. */
-  titleSelector: string;
-  /** Selector inside a card that holds the channel/author text. */
-  channelSelector: string;
+/**
+ * What kind of card a shape matches. Drives curtain copy and per-kind
+ * telemetry on {@link CorrectionEvent.subKind} (wired in a later phase).
+ *
+ *   video         — a single video tile (search results, home grid, sidebar).
+ *   channel       — a channel result; the whole card is one link, so blurring
+ *                   it adds nothing — better hidden flat.
+ *   playlist      — a playlist or mix/radio card.
+ *   shorts-shelf  — the Shorts carousel as a unit; child titles are too
+ *                   short to classify individually, so the shelf collects
+ *                   them and gets hidden as one.
+ *   shelf         — generic "Trending in …" type horizontal carousel.
+ *   post          — community/backstage post or platform-agnostic feed item.
+ */
+export type CardKind = 'video' | 'channel' | 'playlist' | 'shorts-shelf' | 'shelf' | 'post';
+
+/**
+ * How a matched card is concealed.
+ *
+ *   blur — overlay a curtain, let the user peek (good for individual videos
+ *          where the user might want to confirm a false positive).
+ *   hide — `display:none` on the card itself, no curtain UI (good for
+ *          channel cards, shelves, and other "the whole card has one
+ *          purpose" surfaces where hover-to-reveal adds no value).
+ */
+export type HideMode = 'blur' | 'hide';
+
+/**
+ * One filterable surface on a site. The host's filter is a list of these so
+ * channels, videos, shorts shelves, and posts can each declare their own
+ * selectors and concealment behaviour without forking the scan loop.
+ */
+export interface CardShape {
+  /** Drives curtain copy and per-kind telemetry. */
+  kind: CardKind;
+  /** Card-level selector. Comma-list accepted. */
+  selector: string;
+  /**
+   * Sub-selectors whose text contributes to classification. ALL matches
+   * inside the card are concatenated — so a shelf that holds many child
+   * `#video-title` entries accumulates enough Cyrillic to clear the
+   * detector's `MIN_CYRILLIC_FOR_FALLBACK` guard.
+   *
+   * Uses the `[id="…"]` attribute form rather than `#video-title` because
+   * YouTube reuses the same id across many cards (invalid HTML, but real
+   * browsers scope querySelector correctly). jsdom's `#id` query
+   * optimization is document-scoped and returns null for non-first matches,
+   * so the attribute form is the portable shape.
+   */
+  textSelectors: readonly string[];
+  /** Default: `blur`. */
+  hideMode?: HideMode;
+  /** Skip the shape unless the predicate returns true for the current location. */
+  appliesTo?: (loc: Location) => boolean;
+  /** Off-by-default shapes (community posts, generic shelves). Gated by
+   *  `settings.experimentalShapes` — wired in Phase 6. */
+  experimental?: boolean;
 }
 
-export interface BlurredCard {
+export interface SiteContentFilter {
+  shapes: readonly CardShape[];
+}
+
+export interface FilteredCard {
   el: HTMLElement;
   fromLang: LanguageCode;
+  kind: CardKind;
 }
 
-const YOUTUBE_FILTER: ContentFilter = {
-  // YouTube ships different card components per page surface: SERP results,
-  // home grid, watch-page sidebar, playlists. Covering the renderers that
-  // appear on /results and /watch is enough for the user-facing search bug.
-  //
-  // Selectors use the [id="…"] attribute form rather than `#video-title`
-  // because YouTube reuses the same id across many cards (invalid HTML, but
-  // real browsers scope querySelector correctly). jsdom's `#id` query
-  // optimization is document-scoped and returns null for non-first matches,
-  // so the attribute form is the portable shape.
-  cardSelectors: YT_GRID_SELECTORS,
-  titleSelector: '[id="video-title"]',
-  channelSelector: 'ytd-channel-name [id="text"], ytd-channel-name a',
+/** Mobile (`m.youtube.com`) video-tile renderers. The mobile site uses its
+ *  own `ytm-*` element prefix; `[id="video-title"]` is shared with desktop,
+ *  so the same text selectors classify the same way. */
+const YT_MOBILE_VIDEO_SELECTORS: readonly string[] = [
+  'ytm-video-with-context-renderer',
+  'ytm-compact-video-renderer',
+  'ytm-rich-item-renderer',
+];
+
+const YOUTUBE_FILTER: SiteContentFilter = {
+  shapes: [
+    // Standard video tile across SERP, home grid, watch-page sidebar, and
+    // inside-playlist surfaces — desktop and mobile both covered. The
+    // renderer set covers what users actually see on /results and /watch.
+    {
+      kind: 'video',
+      selector: [...YT_GRID_SELECTORS, ...YT_MOBILE_VIDEO_SELECTORS].join(', '),
+      textSelectors: ['[id="video-title"]', 'ytd-channel-name [id="text"]', 'ytd-channel-name a'],
+    },
+    // Channel result on /results and channel chips in the watch-page sidebar.
+    // The whole card is one link to a channel page — blurring + reveal adds
+    // nothing here, so we hide flat. Reading both #channel-title and
+    // #description lets a short channel name borrow Cyrillic evidence from
+    // the longer description.
+    //
+    // Mobile note: `ytm-channel-renderer` is matched, but its inner DOM uses
+    // a different (non-`#channel-title`) structure for the name; full mobile
+    // channel coverage needs additional textSelectors and is tracked as a
+    // follow-up.
+    {
+      kind: 'channel',
+      selector: 'ytd-channel-renderer, ytd-mini-channel-renderer, ytm-channel-renderer',
+      textSelectors: ['#channel-title', '#description'],
+      hideMode: 'hide',
+    },
+    // Playlist, Mix, and Radio results — all card-shaped, all carry the
+    // playlist title in #video-title and the creator in ytd-channel-name.
+    // Keep `blur` so the user can peek if a quirky-titled UA playlist gets
+    // false-positive matched.
+    {
+      kind: 'playlist',
+      selector: 'ytd-playlist-renderer, ytd-radio-renderer, ytd-compact-radio-renderer',
+      textSelectors: ['[id="video-title"]', 'ytd-channel-name'],
+    },
+    // Movie purchase/rental cards. Same UX target as a video tile.
+    {
+      kind: 'video',
+      selector: 'ytd-movie-renderer',
+      textSelectors: ['[id="video-title"]', 'ytd-channel-name'],
+    },
+    // Shorts shelves (the carousel on /results, home, and below the watch
+    // player) — desktop and mobile both covered. Each child Short title is
+    // too short to clear the detector's `MIN_CYRILLIC_FOR_FALLBACK = 10`
+    // bound on its own, but the shelf collects every child
+    // `[id="video-title"]` into one classification input — usually enough to
+    // call a predominantly-RU shelf. Hide-mode, because the carousel is the
+    // unit; per-item reveal would be busywork.
+    //
+    // Mixed-language shelves (UA-distinctive + RU-distinctive items in
+    // equal measure) fall to `unknown` per detectCyrillicLanguage's tie
+    // rule, so they're left alone — see the test in content-filter.test.ts.
+    {
+      kind: 'shorts-shelf',
+      selector: 'ytd-reel-shelf-renderer, ytm-reel-shelf-renderer',
+      textSelectors: ['[id="video-title"]'],
+      hideMode: 'hide',
+    },
+  ],
 };
 
-const FILTERS: readonly { host: string; filter: ContentFilter }[] = [
+const FILTERS: readonly { host: string; filter: SiteContentFilter }[] = [
   { host: 'youtube.com', filter: YOUTUBE_FILTER },
 ];
 
-export function getFilterForHost(host: string): ContentFilter | null {
+export function getFilterForHost(host: string): SiteContentFilter | null {
   for (const { host: m, filter } of FILTERS) {
     if (host === m || host.endsWith(`.${m}`)) return filter;
   }
   return null;
 }
 
-function readCardText(card: HTMLElement, filter: ContentFilter): string {
-  const title = card.querySelector(filter.titleSelector)?.textContent?.trim() ?? '';
-  const channel = card.querySelector(filter.channelSelector)?.textContent?.trim() ?? '';
-  return `${title} ${channel}`.trim();
+/**
+ * Concatenate text from every `textSelectors` match inside `card`. Using
+ * `querySelectorAll` (rather than the first match only) lets the same shape
+ * describe both single-card surfaces (one title) and shelf-like surfaces
+ * (many child titles) — the detector treats the joined string as one
+ * classification input.
+ *
+ * Overlapping selectors are handled by dropping any matched element that's
+ * already contained inside another matched element. That makes selector
+ * authoring forgiving (a fallback-chain pair like `X .name, X a` won't
+ * double-count when both happen to match), and keeps shelf-style
+ * non-nested matches intact (siblings stay).
+ */
+function readShapeText(card: HTMLElement, shape: CardShape): string {
+  const matched = new Set<Element>();
+  for (const sel of shape.textSelectors) {
+    for (const el of card.querySelectorAll(sel)) {
+      matched.add(el);
+    }
+  }
+  const matchedList = [...matched];
+  const parts: string[] = [];
+  for (const el of matchedList) {
+    // Skip nested-inside-another-match — the ancestor's textContent already
+    // includes this element's text.
+    if (matchedList.some((other) => other !== el && other.contains(el))) continue;
+    const text = (el.textContent ?? '').trim();
+    if (text) parts.push(text);
+  }
+  return parts.join(' ');
 }
 
 function attachBlurCurtain(card: HTMLElement, language: LanguageCode): void {
@@ -152,31 +288,33 @@ function attachBlurCurtain(card: HTMLElement, language: LanguageCode): void {
   });
 }
 
-/**
- * Scan `root` for cards matching the filter and blur any whose title+channel
- * reads as a blocked language. Idempotent — cards already checked, blurred,
- * or revealed are skipped, so it can be called repeatedly on DOM mutations.
- *
- * Returns the cards newly blurred on this call, so the caller can log one
- * correction per card without spamming the dashboard.
- */
-export function applyContentFilter(
-  filter: ContentFilter,
-  blocked: readonly LanguageCode[],
-  root: ParentNode = document,
-): BlurredCard[] {
-  // Today only Cyrillic UA-vs-RU is supported; widen this when the detector grows.
-  if (!blocked.includes('ru')) return [];
+/** `display:none` the card and tag it so `restoreAll` in the content script
+ *  picks it up alongside picker hides. The reason string is informational; the
+ *  popup's `getHiddenSummary` only counts entries whose reason equals
+ *  `not-in-priority`, so content-filter hides don't inflate the picker count. */
+function hideCard(card: HTMLElement, kind: CardKind, language: LanguageCode): void {
+  card.setAttribute(HIDDEN_ATTR, `content-filter:${kind}:${language}`);
+  card.style.setProperty('display', 'none', 'important');
+}
 
-  const newlyBlurred: BlurredCard[] = [];
-  const sel = filter.cardSelectors.join(', ');
+// Per-card shape routing: appliesTo guard + signal classification + kind
+// dispatch. Each branch corresponds to a distinct card shape; flattening
+// would just hide the shape taxonomy.
+// fallow-ignore-next-line complexity
+function scanShape(shape: CardShape, root: ParentNode): FilteredCard[] {
+  if (shape.appliesTo && typeof location !== 'undefined' && !shape.appliesTo(location)) return [];
 
-  for (const card of root.querySelectorAll<HTMLElement>(sel)) {
+  const hits: FilteredCard[] = [];
+  for (const card of root.querySelectorAll<HTMLElement>(shape.selector)) {
+    // Lifecycle gates, ordered most-permanent first: a revealed card stays
+    // revealed, a concealed card stays concealed, a scanned-but-not-blocked
+    // card doesn't get re-scanned.
     if (card.hasAttribute(REVEALED_ATTR)) continue;
     if (card.hasAttribute(BLURRED_ATTR)) continue;
+    if (card.hasAttribute(HIDDEN_ATTR)) continue;
     if (card.hasAttribute(CHECKED_ATTR)) continue;
 
-    const text = readCardText(card, filter);
+    const text = readShapeText(card, shape);
     // Lazy-load: card is in DOM but text not yet populated. Skip without
     // marking — the next mutation pass will see it again.
     if (!text) continue;
@@ -186,11 +324,38 @@ export function applyContentFilter(
     const det = detectCyrillicLanguage(text);
     if (det.language !== 'ru') continue;
 
-    attachBlurCurtain(card, det.language);
-    newlyBlurred.push({ el: card, fromLang: det.language });
+    const mode: HideMode = shape.hideMode ?? 'blur';
+    if (mode === 'hide') {
+      hideCard(card, shape.kind, det.language);
+    } else {
+      attachBlurCurtain(card, det.language);
+    }
+    hits.push({ el: card, fromLang: det.language, kind: shape.kind });
   }
+  return hits;
+}
 
-  return newlyBlurred;
+/**
+ * Scan `root` for cards matching each shape and conceal any whose text reads
+ * as a blocked language. Idempotent — cards already concealed or revealed
+ * are skipped, so the function is safe to call repeatedly on DOM mutations.
+ *
+ * Returns the cards newly concealed on this call, so the caller can log one
+ * correction per card without spamming the dashboard.
+ */
+export function applyContentFilter(
+  filter: SiteContentFilter,
+  blocked: readonly LanguageCode[],
+  root: ParentNode = document,
+): FilteredCard[] {
+  // Today only Cyrillic UA-vs-RU is supported; widen this when the detector grows.
+  if (!blocked.includes('ru')) return [];
+
+  const hits: FilteredCard[] = [];
+  for (const shape of filter.shapes) {
+    hits.push(...scanShape(shape, root));
+  }
+  return hits;
 }
 
 /** Clear all blur curtains on the page. Used by the popup's "Show all". */

--- a/docs/multi-shape-content-filter.md
+++ b/docs/multi-shape-content-filter.md
@@ -1,0 +1,246 @@
+# Multi-Shape Content Filter
+
+**Status:** in progress · **Owner:** content-filter · **Tracking:** this doc
+**Related code:** [apps/extension/src/lib/content-filter.ts](../apps/extension/src/lib/content-filter.ts), [apps/extension/src/entrypoints/content.ts](../apps/extension/src/entrypoints/content.ts), [packages/shared/src/index.ts](../packages/shared/src/index.ts)
+
+## Context
+
+Today's content filter on YouTube only matches **video tiles** — `ytd-video-renderer`, `ytd-grid-video-renderer`, `ytd-rich-item-renderer`, `ytd-compact-video-renderer`, `ytd-playlist-video-renderer`. The `ContentFilter` shape in [content-filter.ts:87](../apps/extension/src/lib/content-filter.ts) bakes in two sub-selectors — `titleSelector` and `channelSelector` — that describe a video card and nothing else.
+
+This shape silently misses:
+
+| Surface                                                         | Element                                                     | Status                                                      |
+| --------------------------------------------------------------- | ----------------------------------------------------------- | ----------------------------------------------------------- |
+| Shorts shelf (carousel on `/results`, home, below watch player) | `ytd-reel-shelf-renderer`                                   | untouched                                                   |
+| Shorts grid (`/shorts`)                                         | `ytm-shorts-lockup-view-model-v2`, `ytd-reel-item-renderer` | untouched                                                   |
+| Channel result card                                             | `ytd-channel-renderer`, `ytd-mini-channel-renderer`         | untouched (no `#video-title`, `readCardText` returns empty) |
+| Mix / Radio                                                     | `ytd-radio-renderer`, `ytd-compact-radio-renderer`          | untouched                                                   |
+| Movie result                                                    | `ytd-movie-renderer`                                        | untouched                                                   |
+| Hashtag tile                                                    | `ytd-hashtag-tile-renderer`                                 | untouched                                                   |
+| Community / Backstage post                                      | `ytd-backstage-post-thread-renderer`                        | untouched                                                   |
+| Mobile DOM (`m.youtube.com`)                                    | `ytm-*` variants                                            | untouched (host matches, selectors don't)                   |
+| Playlist result                                                 | `ytd-playlist-renderer`                                     | accidentally matched as video, wrong curtain copy           |
+
+Two missing types the user explicitly named — shorts and channels — sit at opposite ends of the same architectural gap. Channel cards have _no_ title-plus-channel split (the channel name _is_ the title). Shorts shelves are a _unit_ (the whole carousel), not a card with a single title. The current shape can't express either.
+
+## Design
+
+### Types — replace the one-shape struct with a shape list
+
+```ts
+export type CardKind =
+  | 'video' // standard video tile
+  | 'channel' // channel card / mini channel
+  | 'playlist' // playlist or mix card
+  | 'shorts-shelf' // the carousel as a unit
+  | 'shelf' // generic carousel ("Trending in …")
+  | 'post'; // community / forum post
+
+export type HideMode =
+  | 'blur' // overlay curtain, hover-peek (current default)
+  | 'hide'; // display:none on the card, no curtain UI
+
+export interface CardShape {
+  /** Drives curtain copy and the dashboard breakdown. */
+  kind: CardKind;
+  /** Card-level selector — comma-list accepted. */
+  selector: string;
+  /**
+   * Sub-selectors whose text contributes to classification. ALL matches under
+   * the card are concatenated — so a shorts shelf can collect every child
+   * `#video-title` to clear the detector's `MIN_CYRILLIC_FOR_FALLBACK` guard.
+   */
+  textSelectors: readonly string[];
+  /** Default: 'blur'. Use 'hide' for channel cards and shelves. */
+  hideMode?: HideMode;
+  /** Gate by URL path or other location-derived signal. */
+  appliesTo?: (loc: Location) => boolean;
+  /** Marks experimental shapes — gated by `settings.experimentalShapes`. */
+  experimental?: boolean;
+}
+
+export interface SiteContentFilter {
+  shapes: readonly CardShape[];
+}
+```
+
+### YouTube config under the new shape
+
+```ts
+const YOUTUBE_FILTER: SiteContentFilter = {
+  shapes: [
+    {
+      kind: 'video',
+      selector: [
+        'ytd-video-renderer',
+        'ytd-grid-video-renderer',
+        'ytd-rich-item-renderer',
+        'ytd-compact-video-renderer',
+        'ytd-playlist-video-renderer',
+        // Mobile:
+        'ytm-video-with-context-renderer',
+        'ytm-compact-autoplay-renderer',
+        'ytm-rich-item-renderer',
+      ].join(', '),
+      textSelectors: ['[id="video-title"]', 'ytd-channel-name'],
+    },
+    {
+      kind: 'channel',
+      selector: 'ytd-channel-renderer, ytd-mini-channel-renderer, ytm-channel-renderer',
+      textSelectors: ['#channel-title', '#text-container', '#description'],
+      hideMode: 'hide',
+    },
+    {
+      kind: 'playlist',
+      selector: 'ytd-playlist-renderer, ytd-radio-renderer, ytd-compact-radio-renderer',
+      textSelectors: ['[id="video-title"]', 'ytd-channel-name', '#byline'],
+    },
+    {
+      kind: 'video',
+      selector: 'ytd-movie-renderer',
+      textSelectors: ['[id="video-title"]', 'ytd-channel-name'],
+    },
+    {
+      kind: 'shorts-shelf',
+      selector: 'ytd-reel-shelf-renderer, ytm-reel-shelf-renderer',
+      textSelectors: ['#video-title', '.reel-item-endpoint'],
+      hideMode: 'hide',
+    },
+    {
+      kind: 'video',
+      selector: 'ytd-hashtag-tile-renderer',
+      textSelectors: ['#hashtag-title', '#hashtag'],
+      hideMode: 'hide',
+    },
+    // Experimental — gated by settings.experimentalShapes
+    {
+      kind: 'post',
+      selector: 'ytd-backstage-post-thread-renderer',
+      textSelectors: ['#content-text', '#author-text'],
+      appliesTo: (l) => /\/(community|post)/.test(l.pathname),
+      experimental: true,
+    },
+  ],
+};
+```
+
+### Key design choices
+
+- **Shorts shelves use `hide`, not blur.** Individual Short titles are too short to clear the detector's `MIN_CYRILLIC_FOR_FALLBACK = 10` bound. Collecting every child `#video-title` into one classification accumulates enough evidence and matches the user's mental model — "I don't want a Shorts carousel of Russian content," not "selectively peek inside it."
+- **Channels and hashtag tiles use `hide`.** A channel card's whole purpose is the link to the channel; blurring + reveal adds nothing. Same for hashtag tiles.
+- **Playlists keep `blur`** — false-positive risk is real on creator playlists with quirky titles.
+- **Mobile selectors live alongside desktop ones** in the same shape. `getFilterForHost('m.youtube.com')` already returns the YouTube filter via suffix match; we only needed the selectors.
+- **`textSelectors` use `querySelectorAll`**, so a single-match card and a multi-match shelf both work with the same shape definition.
+
+### Other platforms — same shape, no code change
+
+Adding TikTok / Twitter / Reddit becomes a config change:
+
+```ts
+const TWITTER_FILTER: SiteContentFilter = {
+  shapes: [
+    {
+      kind: 'post',
+      selector: 'article[data-testid="tweet"]',
+      textSelectors: ['[data-testid="tweetText"]', '[data-testid="User-Name"]'],
+      experimental: true,
+    },
+  ],
+};
+
+const TIKTOK_FILTER: SiteContentFilter = {
+  shapes: [
+    {
+      kind: 'video',
+      selector: '[data-e2e="recommend-list-item-container"]',
+      textSelectors: ['[data-e2e="video-desc"]', '[data-e2e="user-title"]'],
+      experimental: true,
+    },
+  ],
+};
+```
+
+## Phases
+
+### Phase 1 — Refactor (no behaviour change)
+
+**Goal:** rename `ContentFilter` to `SiteContentFilter`, port the existing video shape to the new list-of-shapes form, dispatch hide-mode through the new path. All existing tests pass.
+
+**Files**
+
+- `apps/extension/src/lib/content-filter.ts` — types + `applyContentFilter` rewrite
+- `apps/extension/src/lib/content-filter.test.ts` — adjust fixtures only
+
+**Tests**
+
+- All existing tests pass.
+- New unit test: `hideMode: 'hide'` path sets `display:none` + `HIDDEN_ATTR`, no curtain attached.
+- New unit test: a `SiteContentFilter` with two shapes scans both selector sets in one call.
+
+### Phase 2 — Channel, playlist/mix, movie, hashtag
+
+**Goal:** cover surfaces the current filter silently misses (excluding shorts shelves).
+
+**Shape additions:** `channel`, `playlist` (incl. radio/mix), `movie`, `hashtag tile` (see config above).
+
+**Tests:** one positive + one Ukrainian-negative + one idempotency per shape.
+
+### Phase 3 — Shorts shelves
+
+**Goal:** collapse Russian Shorts carousels as a unit.
+
+**Risk:** mixed-language shelves. Detector returns `unknown` when UA and RU signals are present — verify a 3-RU + 2-UA shelf is left alone.
+
+### Phase 4 — Mobile selectors (`ytm-*`)
+
+**Goal:** plug the silent miss on `m.youtube.com`.
+
+**Mechanical:** merge `ytm-*` selectors into the existing shape selector strings.
+
+### Phase 5 — Per-kind curtain copy + dashboard sub-kind
+
+**Goal:** curtains read "Russian channel hidden" / "Russian Shorts hidden" instead of pretending everything's a video. Dashboard can break down by kind.
+
+**Files**
+
+- `packages/shared/src/index.ts` — add `subKind?: CardKind` to `CorrectionEvent`
+- `apps/extension/src/lib/i18n/messages-en.ts` + `messages-uk.ts` — `titleForKind`, kind-aware `descriptionForLanguage`/`ariaLabelForLanguage`
+- `apps/extension/src/lib/content-filter.ts` — pass `kind` to curtain
+- `apps/extension/src/entrypoints/content.ts` — emit `subKind` on `logCorrection`
+
+**Tests:** per-kind curtain copy verified in EN + UK; `CorrectionEvent.subKind` populated; backward-compat for events without `subKind`.
+
+### Phase 6 — Experimental shapes behind a flag
+
+**Goal:** ship higher-FP-risk shapes (community posts, generic shelves) off by default.
+
+**Files**
+
+- `packages/shared/src/index.ts` — `MovarSettings.experimentalShapes: boolean` (default `false`)
+- `apps/extension/src/lib/content-filter.ts` — `applyContentFilter` skips experimental shapes when off
+- `apps/extension/src/entrypoints/content.ts` — pass the flag through
+- `apps/extension/src/entrypoints/options/PageContentSection.tsx` — toggle UI
+
+### Phase 7 — Non-YouTube platforms (follow-up PR)
+
+TikTok, Twitter/X, Reddit — one shape config each, gated by `experimentalShapes`, one positive + one negative test each. Carved out so this work can ship without waiting on harder surfaces.
+
+## Out of scope
+
+- Comment filtering (high volume, low value).
+- Ads / promoted slots (ad-blockers exist).
+- Per-Short tile classification inside a shelf (shelf-level hide is the right level of granularity given detector confidence).
+- Dashboard UI changes for `subKind` (the event extension lands in this work; dashboard rendering follows).
+
+## Open questions
+
+1. **Delete `filterContentByLanguage`** + `GOOGLE_SERP_SELECTORS`? It's exported, has tests, but never called from `content.ts`. The new shape-list with `hideMode: 'hide'` covers its use case. **Decision (Phase 1):** leave it in place for now, mark as a follow-up cleanup. Removing it isn't blocking.
+2. **Mixed-language shelf detector behaviour.** Confirmed by inspection: `detectCyrillicLanguage` returns `unknown` when both `ы/ё` and `і/ї/є/ґ` are present in equal measure ([lang-detect/src/index.ts:64](../packages/lang-detect/src/index.ts:64)). Phase 3 test must verify.
+3. **`CorrectionEvent` backward compat.** `subKind` is optional. If the dashboard or any external consumer doesn't tolerate missing values, that's the dashboard's bug. Confirm no schema-validation layer is rejecting unknown keys before shipping Phase 5.
+
+## Rollout
+
+- Phases 1–4 in a single PR — together they're the user-facing win.
+- Phase 5 separately (touches shared types + i18n).
+- Phase 6 separately, gated.
+- Phase 7 follow-up.


### PR DESCRIPTION
## Summary
- Replaces single-shape `ContentFilter` with list-of-shapes `SiteContentFilter`: each shape declares its own card selector, text extraction, and hide mode (`blur` vs `hide`).
- YouTube coverage extended to channel cards, playlists / mixes / radios, movie purchase cards, Shorts shelves, and mobile (`m.youtube.com`) tiles.
- `readShapeText` dedups nested matches so fallback-chain selector pairs (`X .name, X a`) don't double-count.
- Adds `CardKind`, `HideMode`, `CardShape`, `SiteContentFilter`, `FilteredCard` types. Renames `BlurredCard` → `FilteredCard`. Design doc: [docs/multi-shape-content-filter.md](docs/multi-shape-content-filter.md).

## Background
Cherry-picked from the long-running [`feat/multi-shape-content-filter`](https://github.com/rejifald/movar/commit/cdc183a) local branch onto a fresh main base after audit. The original branch also carried a stale PR #17 metrics-audit-clearing commit ([f16bda2](https://github.com/rejifald/movar/commit/f16bda2)); that was dropped as superseded by [#18](https://github.com/rejifald/movar/pull/18).

Merge resolution kept main's `clearAllContentMarks` function alongside the new shape types and renamed `let YT: ContentFilter` → `SiteContentFilter` in the test imports.

## Test plan
- [x] `pnpm --filter=extension typecheck` clean
- [x] `pnpm --filter=extension lint` clean
- [x] `pnpm --filter=extension test` — 338 tests pass (was 320 on main; +18 new from this commit)
- [x] `pnpm --filter=e2e test:fast` — 24 offline e2e tests pass via pre-push hook
- [x] `fallow audit` — warn-only on 7 test-setup clone groups; same pattern documented in the original branch (each test sets up its own DOM fixture inline by design)
- [ ] CI green
- [ ] Manual smoke: load `.output/chrome-mv3/` unpacked, visit youtube.com with Russian content shown, verify channel/playlist/Shorts shelf cards now blur or hide per their shape

🤖 Generated with [Claude Code](https://claude.com/claude-code)