### PR TITLE
fix(ci): upload unpacked extensions so artifacts side-load cleanly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,11 +57,16 @@ jobs:
             .metrics/
             docs/REFACTORING-QUEUE.md
 
-  # Per-browser side-loadable zips for PR testers. The release workflow
-  # ships the chrome zip to both Chrome Web Store and Edge Add-ons, so
-  # the chrome leg's artifact is labeled `movar-chrome-edge` to signal
-  # that one download covers both targets. Safari builds the unpacked
-  # extension; full Safari verification still requires the Xcode wrapper.
+  # Per-browser unpacked extensions for PR testers. We upload the wxt
+  # output directory (not the wxt zip), so the GitHub-wrapped artifact
+  # download extracts straight to `manifest.json` + the rest at the
+  # root — no nested zip to confuse anyone. Chrome/Edge: "Load unpacked"
+  # on the extracted folder. Firefox: `about:debugging` → "Load Temporary
+  # Add-on…" → pick `manifest.json`. The release workflow ships the
+  # chrome zip to both Chrome Web Store and Edge Add-ons (built from the
+  # same `chrome-mv3/` output), so the chrome leg's artifact is labeled
+  # `movar-chrome-edge`. Safari builds the unpacked extension; actually
+  # installing in Safari still needs the Xcode wrapper.
   build:
     runs-on: ubuntu-latest
     needs: verify
@@ -70,13 +75,16 @@ jobs:
       matrix:
         include:
           - browser: chrome
-            script: zip
+            script: build:chrome
+            output: chrome-mv3
             artifact: movar-chrome-edge
           - browser: firefox
-            script: zip:firefox
+            script: build:firefox
+            output: firefox-mv3
             artifact: movar-firefox
           - browser: safari
-            script: zip:safari
+            script: build:safari
+            output: safari-mv3
             artifact: movar-safari
     steps:
       - uses: actions/checkout@v4
@@ -90,10 +98,10 @@ jobs:
       - uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.artifact }}
-          path: apps/extension/.output/movarextension-*-${{ matrix.browser }}.zip
+          path: apps/extension/.output/${{ matrix.output }}/
           if-no-files-found: error
-          # `.output/` starts with a dot, so upload-artifact treats it as
-          # a hidden path and skips it by default. Opt in explicitly.
+          # `.output/` starts with a dot, so upload-artifact treats it
+          # as a hidden path and skips it by default. Opt in explicitly.
           include-hidden-files: true
 
   # Offline e2e suite — the comprehensive CI gate for the extension's
@@ -192,3 +200,4 @@ jobs:
           path: apps/extension/.output/*.zip
           retention-days: 14
           if-no-files-found: ignore
+          include-hidden-files: true


### PR DESCRIPTION
## Summary

PR #40 wired the matrix to upload per-browser zips, but installation failed in Firefox with "this add-on could not be installed because it appears to be corrupt." Root cause: GitHub wraps every artifact in another zip on download, so testers got a zip-of-zip — neither layer is a directly-installable extension, and stable Firefox refuses unsigned drag-drop into `about:addons` regardless.

This swaps each matrix leg's upload from the wxt zip to the unpacked wxt output directory (`chrome-mv3` / `firefox-mv3` / `safari-mv3`). Now the GitHub download wrapper IS the extension: extract once and the contents are `manifest.json` + the rest at the root.

Also switches each leg's script from `zip[:browser]` to `build:<browser>` since no zip step is needed.

## Test plan

- [ ] CI run on this PR produces three artifacts (`movar-chrome-edge`, `movar-firefox`, `movar-safari`), each containing the unpacked extension files at the root.
- [ ] Download `movar-chrome-edge`, extract, point Chrome at the folder via `chrome://extensions` → developer mode → "Load unpacked". Popup + options surfaces render.
- [ ] Download `movar-firefox`, extract, open `about:debugging` → "This Firefox" → "Load Temporary Add-on…" → pick `manifest.json`. Popup + options surfaces render.
- [ ] (Optional) `movar-safari` extracts cleanly; full Safari verification still needs the Xcode wrapper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)