### PR TITLE
chore(ci): drop redundant extension-zips and fallow-metrics artifacts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,17 +45,6 @@ jobs:
       # Audit the PR diff against main — fail if new dead code, complexity,
       # or duplication is introduced. Fallow exits non-zero on regressions.
       - run: pnpm metrics:audit
-      - name: Generate metrics snapshot
-        if: always()
-        run: pnpm metrics
-      - name: Upload metrics report
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: fallow-metrics
-          path: |
-            .metrics/
-            docs/REFACTORING-QUEUE.md
 
   # Per-browser unpacked extensions for PR testers. We upload the wxt
   # output directory (not the wxt zip), so the GitHub-wrapped artifact
@@ -193,11 +182,3 @@ jobs:
           cache: pnpm
       - run: pnpm install --frozen-lockfile
       - run: pnpm verify:release
-      - uses: actions/upload-artifact@v4
-        if: always()
-        with:
-          name: extension-zips
-          path: apps/extension/.output/*.zip
-          retention-days: 14
-          if-no-files-found: ignore
-          include-hidden-files: true


### PR DESCRIPTION
## Summary

A green CI run was producing five artifacts. Most were redundant or unused:

| Artifact | Source | Status |
|---|---|---|
| `movar-chrome-edge` | build matrix | Keep |
| `movar-firefox` | build matrix | Keep |
| `movar-safari` | build matrix | Keep |
| `extension-zips` | verify-release | **Drop** — duplicates the per-browser artifacts |
| `fallow-metrics` | metrics | **Drop** — the audit gate (`pnpm metrics:audit`) is what enforces no regression; nobody downloads the snapshot |

`pnpm metrics:audit` still runs in the metrics job and fails the PR on a regression. `pnpm verify:release` still runs in verify-release and gates publint, addons-linter, etc. Only the artifact uploads (and the now-orphaned `pnpm metrics` snapshot step) are removed.

## Test plan

- [ ] CI run on this PR produces exactly three artifacts on success (`movar-chrome-edge`, `movar-firefox`, `movar-safari`).
- [ ] `metrics:audit` still fails the job on a synthetic regression (smoke-tested separately, not in this PR).
- [ ] `playwright-report` still uploads on e2e failure (unchanged by this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)