### PR TITLE
chore(dev): route process-compose control API over a Unix socket

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "pnpm": ">=11"
   },
   "scripts": {
-    "dev": "process-compose up",
+    "dev": "process-compose up -U -u /tmp/movar-pc.sock",
     "dev:extension": "nx run extension:dev",
     "build": "nx run-many -t build",
     "lint:root": "eslint tooling/ eslint.config.mjs",


### PR DESCRIPTION
## Summary

- Switch `pnpm dev` from `process-compose up` to `process-compose up -U -u /tmp/movar-pc.sock`.
- The default TCP `:8080` collides with Docker Desktop (and other dev tools) on this machine; a Unix domain socket has zero port-conflict surface.
- The dev TUI doesn't need a remote-reachable API, so UDS is strictly better here.

## Test plan

- [ ] `pnpm dev` starts cleanly (no "bind: address already in use" errors)
- [ ] Per-process control via the TUI palette (`:`) still works
- [ ] `lsof -nP -iTCP:8080` no longer shows process-compose

🤖 Generated with [Claude Code](https://claude.com/claude-code)