### PR TITLE
ci: regenerate-baselines pushes via a PAT so CI re-triggers automatically

### DIFF
--- a/.github/workflows/regenerate-baselines.yml
+++ b/.github/workflows/regenerate-baselines.yml
@@ -15,9 +15,10 @@ name: Regenerate visual baselines (Linux)
 # UI change has shifted pixels and `e2e-offline` is failing on visual
 # diffs. Pick the feature branch with the UI change (or `main` if the
 # change has already merged and only Linux is stale). The workflow runs
-# `test:update` under Xvfb, commits any new `*-linux.png` files
-# back to the same ref as `github-actions[bot]`, then dispatches `ci.yml`
-# against the new tip so the green check shows up automatically.
+# `test:update` under Xvfb, then commits any new `*-linux.png` files back
+# to the same ref. The push is authenticated with a PAT
+# (`BASELINE_BOT_PAT`), so it re-triggers `ci.yml` automatically and the
+# fresh green check registers on the PR head.
 #
 # Why direct push (not a PR): regenerated baselines are mechanical
 # output, not a design change. A PR step would buy review the contributor
@@ -26,21 +27,26 @@ name: Regenerate visual baselines (Linux)
 # ceremony. The diff still lands in `git log` so anyone curious can audit
 # it.
 #
-# Why the extra dispatch at the end: a `git push` made with `GITHUB_TOKEN`
-# does NOT re-trigger any workflow that watches `push` (GitHub's
-# infinite-loop guard). Without the dispatch, the freshly-baselined ref
-# would sit green-pending forever until someone hand-pushed a no-op
-# commit. `gh workflow run ci.yml --ref ${{ github.ref_name }}` requires
-# `workflow_dispatch:` to be declared on `ci.yml` (it is).
+# Why a PAT for the push (`BASELINE_BOT_PAT`): a `git push` made with the
+# default `GITHUB_TOKEN` does NOT trigger any workflow (GitHub's
+# infinite-loop guard), so the freshly-baselined commit would sit with no
+# CI and never go green. The old workaround was an extra
+# `gh workflow run ci.yml` hop, but that `workflow_dispatch` run didn't
+# register cleanly as a PR check. Pushing as a PAT-backed identity instead
+# triggers `pull_request` -> `ci.yml` directly. REQUIRED secret: a
+# fine-grained PAT with Contents: Read+Write on this repo, stored as
+# `BASELINE_BOT_PAT`. (A GitHub App token via actions/create-github-app-token
+# works too, and is shorter-lived.)
 
 on:
   workflow_dispatch:
 
-# `contents: write` for the push back. `actions: write` so the final
-# `gh workflow run` succeeds (dispatching a workflow needs that scope).
+# The baseline commit is pushed with `BASELINE_BOT_PAT` (see checkout),
+# which is what makes the push re-trigger CI. `contents: write` keeps the
+# default token write-capable for completeness; no `actions: write` — we
+# no longer dispatch a workflow.
 permissions:
   contents: write
-  actions: write
 
 # Serialise dispatches per ref — two simultaneous regenerations would
 # race on the same push and one would lose the race with a
@@ -53,14 +59,13 @@ jobs:
   regenerate:
     runs-on: ubuntu-latest
     steps:
-      # `ref:` is implicit (defaults to the ref that dispatched us), but
-      # we set `token:` so the later `git push` carries write scope and
-      # can land on the same branch. The default token already has that
-      # scope thanks to the `permissions:` block above; we just need
-      # checkout to wire it through.
+      # `ref:` is implicit (defaults to the ref that dispatched us). We
+      # check out with a PAT (`BASELINE_BOT_PAT`) so the later `git push`
+      # is authenticated as a real identity — a GITHUB_TOKEN push would not
+      # re-trigger `ci.yml` (loop guard), but a PAT push does.
       - uses: actions/checkout@v4
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.BASELINE_BOT_PAT }}
 
       - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
@@ -98,7 +103,6 @@ jobs:
       # commit.
       - name: Commit and push baselines
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           # Disable lefthook for this run: the local repo hooks
           # (`pre-commit`: prettier, vitest; `pre-push`: e2e-fast,
           # metrics) are author-time validation that doesn't belong in
@@ -114,19 +118,14 @@ jobs:
 
           # `--cached --quiet` exits 1 iff there are staged changes.
           # When `update-snapshots` is a no-op (baselines already
-          # current), skip the commit + push + dispatch — there's
-          # nothing to ship and re-triggering CI on the same SHA would
-          # just produce a duplicate failing run.
+          # current), skip the commit + push — there's nothing to ship.
           if git diff --cached --quiet; then
-            echo 'Linux baselines were already current — no commit, no push, no dispatch.'
+            echo 'Linux baselines were already current — no commit, no push.'
             exit 0
           fi
 
           git commit -m 'chore(e2e): regenerate visual baselines (Linux)'
+          # PAT-authenticated push (see checkout) re-triggers ci.yml via
+          # pull_request automatically — the new check registers on its own.
           git push origin HEAD:${{ github.ref_name }}
-
-          # Re-trigger CI on the new tip. `gh` reads GITHUB_TOKEN from
-          # env. `ci.yml` must declare `workflow_dispatch:` for this to
-          # succeed.
-          gh workflow run ci.yml --ref ${{ github.ref_name }}
-          echo 'Pushed regenerated baselines and dispatched ci.yml.'
+          echo 'Pushed regenerated baselines; CI re-triggers via the PAT push.'


### PR DESCRIPTION
## What

`regenerate-baselines.yml` pushes regenerated Linux visual baselines, but the push was authenticated with `GITHUB_TOKEN`. **Pushes authored by `GITHUB_TOKEN` don't trigger any workflow** (GitHub's loop guard), so the freshly-baselined commit got no real CI run. The workflow worked around this with an extra `gh workflow run ci.yml` dispatch — but that `workflow_dispatch` run doesn't register cleanly as a PR status check (it showed up as "no checks reported" on the PR head even though the underlying check-runs were green).

## Change

- Check out + push with a **PAT** (`secrets.BASELINE_BOT_PAT`) instead of `GITHUB_TOKEN`. A PAT-authored push **does** trigger `pull_request` → `ci.yml`, so the new check registers automatically on the PR head.
- Remove the `gh workflow run ci.yml` dispatch step and the `actions: write` permission (no longer needed).
- Update the rationale comments.

## ⚠️ Required before next use

Create a repo secret **`BASELINE_BOT_PAT`** — a fine-grained PAT with **Contents: Read and write** on this repo (a classic PAT with `repo` scope also works). Until it's set, `regenerate-baselines.yml` will fail at checkout/push.

Alternative if you'd rather not store a long-lived PAT: a GitHub App token via `actions/create-github-app-token` (shorter-lived, scoped) — happy to switch to that if you prefer.

## Context

Surfaced while fixing the `e2e-offline` visual-baseline failure on the v1.1.0 release PR (#53), where the bot's baseline commit needed a manual nudge to get a green check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
