### PR TITLE
fix(ci): produce one side-loadable extension zip per browser

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,12 +57,27 @@ jobs:
             .metrics/
             docs/REFACTORING-QUEUE.md
 
+  # Per-browser side-loadable zips for PR testers. The release workflow
+  # ships the chrome zip to both Chrome Web Store and Edge Add-ons, so
+  # the chrome leg's artifact is labeled `movar-chrome-edge` to signal
+  # that one download covers both targets. Safari builds the unpacked
+  # extension; full Safari verification still requires the Xcode wrapper.
   build:
     runs-on: ubuntu-latest
     needs: verify
     strategy:
+      fail-fast: false
       matrix:
-        browser: [chrome, firefox, edge]
+        include:
+          - browser: chrome
+            script: zip
+            artifact: movar-chrome-edge
+          - browser: firefox
+            script: zip:firefox
+            artifact: movar-firefox
+          - browser: safari
+            script: zip:safari
+            artifact: movar-safari
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
@@ -71,11 +86,12 @@ jobs:
           node-version-file: .nvmrc
           cache: pnpm
       - run: pnpm install --frozen-lockfile
-      - run: pnpm nx run extension:build -- --browser=${{ matrix.browser }}
+      - run: pnpm --filter @movar/extension ${{ matrix.script }}
       - uses: actions/upload-artifact@v4
         with:
-          name: movar-${{ matrix.browser }}
-          path: apps/extension/.output/
+          name: ${{ matrix.artifact }}
+          path: apps/extension/.output/movarextension-*-${{ matrix.browser }}.zip
+          if-no-files-found: error
 
   # Offline e2e suite — the comprehensive CI gate for the extension's
   # rendered surfaces and content-script behaviour. Runs in parallel with

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,6 +92,9 @@ jobs:
           name: ${{ matrix.artifact }}
           path: apps/extension/.output/movarextension-*-${{ matrix.browser }}.zip
           if-no-files-found: error
+          # `.output/` starts with a dot, so upload-artifact treats it as
+          # a hidden path and skips it by default. Opt in explicitly.
+          include-hidden-files: true
 
   # Offline e2e suite — the comprehensive CI gate for the extension's
   # rendered surfaces and content-script behaviour. Runs in parallel with


### PR DESCRIPTION
## Summary

- The `build` matrix in `.github/workflows/ci.yml` was broken: `--browser=` was ignored by the Nx target, so each leg built all three browsers and uploaded the entire `.output/` tree as identical artifacts.
- Switched to an `include` block that runs the real per-browser `wxt zip` scripts and globs the precise zip from `.output/`, with `if-no-files-found: error` so a missing zip fails loudly. Added `fail-fast: false` so one browser's break can't hide the others.
- Dropped `edge` as a matrix leg — the release workflow already ships the chrome zip to both Chrome Web Store and Edge Add-ons, so the chrome artifact is labeled `movar-chrome-edge` to signal that one download covers both.

## Test plan

- [ ] CI run on this PR produces three artifacts (`movar-chrome-edge`, `movar-firefox`, `movar-safari`), each a single zip.
- [ ] Download `movar-chrome-edge`, extract, load unpacked in Chrome — popup + options surfaces render.
- [ ] Download `movar-firefox`, extract, load `manifest.json` as a temp add-on in Firefox.
- [ ] (Optional) `movar-safari` zip extracts cleanly; full Safari verification needs the Xcode wrapper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)