### PR TITLE
fix(marketing): make footer mobile friendly

### DIFF
--- a/apps/marketing/src/components/Footer.astro
+++ b/apps/marketing/src/components/Footer.astro
@@ -15,22 +15,27 @@ const year = new Date().getFullYear();
 
 <footer class="mt-auto border-t border-border bg-surface px-6 py-8 text-sm text-ink-soft">
   <div class="mx-auto flex max-w-5xl flex-col items-start justify-between gap-4 sm:flex-row sm:items-center">
-    <div class="flex items-center gap-2">
+    <div class="flex flex-wrap items-center gap-x-2 gap-y-1">
       <img src="/icon.svg" alt="" width="20" height="20" class="rounded" />
-      <span>
-        <span class="font-display font-bold text-ink-strong">movar.fyi</span>
-        &middot; &copy; {year} {t.credits}
-      </span>
+      <span class="font-display font-bold text-ink-strong">movar.fyi</span>
+      <span aria-hidden="true" class="hidden sm:inline">&middot;</span>
+      <span>&copy; {year} {t.credits}</span>
     </div>
-    <nav class="flex items-center gap-5">
-      <a href={privacy} class="hover:text-ink-strong transition">{t.privacy}</a>
+    <nav class="flex flex-col items-start gap-1 sm:flex-row sm:items-center sm:gap-5">
+      <a
+        href={privacy}
+        class="-mx-2 px-2 py-2.5 transition hover:text-ink-strong sm:mx-0 sm:p-0">{t.privacy}</a>
       <a
         href={SOURCE_URL}
         target="_blank"
         rel="noopener noreferrer"
-        class="hover:text-ink-strong transition">{t.sourceCode}</a>
-      <a href={`${home}#download`} class="hover:text-ink-strong transition">{t.download}</a>
-      <a href={FEEDBACK_URL} class="hover:text-ink-strong transition">{t.feedback}</a>
+        class="-mx-2 px-2 py-2.5 transition hover:text-ink-strong sm:mx-0 sm:p-0">{t.sourceCode}</a>
+      <a
+        href={`${home}#download`}
+        class="-mx-2 px-2 py-2.5 transition hover:text-ink-strong sm:mx-0 sm:p-0">{t.download}</a>
+      <a
+        href={FEEDBACK_URL}
+        class="-mx-2 px-2 py-2.5 transition hover:text-ink-strong sm:mx-0 sm:p-0">{t.feedback}</a>
     </nav>
   </div>
 </footer>

--- a/apps/marketing/src/components/Footer.stories.tsx
+++ b/apps/marketing/src/components/Footer.stories.tsx
@@ -13,29 +13,41 @@ function FooterMock({ lang = 'en' as Locale, year = new Date().getFullYear() }):
   return (
     <footer className="border-border bg-surface text-ink-soft mt-auto border-t px-6 py-8 text-sm">
       <div className="mx-auto flex max-w-5xl flex-col items-start justify-between gap-4 sm:flex-row sm:items-center">
-        <div className="flex items-center gap-2">
+        <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
           <img src="/icon.svg" alt="" width={20} height={20} className="rounded" />
+          <span className="font-display text-ink-strong font-bold">movar.fyi</span>
+          <span aria-hidden="true" className="hidden sm:inline">
+            &middot;
+          </span>
           <span>
-            <span className="font-display text-ink-strong font-bold">movar.fyi</span> &middot;
             &copy; {year} {t.credits}
           </span>
         </div>
-        <nav className="flex items-center gap-5">
-          <a href={privacy} className="hover:text-ink-strong transition">
+        <nav className="flex flex-col items-start gap-1 sm:flex-row sm:items-center sm:gap-5">
+          <a
+            href={privacy}
+            className="hover:text-ink-strong -mx-2 px-2 py-2.5 transition sm:mx-0 sm:p-0"
+          >
             {t.privacy}
           </a>
           <a
             href={SOURCE_URL}
             target="_blank"
             rel="noopener noreferrer"
-            className="hover:text-ink-strong transition"
+            className="hover:text-ink-strong -mx-2 px-2 py-2.5 transition sm:mx-0 sm:p-0"
           >
             {t.sourceCode}
           </a>
-          <a href={`${home}#download`} className="hover:text-ink-strong transition">
+          <a
+            href={`${home}#download`}
+            className="hover:text-ink-strong -mx-2 px-2 py-2.5 transition sm:mx-0 sm:p-0"
+          >
             {t.download}
           </a>
-          <a href={FEEDBACK_URL} className="hover:text-ink-strong transition">
+          <a
+            href={FEEDBACK_URL}
+            className="hover:text-ink-strong -mx-2 px-2 py-2.5 transition sm:mx-0 sm:p-0"
+          >
             {t.feedback}
           </a>
         </nav>


### PR DESCRIPTION
## What

Makes the marketing site footer mobile-friendly (independent of PR #50).

- **Links stack in a column on mobile** with comfortable **~40px tap targets** (was ~20px — below the WCAG 2.2 AA 24px floor). Hit area expands via `-mx-2 px-2 py-2.5`; text stays aligned with the copyright. Resets to the inline row at `sm`.
- **Brand/copyright row wraps**: logo + `movar.fyi` on line 1, copyright (`· © YYYY …`) on its own line below — no orphaned wrapping, no horizontal overflow.
- **Desktop is unchanged** — all mobile-only padding/margins reset at `sm` (verified: row, gap-5, padding/margin = 0).

Mirrored the same classes in `Footer.stories.tsx` (the React mock kept in sync per its own comment).

## Design review

Applied a design critique focused on mobile: contrast passes (4.8:1 light / 6.9:1 dark), decorative logo `alt=""` is correct; the one real gap was tap-target size, which this fixes.

## Verification

Built the static site and measured the live DOM at 375px and 900px:
- mobile: nav `flex-direction: column`, each link 40px tall, 4px gaps, text at x=24, no overflow
- desktop: nav `row`, single line, gap 20px, link padding/margin reset to 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)