### PR TITLE
feat(marketing): wire firefox cta and expand browser detection

### DIFF
--- a/.fallowrc.json
+++ b/.fallowrc.json
@@ -7,7 +7,8 @@
     "**/*.fixture.html",
     "apps/extension/preview/**",
     "apps/extension/scripts/**",
-    "apps/e2e/playwright.*.ts"
+    "apps/e2e/playwright.*.ts",
+    "apps/extension/safari/**/Resources/**"
   ],
   "ignoreDependencies": [
     "@wxt-dev/module-react",

--- a/apps/extension/eslint.config.mjs
+++ b/apps/extension/eslint.config.mjs
@@ -46,6 +46,9 @@ export default [
   // Build/release helpers under `scripts/` are Node ESM modules invoked by
   // shell scripts (e.g. scripts/verify-release.sh). They legitimately use
   // `process` and `console`, and they never run inside the extension itself.
+  // `process.exit()` is the standard way to surface a non-zero exit code
+  // to the calling shell — the unicorn rule is for runtime code, not CLI
+  // helpers like these.
   {
     files: ['scripts/**/*.{mjs,mts}'],
     languageOptions: {
@@ -58,6 +61,7 @@ export default [
     },
     rules: {
       'no-console': 'off',
+      'unicorn/no-process-exit': 'off',
     },
   },
   // Storybook config + scene stories. Layout-only React, no extension APIs;

--- a/apps/marketing/src/components/DownloadButtons.astro
+++ b/apps/marketing/src/components/DownloadButtons.astro
@@ -1,16 +1,24 @@
 ---
 /*
  * Single CTA. The visitor doesn't pick a store — we detect their browser and
- * point the button at the matching one.
+ * point the button at the matching marketplace, with a GitHub-releases
+ * fallback so the button is always actionable.
  *
- * SSR renders the generic "Add Movar to your browser" label so the page is
- * useful with no JS and avoids a Chrome-specific flash for Edge/Firefox
- * visitors. The inline script below detects the visitor's browser and swaps
- * in the matching label + href.
+ * SSR renders the neutral "Add Movar to your browser" label with the GitHub
+ * fallback href so no-JS visitors and visitors mid-script-load both get a
+ * working destination. The inline script below detects the visitor's browser
+ * and swaps in the matching store label + href when there's a better target.
  *
- * While a per-browser listing isn't live (`liveAt` is null), the CTA is
- * disabled and shows a "Soon" badge. As stores go live, set the matching
- * `liveAt` to today's date and the CTA picks them up automatically.
+ * Per-browser states the script can land on:
+ * - Detected browser, matched store live  → enabled, per-browser label + href.
+ * - Detected browser, matched store Soon  → disabled, per-browser label
+ *                                           + "Soon" badge.
+ * - Unrecognised browser                  → enabled, "Get Movar from GitHub"
+ *                                           label, GitHub releases href.
+ *
+ * Opera and Brave install Chromium extensions via the Chrome Web Store
+ * but get their own button label. Safari needs a separate WebExtension
+ * build + App Store submission, tracked as its own Soon entry.
  */
 
 import { strings, type Locale } from '../i18n';
@@ -22,28 +30,58 @@ interface Props {
 const { lang = 'en' } = Astro.props;
 const t = strings[lang].download;
 
+type StoreId = 'chrome' | 'edge' | 'firefox' | 'safari';
+type BrowserId = 'chrome' | 'edge' | 'firefox' | 'opera' | 'brave' | 'safari';
+
 interface Store {
   href: string;
   liveAt: string | null;
 }
 
-const stores: Record<'chrome' | 'edge' | 'firefox', Store> = {
+// Universal fallback for visitors on a browser we don't recognise (Tor,
+// mobile in-app browsers, niche/private builds). Also the SSR href so the
+// CTA is never enabled-but-broken before the script runs.
+const fallbackHref = 'https://github.com/rejifald/movar/releases';
+
+const stores: Record<StoreId, Store> = {
   chrome: { href: '#', liveAt: null }, // TODO: paste Chrome Web Store URL on first publish
   edge: { href: '#', liveAt: null }, // TODO: paste Edge Add-ons URL on first publish
-  firefox: { href: '#', liveAt: null }, // TODO: paste Firefox AMO URL on first publish
+  // AMO redirects no-locale URLs to the visitor's preferred locale, so
+  // both the en and uk pages share one link.
+  firefox: { href: 'https://addons.mozilla.org/firefox/addon/movar/', liveAt: '2026-06-01' },
+  safari: { href: '#', liveAt: null }, // TODO: ship a Safari WebExtension + App Store listing
 };
 
-const anyLive = Object.values(stores).some((s) => s.liveAt !== null);
+// Opera and Brave install Chromium extensions from the Chrome Web Store —
+// reusing the chrome listing as the marketplace truth, while each browser
+// keeps its own user-facing label.
+const browserStore: Record<BrowserId, StoreId> = {
+  chrome: 'chrome',
+  edge: 'edge',
+  firefox: 'firefox',
+  opera: 'chrome',
+  brave: 'chrome',
+  safari: 'safari',
+};
+
+const perBrowser: Record<BrowserId, Store> = {
+  chrome: stores[browserStore.chrome],
+  edge: stores[browserStore.edge],
+  firefox: stores[browserStore.firefox],
+  opera: stores[browserStore.opera],
+  brave: stores[browserStore.brave],
+  safari: stores[browserStore.safari],
+};
 ---
 
 <div id="download" class="flex justify-center">
   <a
     data-cta
-    data-stores={JSON.stringify(stores)}
+    data-stores={JSON.stringify(perBrowser)}
     data-labels={JSON.stringify(t.add)}
     data-soon-label={t.soon}
-    href={anyLive ? '#' : undefined}
-    aria-disabled={anyLive ? undefined : 'true'}
+    data-fallback-label={t.viaGithub}
+    href={fallbackHref}
     class:list={[
       'group inline-flex items-center justify-center gap-2 rounded-xl px-6 py-3 text-sm font-semibold transition',
       'border border-accent bg-accent text-accent-on shadow-sm hover:shadow-md',
@@ -51,64 +89,60 @@ const anyLive = Object.values(stores).some((s) => s.liveAt !== null);
     ]}
   >
     <span data-cta-label>{t.addGeneric}</span>
-    {/*
-     * Tinted with bg-black/25 (not bg-accent-deep) so the badge stays a
-     * darker patch on the green button in both light and dark mode.
-     * accent-deep flips to a light green in dark mode (it's now a text
-     * colour for dark surfaces), which would kill white-on-green contrast
-     * here.
-     */}
-    {
-      !anyLive && (
-        <span
-          data-cta-soon
-          class="rounded-md bg-black/25 px-1.5 py-0.5 text-[11px] font-medium uppercase tracking-wide text-accent-on"
-        >
-          {t.soon}
-        </span>
-      )
-    }
   </a>
 </div>
 
 <script>
-  type StoreId = 'chrome' | 'edge' | 'firefox';
+  type BrowserId = 'chrome' | 'edge' | 'firefox' | 'opera' | 'brave' | 'safari';
 
   const cta = document.querySelector<HTMLAnchorElement>('[data-cta]');
   if (cta) {
-    // Order matters: Edge UA also matches "Chrome", so check Edge first.
+    // Order matters: Edge and Opera UAs also match "Chrome", so check
+    // their distinguishing tokens first. Brave hides itself in the UA
+    // but exposes `navigator.brave`. Safari is matched last because
+    // Chromium UAs also contain the literal "Safari".
     const ua = navigator.userAgent.toLowerCase();
-    let id: StoreId | null = null;
+    let id: BrowserId | null = null;
     if (ua.includes('edg/')) id = 'edge';
     else if (ua.includes('firefox')) id = 'firefox';
+    else if (ua.includes('opr/')) id = 'opera';
+    else if ('brave' in navigator) id = 'brave';
     else if (ua.includes('chrome')) id = 'chrome';
+    else if (ua.includes('safari')) id = 'safari';
 
-    if (id) {
-      const stores = JSON.parse(cta.dataset['stores'] ?? '{}') as Record<
-        StoreId,
-        { href: string; liveAt: string | null }
-      >;
-      const labels = JSON.parse(cta.dataset['labels'] ?? '{}') as Record<StoreId, string>;
-      const soonLabel = cta.dataset['soonLabel'] ?? '';
+    const stores = JSON.parse(cta.dataset['stores'] ?? '{}') as Record<
+      BrowserId,
+      { href: string; liveAt: string | null }
+    >;
+    const labels = JSON.parse(cta.dataset['labels'] ?? '{}') as Record<BrowserId, string>;
+    const soonLabel = cta.dataset['soonLabel'] ?? '';
+    const fallbackLabel = cta.dataset['fallbackLabel'] ?? '';
 
-      const labelEl = cta.querySelector<HTMLSpanElement>('[data-cta-label]');
+    const labelEl = cta.querySelector<HTMLSpanElement>('[data-cta-label]');
+
+    if (!id) {
+      // Unrecognised browser — keep the SSR GitHub href and refresh the
+      // label so visitors know where the button leads.
+      if (labelEl) labelEl.textContent = fallbackLabel;
+    } else {
       if (labelEl) labelEl.textContent = labels[id];
-
       const store = stores[id];
-      const existingSoon = cta.querySelector<HTMLSpanElement>('[data-cta-soon]');
-
       if (store?.liveAt) {
         cta.href = store.href;
-        cta.removeAttribute('aria-disabled');
-        existingSoon?.remove();
       } else {
+        // Store not live yet — disable and show the Soon badge instead
+        // of routing this visitor to a generic GitHub release for their
+        // browser. They'll get the proper store when it opens.
         cta.removeAttribute('href');
         cta.setAttribute('aria-disabled', 'true');
-        if (!existingSoon && labelEl) {
+        if (labelEl) {
           const span = document.createElement('span');
           span.dataset['ctaSoon'] = '';
-          // Mirror the SSR markup above — see the comment there for why
-          // bg-black/25 rather than bg-accent-deep.
+          // Tinted with bg-black/25 (not bg-accent-deep) so the badge
+          // stays a darker patch on the green button in both light and
+          // dark mode. accent-deep flips to a light green in dark mode
+          // (it's now a text colour for dark surfaces), which would kill
+          // white-on-green contrast here.
           span.className =
             'rounded-md bg-black/25 px-1.5 py-0.5 text-[11px] font-medium uppercase tracking-wide text-accent-on';
           span.textContent = soonLabel;

--- a/apps/marketing/src/components/DownloadButtons.stories.tsx
+++ b/apps/marketing/src/components/DownloadButtons.stories.tsx
@@ -5,16 +5,19 @@ import { strings, type Locale } from '../i18n';
 
 /**
  * React mock of `DownloadButtons.astro`. The Astro version ships an SSR
- * "Add Movar to your browser · Soon" fallback and an inline script that
- * detects the visitor's browser and swaps the label + href to whichever
- * store matches. The mock here doesn't run the script — instead it accepts
- * `browser` + `live` controls so each ship-time state has its own story.
+ * "Add Movar to your browser" fallback (with the GitHub releases href so
+ * the button is always actionable) and an inline script that detects the
+ * visitor's browser and swaps the label + href to whichever store matches.
+ * The mock here doesn't run the script — instead it accepts `browser` +
+ * `live` controls so each post-detection state has its own story.
  *
- * In v1 every store has `liveAt: null`, so the Soon badge is the only path
- * users will see. The Live stories are forward-looking previews of the
- * post-launch UI for each browser.
+ * As of 2026-06-01 only Firefox is live; Chrome, Edge, Opera, Brave and
+ * Safari render disabled with the Soon badge until their listings publish.
+ * Visitors on a browser we don't recognise see the GitHub releases CTA,
+ * enabled. The `live` toggle is ignored when `browser` is `unknown` —
+ * GitHub is always available, so unknown is never Soon.
  */
-type Browser = 'chrome' | 'edge' | 'firefox' | 'unknown';
+type Browser = 'chrome' | 'edge' | 'firefox' | 'opera' | 'brave' | 'safari' | 'unknown';
 type KnownBrowser = Exclude<Browser, 'unknown'>;
 
 interface MockProps {
@@ -24,12 +27,19 @@ interface MockProps {
   live?: boolean;
 }
 
-/** Pick the per-browser label, falling back to the generic when unknown. */
-function resolveAddLabel(t: (typeof strings)[Locale]['download'], browser: Browser): string {
-  if (browser !== 'unknown' && browser in t.add) {
-    return t.add[browser as KnownBrowser];
-  }
+/** Pick the per-browser label, with a GitHub fallback for unknown browsers. */
+function resolveLabel(t: (typeof strings)[Locale]['download'], browser: Browser): string {
+  if (browser === 'unknown') return t.viaGithub;
+  if (browser in t.add) return t.add[browser as KnownBrowser];
   return t.addGeneric;
+}
+
+/**
+ * Pick the anchor attributes for the enabled/disabled state. Collapses two
+ * ternaries (href + aria-disabled) into one, which keeps the mock simple.
+ */
+function anchorAttrs(enabled: boolean): { href?: string; 'aria-disabled'?: 'true' } {
+  return enabled ? { href: '#' } : { 'aria-disabled': 'true' };
 }
 
 function DownloadButtonsMock({
@@ -38,18 +48,20 @@ function DownloadButtonsMock({
   live = false,
 }: MockProps): JSX.Element {
   const t = strings[lang].download;
-  const label = resolveAddLabel(t, browser);
+  const label = resolveLabel(t, browser);
+  // Unknown browsers route to the GitHub releases page — always enabled,
+  // never Soon. Known browsers respect the `live` toggle.
+  const enabled = browser === 'unknown' || live;
 
   return (
     <div className="grid place-items-center px-6 py-20">
       <div id="download" className="flex justify-center">
         <a
-          href={live ? '#' : undefined}
-          aria-disabled={live ? undefined : 'true'}
+          {...anchorAttrs(enabled)}
           className="group border-accent bg-accent text-accent-on inline-flex items-center justify-center gap-2 rounded-xl border px-6 py-3 text-sm font-semibold shadow-sm transition hover:shadow-md aria-disabled:cursor-not-allowed aria-disabled:opacity-60 aria-disabled:hover:shadow-sm"
         >
           <span>{label}</span>
-          {!live && (
+          {!enabled && (
             <span className="text-accent-on rounded-md bg-black/25 px-1.5 py-0.5 text-[11px] font-medium tracking-wide uppercase">
               {t.soon}
             </span>
@@ -67,7 +79,15 @@ const meta = {
     lang: { control: { type: 'inline-radio' }, options: ['en', 'uk'] satisfies Locale[] },
     browser: {
       control: { type: 'inline-radio' },
-      options: ['unknown', 'chrome', 'edge', 'firefox'] satisfies Browser[],
+      options: [
+        'unknown',
+        'chrome',
+        'edge',
+        'firefox',
+        'opera',
+        'brave',
+        'safari',
+      ] satisfies Browser[],
     },
     live: { control: 'boolean' },
   },
@@ -76,13 +96,25 @@ export default meta;
 
 type Story = StoryObj<typeof meta>;
 
-export const SoonGeneric: Story = {
-  name: 'Soon · unknown browser (SSR fallback)',
+export const FallbackUnknown: Story = {
+  name: 'GitHub fallback · unknown browser',
   args: { lang: 'en', browser: 'unknown', live: false },
 };
 export const SoonChrome: Story = {
   name: 'Soon · Chrome',
   args: { lang: 'en', browser: 'chrome', live: false },
+};
+export const SoonOpera: Story = {
+  name: 'Soon · Opera',
+  args: { lang: 'en', browser: 'opera', live: false },
+};
+export const SoonBrave: Story = {
+  name: 'Soon · Brave',
+  args: { lang: 'en', browser: 'brave', live: false },
+};
+export const SoonSafari: Story = {
+  name: 'Soon · Safari',
+  args: { lang: 'en', browser: 'safari', live: false },
 };
 export const LiveChrome: Story = {
   name: 'Live · Chrome',
@@ -92,7 +124,7 @@ export const LiveFirefox: Story = {
   name: 'Live · Firefox',
   args: { lang: 'en', browser: 'firefox', live: true },
 };
-export const SoonUkrainian: Story = {
-  name: 'Soon · Ukrainian',
+export const FallbackUkrainian: Story = {
+  name: 'GitHub fallback · Ukrainian',
   args: { lang: 'uk', browser: 'unknown', live: false },
 };

--- a/apps/marketing/src/i18n.ts
+++ b/apps/marketing/src/i18n.ts
@@ -115,10 +115,20 @@ interface FooterStrings {
 }
 
 interface DownloadStrings {
-  /** Per-browser labels. JS swaps the CTA to the one matching the visitor. */
-  add: Record<'chrome' | 'edge' | 'firefox', string>;
-  /** Fallback label rendered before JS runs and for unrecognised browsers. */
+  /**
+   * Per-browser labels. JS swaps the CTA to the one matching the visitor.
+   * Opera and Brave install Chromium extensions via the Chrome Web Store
+   * but show their own brand on the button.
+   */
+  add: Record<'chrome' | 'edge' | 'firefox' | 'opera' | 'brave' | 'safari', string>;
+  /** Neutral SSR label, rendered before JS runs. */
   addGeneric: string;
+  /**
+   * Label shown post-detection to visitors on an unrecognised browser
+   * (Tor, mobile in-app browsers, niche/private builds). The CTA points
+   * at the GitHub releases page so power users can sideload a build.
+   */
+  viaGithub: string;
   /** Inline badge on the CTA when the matched store isn't live yet. */
   soon: string;
 }
@@ -431,8 +441,12 @@ const en: Strings = {
       chrome: 'Add to Chrome',
       edge: 'Add to Edge',
       firefox: 'Add to Firefox',
+      opera: 'Add to Opera',
+      brave: 'Add to Brave',
+      safari: 'Add to Safari',
     },
     addGeneric: 'Add Movar to your browser',
+    viaGithub: 'Get Movar from GitHub',
     soon: 'Soon',
   },
   og: {
@@ -731,8 +745,12 @@ const uk: Strings = {
       chrome: 'Додати в Chrome',
       edge: 'Додати в Edge',
       firefox: 'Додати в Firefox',
+      opera: 'Додати в Opera',
+      brave: 'Додати в Brave',
+      safari: 'Додати в Safari',
     },
     addGeneric: 'Додати Movar у браузер',
+    viaGithub: 'Завантажити Movar з GitHub',
     soon: 'Незабаром',
   },
   og: {

--- a/tooling/eslint-config-movar/configs/ignores.js
+++ b/tooling/eslint-config-movar/configs/ignores.js
@@ -23,6 +23,18 @@ export const workspaceIgnores = {
     // Demo-video pipeline output — captured WebM and ffmpeg derivations.
     'apps/e2e/demo-results/**',
     'apps/e2e/src/demo/out/**',
+    // Safari Web Extension wrapper Resources directories:
+    //   - `Shared (Extension)/Resources/` is rsynced from
+    //     `.output/safari-mv3/` by `scripts/sync-safari-resources.mts`
+    //     and contains bundler output (minified JS, chunks/) that's
+    //     not lintable as workspace source.
+    //   - `Shared (App)/Resources/` carries the Xcode app-shell's host
+    //     scripts that run in WebKit's host page context, not the
+    //     workspace's TypeScript browser env, so they trip every
+    //     no-undef rule.
+    // ESLint coverage for either can be added back with a scoped config
+    // once the Safari shell has its own globals declared.
+    '**/safari/**/Resources/**',
     // Per-developer runtime junk that doesn't get committed (see .gitignore)
     // but does sit on disk under apps/* and would otherwise trip
     // browser-flavoured globals (e.g. Firefox prefs.js's `user_pref`).


### PR DESCRIPTION
## Summary

- Firefox AMO link goes live (`liveAt: 2026-06-01`); the CTA now matches the visitor's browser via UA detection.
- Per-browser labels for Opera, Brave, and Safari. Opera and Brave install Chromium extensions from the Chrome Web Store but keep their own brand on the button. Safari is a separate placeholder store.
- Unrecognised browsers (Tor, mobile in-app browsers, niche/private builds) fall back to the GitHub releases page. The SSR href is the same GitHub URL so no-JS visitors get a working destination instead of a placeholder `#`.

### Lint-plumbing side-effects (required to commit)

- `**/safari/**/Resources/**` added to the shared ESLint `workspaceIgnores` and to `.fallowrc.json` `ignorePatterns`. The Resources directory is rsynced from `.output/safari-mv3/` by `sync-safari-resources.mts` (bundler output) and contains the Xcode app-shell's host scripts — not workspace source.
- `unicorn/no-process-exit` disabled for `apps/extension/scripts/**/*.{mjs,mts}`. The existing override already declares these CLI helpers legitimately use `process` — `process.exit` is the standard exit-code path.

## Test plan

- [x] `astro check` clean (0 errors).
- [x] Replayed detection script against the live page's serialized data for all seven cases (Chrome / Edge / Firefox / Opera / Brave / Safari / Unknown) — every state renders the right label + href + Soon-vs-enabled.
- [x] Inspected SSR HTML: href is the GitHub releases URL, label is neutral, no Soon badge → no-JS visitors get a working destination.
- [x] Pre-commit (eslint, prettier, test, typecheck, commitlint) and pre-push (fallow audit) all clean on the workspace.
- [ ] Marketing CI checks pass on this PR.
- [ ] Spot-check the live deploy preview on Chrome (expect "Add to Chrome · Soon" disabled) and on Firefox (expect "Add to Firefox" → AMO).

🤖 Generated with [Claude Code](https://claude.com/claude-code)