### PR TITLE
feat(extension): Safari app extension — build, deploy, and enablement screen

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,10 @@
 name: Release
 
-# Submits the extension to AMO, Chrome Web Store, and Edge Add-ons, and
-# attaches all four artifact zips (chrome, firefox, safari, sources) to
-# the GitHub Release for archival.
+# Submits the extension to AMO, Chrome Web Store, Edge Add-ons, and — when
+# Apple signing secrets are present — the App Store (iOS + macOS) plus a
+# notarized direct-download .dmg. Attaches the four web-ext artifact zips
+# (chrome, firefox, safari, sources) and the notarized macOS .dmg to the
+# GitHub Release for archival.
 #
 # Trigger: publish a GitHub Release whose tag matches `extension-v<semver>`
 # (e.g. `extension-v1.0.1`). The tag must match
@@ -24,11 +26,12 @@ name: Release
 # secrets log a warning and skip, rather than failing the whole release.
 # This lets you wire up one store at a time without breaking the others.
 #
-# Safari is intentionally not auto-submitted: App Store Connect
-# notarization requires a macOS runner, Apple Developer Program
-# enrollment, and signing certs that are out of scope here. The Safari
-# zip is still built and attached to the Release for archival / manual
-# submission via Xcode + Transporter.
+# Safari ships through the `release-safari` job on a macOS runner: it
+# archives the Xcode wrapper, uploads the iOS + macOS builds to App Store
+# Connect, and notarizes a Developer ID .dmg for direct download. Like the
+# other store jobs it skips (with a warning) when its Apple secrets are
+# absent, so it stays dormant until the Apple Developer account is enrolled
+# and the secrets are set. Setup + secrets: docs/safari-deploy.md.
 #
 # Reviewers at every store are still humans — this workflow only delivers
 # the artifact to each store's review queue.
@@ -327,3 +330,147 @@ jobs:
             -o /dev/null -w '%{http_code}')
           [ "$publish_code" = "202" ] || { echo "::error::Edge publish returned HTTP $publish_code"; exit 1; }
           echo "Submitted to Edge Add-ons review queue."
+
+  release-safari:
+    needs: prepare
+    # macOS runner is required for xcodebuild / notarytool. Pinned for a
+    # deterministic Xcode (the modern `app-store-connect` export method needs
+    # Xcode 15.3+). macOS minutes cost ~10x Linux, so — like the other store
+    # jobs — this runs only at release time; per-PR coverage is the cheap
+    # Linux `build:safari` web-ext build in ci.yml.
+    runs-on: macos-15
+    # Submit only for a published Release, or a dispatch explicitly opting in
+    # with dry_run=false. A release-branch push validates the web-ext build in
+    # `prepare` but never reaches Apple.
+    if: >-
+      github.event_name == 'release' ||
+      (github.event_name == 'workflow_dispatch' && !inputs.dry_run)
+    steps:
+      - uses: actions/checkout@v4
+
+      - id: check
+        name: Check Apple signing credentials
+        env:
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          APPLE_ASC_KEY_ID: ${{ secrets.APPLE_ASC_KEY_ID }}
+          APPLE_ASC_ISSUER_ID: ${{ secrets.APPLE_ASC_ISSUER_ID }}
+          APPLE_ASC_API_KEY_P8: ${{ secrets.APPLE_ASC_API_KEY_P8 }}
+          APPLE_DIST_CERT_P12_BASE64: ${{ secrets.APPLE_DIST_CERT_P12_BASE64 }}
+          APPLE_DEVELOPER_ID_CERT_P12_BASE64: ${{ secrets.APPLE_DEVELOPER_ID_CERT_P12_BASE64 }}
+        run: |
+          if [ -z "$APPLE_TEAM_ID" ] || [ -z "$APPLE_ASC_KEY_ID" ] \
+            || [ -z "$APPLE_ASC_ISSUER_ID" ] || [ -z "$APPLE_ASC_API_KEY_P8" ] \
+            || [ -z "$APPLE_DIST_CERT_P12_BASE64" ] \
+            || [ -z "$APPLE_DEVELOPER_ID_CERT_P12_BASE64" ]; then
+            echo "::warning::Apple credentials missing — skipping Safari release (see docs/safari-deploy.md)"
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - if: steps.check.outputs.skip != 'true'
+        uses: pnpm/action-setup@v4
+      - if: steps.check.outputs.skip != 'true'
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+          cache: pnpm
+
+      - if: steps.check.outputs.skip != 'true'
+        run: pnpm install --frozen-lockfile
+
+      # Build the Safari web extension and sync it into the Xcode project's
+      # Extension Resources (gitignored; empty on a fresh runner).
+      - if: steps.check.outputs.skip != 'true'
+        run: pnpm --filter @movar/extension build:safari
+
+      # One self-contained step: stand up a throwaway keychain, archive both
+      # apps, export + upload to App Store Connect, then export + notarize +
+      # staple the Developer ID build and package the .dmg. Kept in a single
+      # shell so the generated keychain password and temp paths stay in scope.
+      - if: steps.check.outputs.skip != 'true'
+        name: Archive, sign, notarize, and submit
+        env:
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          APPLE_ASC_KEY_ID: ${{ secrets.APPLE_ASC_KEY_ID }}
+          APPLE_ASC_ISSUER_ID: ${{ secrets.APPLE_ASC_ISSUER_ID }}
+          APPLE_ASC_API_KEY_P8: ${{ secrets.APPLE_ASC_API_KEY_P8 }}
+          APPLE_DIST_CERT_P12_BASE64: ${{ secrets.APPLE_DIST_CERT_P12_BASE64 }}
+          APPLE_DIST_CERT_PASSWORD: ${{ secrets.APPLE_DIST_CERT_PASSWORD }}
+          APPLE_DEVELOPER_ID_CERT_P12_BASE64: ${{ secrets.APPLE_DEVELOPER_ID_CERT_P12_BASE64 }}
+          APPLE_DEVELOPER_ID_CERT_PASSWORD: ${{ secrets.APPLE_DEVELOPER_ID_CERT_PASSWORD }}
+          VERSION: ${{ needs.prepare.outputs.version }}
+          BUILD_NUMBER: ${{ github.run_number }}
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          IS_RELEASE: ${{ github.event_name == 'release' }}
+        run: |
+          set -euo pipefail
+          PROJECT="apps/extension/safari/Movar/Movar.xcodeproj"
+          KEY_PATH="$HOME/.private_keys/AuthKey_${APPLE_ASC_KEY_ID}.p8"
+
+          # --- throwaway keychain + signing certs ---
+          KEYCHAIN="$RUNNER_TEMP/movar-signing.keychain-db"
+          KEYCHAIN_PW="$(uuidgen)"
+          security create-keychain -p "$KEYCHAIN_PW" "$KEYCHAIN"
+          security set-keychain-settings -lut 3600 "$KEYCHAIN"
+          security unlock-keychain -p "$KEYCHAIN_PW" "$KEYCHAIN"
+          echo "$APPLE_DIST_CERT_P12_BASE64" | base64 --decode > "$RUNNER_TEMP/dist.p12"
+          echo "$APPLE_DEVELOPER_ID_CERT_P12_BASE64" | base64 --decode > "$RUNNER_TEMP/devid.p12"
+          security import "$RUNNER_TEMP/dist.p12" -k "$KEYCHAIN" -P "$APPLE_DIST_CERT_PASSWORD" -T /usr/bin/codesign -T /usr/bin/productbuild
+          security import "$RUNNER_TEMP/devid.p12" -k "$KEYCHAIN" -P "$APPLE_DEVELOPER_ID_CERT_PASSWORD" -T /usr/bin/codesign -T /usr/bin/productbuild
+          security set-key-partition-list -S apple-tool:,apple: -k "$KEYCHAIN_PW" "$KEYCHAIN" >/dev/null
+          # Make our throwaway keychain the (only) user keychain so xcodebuild's
+          # automatic signing finds the imported identities. The runner is
+          # ephemeral, so replacing the search list is fine.
+          security list-keychains -d user -s "$KEYCHAIN"
+          security default-keychain -d user -s "$KEYCHAIN"
+
+          # --- App Store Connect API key (archive profiles + altool + notarytool) ---
+          mkdir -p "$HOME/.private_keys" "$HOME/.appstoreconnect/private_keys"
+          echo "$APPLE_ASC_API_KEY_P8" | base64 --decode > "$KEY_PATH"
+          cp "$KEY_PATH" "$HOME/.appstoreconnect/private_keys/"
+
+          AUTH=( -allowProvisioningUpdates
+            -authenticationKeyPath "$KEY_PATH"
+            -authenticationKeyID "$APPLE_ASC_KEY_ID"
+            -authenticationKeyIssuerID "$APPLE_ASC_ISSUER_ID" )
+          VERS=( MARKETING_VERSION="$VERSION" CURRENT_PROJECT_VERSION="$BUILD_NUMBER" DEVELOPMENT_TEAM="$APPLE_TEAM_ID" )
+
+          # --- archive iOS + macOS ---
+          xcodebuild -project "$PROJECT" -scheme "Movar (iOS)" -configuration Release \
+            -destination 'generic/platform=iOS' -archivePath "$RUNNER_TEMP/Movar-iOS.xcarchive" \
+            "${VERS[@]}" "${AUTH[@]}" archive
+          xcodebuild -project "$PROJECT" -scheme "Movar (macOS)" -configuration Release \
+            -destination 'generic/platform=macOS' -archivePath "$RUNNER_TEMP/Movar-macOS.xcarchive" \
+            "${VERS[@]}" "${AUTH[@]}" archive
+
+          # --- App Store: export + upload (iOS .ipa, macOS .pkg) ---
+          xcodebuild -exportArchive -archivePath "$RUNNER_TEMP/Movar-iOS.xcarchive" \
+            -exportPath "$RUNNER_TEMP/appstore-ios" \
+            -exportOptionsPlist apps/extension/safari/exportOptions/app-store.plist "${AUTH[@]}"
+          xcodebuild -exportArchive -archivePath "$RUNNER_TEMP/Movar-macOS.xcarchive" \
+            -exportPath "$RUNNER_TEMP/appstore-mac" \
+            -exportOptionsPlist apps/extension/safari/exportOptions/app-store.plist "${AUTH[@]}"
+          xcrun altool --upload-app -t ios \
+            -f "$(ls "$RUNNER_TEMP"/appstore-ios/*.ipa)" \
+            --apiKey "$APPLE_ASC_KEY_ID" --apiIssuer "$APPLE_ASC_ISSUER_ID"
+          xcrun altool --upload-app -t macos \
+            -f "$(ls "$RUNNER_TEMP"/appstore-mac/*.pkg)" \
+            --apiKey "$APPLE_ASC_KEY_ID" --apiIssuer "$APPLE_ASC_ISSUER_ID"
+
+          # --- Developer ID: export + notarize + staple + .dmg (direct download) ---
+          xcodebuild -exportArchive -archivePath "$RUNNER_TEMP/Movar-macOS.xcarchive" \
+            -exportPath "$RUNNER_TEMP/devid-mac" \
+            -exportOptionsPlist apps/extension/safari/exportOptions/developer-id.plist "${AUTH[@]}"
+          APP="$RUNNER_TEMP/devid-mac/Movar.app"
+          ditto -c -k --keepParent "$APP" "$RUNNER_TEMP/Movar-notarize.zip"
+          xcrun notarytool submit "$RUNNER_TEMP/Movar-notarize.zip" \
+            --key "$KEY_PATH" --key-id "$APPLE_ASC_KEY_ID" --issuer "$APPLE_ASC_ISSUER_ID" --wait
+          xcrun stapler staple "$APP"
+          DMG="$RUNNER_TEMP/Movar-${VERSION}.dmg"
+          hdiutil create -volname "Movar" -srcfolder "$APP" -ov -format UDZO "$DMG"
+
+          # Attach the notarized .dmg to the GitHub Release (release event only).
+          if [ "$IS_RELEASE" = "true" ]; then
+            gh release upload "$RELEASE_TAG" "$DMG" --clobber
+          fi
+          echo "Safari: uploaded iOS + macOS to App Store Connect; notarized $DMG."

--- a/apps/extension/package.json
+++ b/apps/extension/package.json
@@ -13,6 +13,7 @@
     "build:chrome": "wxt build",
     "build:firefox": "wxt build -b firefox",
     "build:safari": "wxt build -b safari && tsx scripts/sync-safari-resources.mts",
+    "build:safari:app": "tsx scripts/build-safari-app.mts",
     "sync:safari": "tsx scripts/sync-safari-resources.mts",
     "zip": "wxt zip",
     "zip:firefox": "wxt zip -b firefox",

--- a/apps/extension/safari/Movar/Movar.xcodeproj/project.pbxproj
+++ b/apps/extension/safari/Movar/Movar.xcodeproj/project.pbxproj
@@ -95,6 +95,7 @@
 
 /* Begin PBXFileReference section */
 		3B701C452FCE1FC100E8A5FF /* Base */ = {isa = PBXFileReference; lastKnownFileType = text.html; name = Base; path = Base.lproj/Main.html; sourceTree = "<group>"; };
+		3B701CA12FCE1FC100E8A5FF /* uk */ = {isa = PBXFileReference; lastKnownFileType = text.html; name = uk; path = uk.lproj/Main.html; sourceTree = "<group>"; };
 		3B701C462FCE1FC100E8A5FF /* Icon.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = Icon.png; sourceTree = "<group>"; };
 		3B701C472FCE1FC100E8A5FF /* Style.css */ = {isa = PBXFileReference; lastKnownFileType = text.css; path = Style.css; sourceTree = "<group>"; };
 		3B701C482FCE1FC100E8A5FF /* Script.js */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.javascript; path = Script.js; sourceTree = "<group>"; };
@@ -382,6 +383,7 @@
 			knownRegions = (
 				en,
 				Base,
+				uk,
 			);
 			mainGroup = 3B701C3D2FCE1FC100E8A5FF;
 			minimizedProjectReferenceProxies = 1;
@@ -518,6 +520,7 @@
 			isa = PBXVariantGroup;
 			children = (
 				3B701C452FCE1FC100E8A5FF /* Base */,
+				3B701CA12FCE1FC100E8A5FF /* uk */,
 			);
 			name = Main.html;
 			sourceTree = "<group>";

--- a/apps/extension/safari/Movar/Movar.xcodeproj/xcshareddata/xcschemes/Movar (iOS).xcscheme
+++ b/apps/extension/safari/Movar/Movar.xcodeproj/xcshareddata/xcschemes/Movar (iOS).xcscheme
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "2630"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "3B701C502FCE1FC200E8A5FF"
+               BuildableName = "Movar.app"
+               BlueprintName = "Movar (iOS)"
+               ReferencedContainer = "container:Movar.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Release"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "3B701C502FCE1FC200E8A5FF"
+            BuildableName = "Movar.app"
+            BlueprintName = "Movar (iOS)"
+            ReferencedContainer = "container:Movar.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "3B701C502FCE1FC200E8A5FF"
+            BuildableName = "Movar.app"
+            BlueprintName = "Movar (iOS)"
+            ReferencedContainer = "container:Movar.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/apps/extension/safari/Movar/Movar.xcodeproj/xcshareddata/xcschemes/Movar (macOS).xcscheme
+++ b/apps/extension/safari/Movar/Movar.xcodeproj/xcshareddata/xcschemes/Movar (macOS).xcscheme
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "2630"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "3B701C622FCE1FC200E8A5FF"
+               BuildableName = "Movar.app"
+               BlueprintName = "Movar (macOS)"
+               ReferencedContainer = "container:Movar.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Release"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "3B701C622FCE1FC200E8A5FF"
+            BuildableName = "Movar.app"
+            BlueprintName = "Movar (macOS)"
+            ReferencedContainer = "container:Movar.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "3B701C622FCE1FC200E8A5FF"
+            BuildableName = "Movar.app"
+            BlueprintName = "Movar (macOS)"
+            ReferencedContainer = "container:Movar.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/apps/extension/safari/Movar/Shared (App)/Resources/Script.js
+++ b/apps/extension/safari/Movar/Shared (App)/Resources/Script.js
@@ -1,28 +1,19 @@
 function show(platform, enabled, useSettingsInsteadOfPreferences) {
   document.body.classList.add(`platform-${platform}`);
 
-  // ViewController.swift passes `useSettingsInsteadOfPreferences=false` on
-  // macOS 12 and earlier (where the Safari Settings → Extensions UI was
-  // still labelled "Safari Preferences"). The Main.html copy assumes the
-  // modern "Settings" wording, so flip it back to the legacy label here.
+  // macOS 12 and earlier called the pane "Safari Preferences", not "Settings".
+  // Each localized Main.html carries its own legacy wording in data-legacy, so
+  // this swap stays correct in every language.
   if (useSettingsInsteadOfPreferences === false) {
-    document.getElementsByClassName('platform-mac state-on')[0].innerText =
-      'Movar is on. Manage it in Safari → Preferences → Extensions.';
-    document.getElementsByClassName('platform-mac state-off')[0].innerText =
-      'Movar is off. Turn it back on in Safari → Preferences → Extensions.';
-    document.getElementsByClassName('platform-mac state-unknown')[0].innerText =
-      'Turn on Movar in Safari → Preferences → Extensions.';
-    document.getElementsByClassName('platform-mac open-preferences')[0].innerText =
-      'Quit and Open Safari Preferences…';
+    for (const element of document.querySelectorAll('[data-legacy]')) {
+      element.textContent = element.dataset.legacy;
+    }
   }
 
-  if (typeof enabled === 'boolean') {
-    document.body.classList.toggle(`state-on`, enabled);
-    document.body.classList.toggle(`state-off`, !enabled);
-  } else {
-    document.body.classList.remove(`state-on`);
-    document.body.classList.remove(`state-off`);
-  }
+  // "On" is the only distinct state. Anything else — not yet enabled, or still
+  // unknown — shows the same setup instructions, because the action is
+  // identical: turn Movar on in Safari. (`enabled` is undefined on iOS.)
+  document.body.classList.toggle('state-on', enabled === true);
 }
 
 function openPreferences() {

--- a/apps/extension/safari/Movar/Shared (App)/Resources/Style.css
+++ b/apps/extension/safari/Movar/Shared (App)/Resources/Style.css
@@ -1,72 +1,314 @@
-* {
-  -webkit-user-select: none;
-  -webkit-user-drag: none;
-  cursor: default;
-}
+/* Movar — Safari app enablement screen.
+   Rendered in a WKWebView (ViewController.swift) inside the native macOS/iOS
+   wrapper. CSP is `default-src 'self'`, so no web fonts or remote assets:
+   we lean on the native system font, mirror the @movar/ui tokens inline, and
+   inline the lucide icon set as an SVG <symbol> sprite (see Main.html). */
 
 :root {
   color-scheme: light dark;
 
-  --spacing: 20px;
+  /* Mirrors packages/ui/src/tokens.css (the subset this screen uses). */
+  --bg: #fafaf9;
+  --surface-2: #f5f5f4;
+  --border: #e7e5e4;
+  --border-strong: #d6d3d1;
+  --ink-faint: #737373;
+  --ink-soft: #78716c;
+  --ink: #44403c;
+  --ink-strong: #1c1917;
+  --accent: #15803d;
+  --accent-on: #ffffff;
+
+  --radius: 8px;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --bg: #0c0a09;
+    --surface-2: #292524;
+    --border: #2e2a27;
+    --border-strong: #44403c;
+    --ink-faint: #a3a3a3;
+    --ink-soft: #a8a29e;
+    --ink: #d6d3d1;
+    --ink-strong: #fafaf9;
+    --accent: #15803d;
+    --accent-on: #ffffff;
+  }
+}
+
+* {
+  -webkit-user-select: none;
+  -webkit-user-drag: none;
+  cursor: default;
+  box-sizing: border-box;
+}
+
+/* Visually hidden, still read by assistive tech (e.g. the "then" that turns
+   the chip path into "Safari then Settings then Extensions"). */
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  padding: 0;
+  border: 0;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+}
+
+.sprite {
+  position: absolute;
+  width: 0;
+  height: 0;
 }
 
 html {
   height: 100%;
 }
 
+/* Three zones — brand / task / trust — separated generously, while elements
+   inside each zone sit close together (proximity = grouping). */
 body {
   display: flex;
+  flex-direction: column;
   align-items: center;
   justify-content: center;
-  flex-direction: column;
+  gap: 52px;
 
-  gap: var(--spacing);
-  margin: 0 calc(var(--spacing) * 2);
   height: 100%;
+  margin: 0;
+  padding: 18px;
+  overflow: hidden;
 
-  font: -apple-system-short-body;
+  background: var(--bg);
+  color: var(--ink);
+  font-family: -apple-system, BlinkMacSystemFont, 'SF Pro Text', system-ui, sans-serif;
+  font-size: 13px;
+  line-height: 1.45;
   text-align: center;
+  -webkit-font-smoothing: antialiased;
 }
 
-h1 {
+/* --- Brand: compact horizontal lockup ---------------------------------- */
+
+/* Logo on the left; title + subtitle stacked on the right. The two text rows
+   share the same height (line-height), and the 40px logo spans both. */
+.brand {
+  display: flex;
+  align-items: center;
+  gap: 11px;
+}
+
+.brand-icon {
+  width: 40px;
+  height: 40px;
+  flex: 0 0 auto;
+  filter: drop-shadow(0 3px 8px rgba(20, 15, 5, 0.18));
+}
+
+.brand-text {
+  display: flex;
+  flex-direction: column;
+  text-align: left;
+}
+
+.brand-title {
   margin: 0;
-  font: -apple-system-headline;
-  font-size: 1.5em;
+  font-size: 17px;
+  font-weight: 700;
+  letter-spacing: -0.01em;
+  line-height: 20px;
+  color: var(--ink-strong);
 }
 
-.tagline {
+.brand-subtitle {
   margin: 0;
-  opacity: 0.7;
+  font-size: 12px;
+  line-height: 20px;
+  color: var(--ink-soft);
 }
 
-body:not(.platform-mac, .platform-ios) :is(.platform-mac, .platform-ios) {
+/* --- Task: the status message + its call to action --------------------- */
+
+.task {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 17px;
+}
+
+.status-region {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.status {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+  max-width: 340px;
+}
+
+.headline {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  margin: 0;
+  font-size: 20px;
+  font-weight: 700;
+  letter-spacing: -0.01em;
+  color: var(--ink-strong);
+}
+
+.dot {
+  width: 9px;
+  height: 9px;
+  border-radius: 50%;
+  background: var(--accent);
+  box-shadow: 0 0 0 3px rgba(21, 128, 61, 0.16);
+}
+
+.helper {
+  margin: 0;
+  margin-top: 1px;
+  font-size: 12.5px;
+  color: var(--ink-soft);
+}
+
+/* Safari → Settings → Extensions as icon-led steps (lucide compass / settings
+   / puzzle), echoing the popup's chip + "→" priority chain. */
+
+.path {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: center;
+  gap: 5px;
+  margin: 2px 0 0;
+}
+
+.chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 3px 8px 3px 7px;
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius);
+  background: var(--surface-2);
+  color: var(--ink-strong);
+  font-size: 11.5px;
+  font-weight: 600;
+  white-space: nowrap;
+}
+
+.chip .ico {
+  width: 13px;
+  height: 13px;
+  flex: 0 0 auto;
+  color: var(--accent);
+}
+
+.sep {
+  color: var(--ink-faint);
+  font-size: 12px;
+}
+
+/* --- Action ------------------------------------------------------------ */
+
+button.open-preferences {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  -webkit-appearance: none;
+  appearance: none;
+  border: none;
+  border-radius: 8px;
+  padding: 10px 18px;
+  background: var(--accent);
+  color: var(--accent-on);
+  box-shadow:
+    0 1px 2px rgba(20, 15, 5, 0.12),
+    0 1px 1px rgba(20, 15, 5, 0.06);
+  font-family: inherit;
+  font-size: 13px;
+  font-weight: 600;
+  transition: background-color 120ms ease;
+}
+
+button.open-preferences .ico {
+  width: 15px;
+  height: 15px;
+  flex: 0 0 auto;
+}
+
+button.open-preferences:hover {
+  background: #1a9648;
+}
+
+button.open-preferences:active {
+  background: #126c34;
+}
+
+button.open-preferences:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  button.open-preferences {
+    transition: none;
+  }
+}
+
+/* --- Trust footer: same lucide marks as the marketing hero -------------- */
+
+.trust {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: center;
+  gap: 5px 12px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  color: var(--ink-faint);
+  font-size: 11px;
+}
+
+.trust li {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+}
+
+.trust .ico {
+  width: 13px;
+  height: 13px;
+  flex: 0 0 auto;
+}
+
+/* --- Platform / state visibility --------------------------------------- */
+
+/* Nothing platform-specific until Swift calls show(). */
+body:not(.platform-mac, .platform-ios) .status {
   display: none;
 }
 
+body.platform-mac .platform-ios,
 body.platform-ios .platform-mac {
   display: none;
 }
 
-body.platform-mac .platform-ios {
+/* macOS has two states: setup (default) and on. A disabled or not-yet-enabled
+   extension shows the setup instructions — the action is the same either way. */
+body.platform-mac:not(.state-on) .state-on {
   display: none;
 }
 
-body.platform-ios .platform-mac {
+body.platform-mac.state-on .state-setup {
   display: none;
-}
-
-body:not(.state-on, .state-off) :is(.state-on, .state-off) {
-  display: none;
-}
-
-body.state-on :is(.state-off, .state-unknown) {
-  display: none;
-}
-
-body.state-off :is(.state-on, .state-unknown) {
-  display: none;
-}
-
-button {
-  font-size: 1em;
 }

--- a/apps/extension/safari/Movar/Shared (App)/Resources/uk.lproj/Main.html
+++ b/apps/extension/safari/Movar/Shared (App)/Resources/uk.lproj/Main.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en">
+<html lang="uk">
   <head>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta http-equiv="Content-Security-Policy" content="default-src 'self'" />
@@ -116,7 +116,7 @@
       <img class="brand-icon" src="../Icon.png" width="128" height="128" alt="" />
       <div class="brand-text">
         <h1 class="brand-title">Movar</h1>
-        <p class="brand-subtitle">Keep the internet in your language.</p>
+        <p class="brand-subtitle">Налаштуйте інтернет на рідну мову.</p>
       </div>
     </header>
 
@@ -127,78 +127,79 @@
       <div class="status-region" aria-live="polite" aria-atomic="true">
         <!-- iOS: enable from the Settings app -->
         <div class="status platform-ios">
-          <h2 class="headline">One last step</h2>
-          <p class="helper">Turn on Movar in the Settings app:</p>
+          <h2 class="headline">Останній крок</h2>
+          <p class="helper">Увімкніть Movar у застосунку «Налаштування»:</p>
           <p class="path">
             <span class="chip"
-              ><svg class="ico" aria-hidden="true"><use href="#ic-settings" /></svg>Settings</span
+              ><svg class="ico" aria-hidden="true"><use href="#ic-settings" /></svg
+              >Налаштування</span
             >
             <span class="sep"
-              ><span aria-hidden="true">→</span><span class="sr-only"> then </span></span
+              ><span aria-hidden="true">→</span><span class="sr-only"> далі </span></span
             >
             <span class="chip"
               ><svg class="ico" aria-hidden="true"><use href="#ic-compass" /></svg>Safari</span
             >
             <span class="sep"
-              ><span aria-hidden="true">→</span><span class="sr-only"> then </span></span
+              ><span aria-hidden="true">→</span><span class="sr-only"> далі </span></span
             >
             <span class="chip"
-              ><svg class="ico" aria-hidden="true"><use href="#ic-puzzle" /></svg>Extensions</span
+              ><svg class="ico" aria-hidden="true"><use href="#ic-puzzle" /></svg>Розширення</span
             >
           </p>
         </div>
 
         <!-- macOS, not yet enabled (fresh install or disabled): same setup -->
         <div class="status platform-mac state-setup">
-          <h2 class="headline">One last step</h2>
-          <p class="helper">Turn on Movar in Safari:</p>
+          <h2 class="headline">Останній крок</h2>
+          <p class="helper">Увімкніть Movar у Safari:</p>
           <p class="path">
             <span class="chip"
               ><svg class="ico" aria-hidden="true"><use href="#ic-compass" /></svg>Safari</span
             >
             <span class="sep"
-              ><span aria-hidden="true">→</span><span class="sr-only"> then </span></span
+              ><span aria-hidden="true">→</span><span class="sr-only"> далі </span></span
             >
             <span class="chip"
               ><svg class="ico" aria-hidden="true"><use href="#ic-settings" /></svg
-              ><span class="settings-label" data-legacy="Preferences">Settings</span></span
+              ><span class="settings-label" data-legacy="Параметри">Налаштування</span></span
             >
             <span class="sep"
-              ><span aria-hidden="true">→</span><span class="sr-only"> then </span></span
+              ><span aria-hidden="true">→</span><span class="sr-only"> далі </span></span
             >
             <span class="chip"
-              ><svg class="ico" aria-hidden="true"><use href="#ic-puzzle" /></svg>Extensions</span
+              ><svg class="ico" aria-hidden="true"><use href="#ic-puzzle" /></svg>Розширення</span
             >
           </p>
         </div>
 
         <!-- macOS, enabled -->
         <div class="status platform-mac state-on">
-          <h2 class="headline"><span class="dot" aria-hidden="true"></span>Movar is on</h2>
-          <p class="helper">Manage it any time in Safari:</p>
+          <h2 class="headline"><span class="dot" aria-hidden="true"></span>Movar увімкнено</h2>
+          <p class="helper">Керуйте ним будь-коли в Safari:</p>
           <p class="path">
             <span class="chip"
               ><svg class="ico" aria-hidden="true"><use href="#ic-compass" /></svg>Safari</span
             >
             <span class="sep"
-              ><span aria-hidden="true">→</span><span class="sr-only"> then </span></span
+              ><span aria-hidden="true">→</span><span class="sr-only"> далі </span></span
             >
             <span class="chip"
               ><svg class="ico" aria-hidden="true"><use href="#ic-settings" /></svg
-              ><span class="settings-label" data-legacy="Preferences">Settings</span></span
+              ><span class="settings-label" data-legacy="Параметри">Налаштування</span></span
             >
             <span class="sep"
-              ><span aria-hidden="true">→</span><span class="sr-only"> then </span></span
+              ><span aria-hidden="true">→</span><span class="sr-only"> далі </span></span
             >
             <span class="chip"
-              ><svg class="ico" aria-hidden="true"><use href="#ic-puzzle" /></svg>Extensions</span
+              ><svg class="ico" aria-hidden="true"><use href="#ic-puzzle" /></svg>Розширення</span
             >
           </p>
         </div>
       </div>
 
       <button class="platform-mac open-preferences">
-        <span data-legacy="Open Safari Preferences">Open Safari Settings</span>
+        <span data-legacy="Відкрити параметри Safari">Відкрити налаштування Safari</span>
         <svg class="ico" aria-hidden="true"><use href="#ic-launch" /></svg>
       </button>
     </main>
@@ -206,14 +207,14 @@
     <footer>
       <ul class="trust">
         <li>
-          <svg class="ico" aria-hidden="true"><use href="#ic-tag" /></svg>Free
+          <svg class="ico" aria-hidden="true"><use href="#ic-tag" /></svg>Безкоштовно
         </li>
         <li>
-          <svg class="ico" aria-hidden="true"><use href="#ic-code" /></svg>Open source
+          <svg class="ico" aria-hidden="true"><use href="#ic-code" /></svg>Відкритий код
         </li>
         <li>
-          <svg class="ico" aria-hidden="true"><use href="#ic-shield" /></svg>Nothing leaves your
-          browser
+          <svg class="ico" aria-hidden="true"><use href="#ic-shield" /></svg>Нічого не покидає
+          браузер
         </li>
       </ul>
     </footer>

--- a/apps/extension/safari/Movar/Shared (App)/ViewController.swift
+++ b/apps/extension/safari/Movar/Shared (App)/ViewController.swift
@@ -33,6 +33,18 @@ class ViewController: PlatformViewController, WKNavigationDelegate, WKScriptMess
 
         self.webView.configuration.userContentController.add(self, name: "controller")
 
+#if os(macOS)
+        // Re-check the extension state whenever the app regains focus — e.g.
+        // after the user enables Movar in Safari and switches back — so this
+        // screen can update to "Movar is on" without the app having to quit.
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(refreshExtensionState),
+            name: NSApplication.didBecomeActiveNotification,
+            object: nil
+        )
+#endif
+
         self.webView.loadFileURL(Bundle.main.url(forResource: "Main", withExtension: "html")!, allowingReadAccessTo: Bundle.main.resourceURL!)
     }
 
@@ -41,7 +53,12 @@ class ViewController: PlatformViewController, WKNavigationDelegate, WKScriptMess
         webView.evaluateJavaScript("show('ios')")
 #elseif os(macOS)
         webView.evaluateJavaScript("show('mac')")
+        refreshExtensionState()
+#endif
+    }
 
+#if os(macOS)
+    @objc func refreshExtensionState() {
         SFSafariExtensionManager.getStateOfSafariExtension(withIdentifier: extensionBundleIdentifier) { (state, error) in
             guard let state = state, error == nil else {
                 // Insert code to inform the user that something went wrong.
@@ -50,14 +67,14 @@ class ViewController: PlatformViewController, WKNavigationDelegate, WKScriptMess
 
             DispatchQueue.main.async {
                 if #available(macOS 13, *) {
-                    webView.evaluateJavaScript("show('mac', \(state.isEnabled), true)")
+                    self.webView.evaluateJavaScript("show('mac', \(state.isEnabled), true)")
                 } else {
-                    webView.evaluateJavaScript("show('mac', \(state.isEnabled), false)")
+                    self.webView.evaluateJavaScript("show('mac', \(state.isEnabled), false)")
                 }
             }
         }
-#endif
     }
+#endif
 
     func userContentController(_ userContentController: WKUserContentController, didReceive message: WKScriptMessage) {
 #if os(macOS)
@@ -65,14 +82,13 @@ class ViewController: PlatformViewController, WKNavigationDelegate, WKScriptMess
             return
         }
 
+        // Open Safari's Extensions settings with Movar selected. We deliberately
+        // do not quit the app: the didBecomeActive observer above refreshes this
+        // screen when the user returns, confirming the extension is on.
         SFSafariApplication.showPreferencesForExtension(withIdentifier: extensionBundleIdentifier) { error in
             guard error == nil else {
                 // Insert code to inform the user that something went wrong.
                 return
-            }
-
-            DispatchQueue.main.async {
-                NSApp.terminate(self)
             }
         }
 #endif

--- a/apps/extension/safari/Movar/macOS (App)/Base.lproj/Main.storyboard
+++ b/apps/extension/safari/Movar/macOS (App)/Base.lproj/Main.storyboard
@@ -80,7 +80,7 @@
                     <window key="window" title="Movar" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" restorable="NO" releasedWhenClosed="NO" animationBehavior="default" id="IQv-IB-iLA">
                         <windowStyleMask key="styleMask" titled="YES" closable="YES"/>
                         <windowCollectionBehavior key="collectionBehavior" fullScreenNone="YES"/>
-                        <rect key="contentRect" x="196" y="240" width="425" height="325"/>
+                        <rect key="contentRect" x="196" y="240" width="425" height="350"/>
                         <rect key="screenRect" x="0.0" y="0.0" width="1680" height="1027"/>
                         <connections>
                             <outlet property="delegate" destination="B8D-0N-5wS" id="98r-iN-zZc"/>
@@ -99,11 +99,11 @@
             <objects>
                 <viewController id="XfG-lQ-9wD" customClass="ViewController" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" id="m2S-Jp-Qdl">
-                        <rect key="frame" x="0.0" y="0.0" width="425" height="325"/>
+                        <rect key="frame" x="0.0" y="0.0" width="425" height="350"/>
                         <autoresizingMask key="autoresizingMask"/>
                         <subviews>
                             <wkWebView wantsLayer="YES" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="eOr-cG-IQY">
-                                <rect key="frame" x="0.0" y="0.0" width="425" height="325"/>
+                                <rect key="frame" x="0.0" y="0.0" width="425" height="350"/>
                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                 <wkWebViewConfiguration key="configuration">
                                     <audiovisualMediaTypes key="mediaTypesRequiringUserActionForPlayback" none="YES"/>

--- a/apps/extension/safari/exportOptions/app-store.plist
+++ b/apps/extension/safari/exportOptions/app-store.plist
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  xcodebuild -exportArchive options for the App Store path (iOS + macOS).
+
+  `app-store-connect` is the Xcode 15.3+ name for the old `app-store` method.
+  `teamID` is intentionally omitted: the archive is built with
+  `DEVELOPMENT_TEAM=$APPLE_TEAM_ID` and `signingStyle = automatic` +
+  `-allowProvisioningUpdates` (with the App Store Connect API key) lets Xcode
+  resolve the team and fetch/create the distribution profiles at export time.
+  `manageAppVersionAndBuildNumber = false` keeps the version we pass via
+  `MARKETING_VERSION` / `CURRENT_PROJECT_VERSION` instead of Xcode rewriting it.
+-->
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>method</key>
+	<string>app-store-connect</string>
+	<key>destination</key>
+	<string>export</string>
+	<key>signingStyle</key>
+	<string>automatic</string>
+	<key>manageAppVersionAndBuildNumber</key>
+	<false/>
+	<key>uploadSymbols</key>
+	<true/>
+</dict>
+</plist>

--- a/apps/extension/safari/exportOptions/developer-id.plist
+++ b/apps/extension/safari/exportOptions/developer-id.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  xcodebuild -exportArchive options for the notarized direct-download path
+  (macOS only). `developer-id` exports the app signed with the "Developer ID
+  Application" certificate for distribution outside the Mac App Store; the
+  release-safari job then notarizes it (xcrun notarytool) and staples the
+  ticket (xcrun stapler) before packaging the .dmg hosted off movar.fyi.
+
+  `teamID` is omitted for the same reason as app-store.plist — it's resolved
+  from the archive's `DEVELOPMENT_TEAM` plus automatic signing.
+-->
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>method</key>
+	<string>developer-id</string>
+	<key>destination</key>
+	<string>export</string>
+	<key>signingStyle</key>
+	<string>automatic</string>
+</dict>
+</plist>

--- a/apps/extension/scripts/build-safari-app.mts
+++ b/apps/extension/scripts/build-safari-app.mts
@@ -1,0 +1,96 @@
+/*
+ * Build a locally-installable, ad-hoc-signed macOS `Movar.app` from the Safari
+ * Xcode wrapper — no Apple Developer account required.
+ *
+ * Pipeline:
+ *   1. `pnpm build:safari` — WXT `-b safari` build + `sync-safari-resources.mts`,
+ *      which populates the gitignored `Shared (Extension)/Resources/`. This MUST
+ *      run before xcodebuild: a fresh checkout has empty Resources, so the
+ *      compiled `.appex` would ship without a manifest and Safari would reject it.
+ *   2. `xcodebuild build` of the shared `Movar (macOS)` scheme, ad-hoc signed
+ *      (`CODE_SIGN_IDENTITY=-`), with the app version fed from package.json via
+ *      `MARKETING_VERSION` / `CURRENT_PROJECT_VERSION` build-setting overrides.
+ *      The targets use `GENERATE_INFOPLIST_FILE=YES`, so these flow into the
+ *      synthesized Info.plist without mutating the committed `project.pbxproj`.
+ *   3. Copy the product to `.output/safari/Movar.app` with `ditto` (bundle-safe:
+ *      preserves the ad-hoc seal and any internal symlinks) and print the steps
+ *      to load it into Safari.
+ *
+ * Ad-hoc signing is enough to RUN the app on this Mac, but Safari only loads an
+ * unsigned/ad-hoc Web Extension after you enable Develop ▸ Allow Unsigned
+ * Extensions. The release-grade *signed* build lives in the `release-safari` CI
+ * job (.github/workflows/release.yml), not here.
+ */
+import { spawnSync } from 'node:child_process';
+import { mkdirSync, readFileSync, rmSync } from 'node:fs';
+import path from 'node:path';
+
+const ROOT = path.resolve(import.meta.dirname, '..');
+const PROJECT = path.join(ROOT, 'safari', 'Movar', 'Movar.xcodeproj');
+const SCHEME = 'Movar (macOS)';
+const DERIVED = path.join(ROOT, 'safari', 'build');
+const PRODUCT = path.join(DERIVED, 'Build', 'Products', 'Release', 'Movar.app');
+const OUT_DIR = path.join(ROOT, '.output', 'safari');
+const OUT_APP = path.join(OUT_DIR, 'Movar.app');
+
+function run(command: string, args: string[], cwd = ROOT): void {
+  process.stdout.write(`\n[movar:safari-app] ${command} ${args.join(' ')}\n`);
+  const result = spawnSync(command, args, { cwd, stdio: 'inherit' });
+  if (result.error) {
+    process.stderr.write(
+      `[movar:safari-app] failed to spawn \`${command}\`: ${result.error.message}\n`,
+    );
+    process.exit(1);
+  }
+  if (result.status !== 0) {
+    process.stderr.write(
+      `[movar:safari-app] \`${command}\` exited with code ${result.status ?? 'null (signal)'}\n`,
+    );
+    process.exit(result.status ?? 1);
+  }
+}
+
+// 1. Web-extension build + resource sync (one source of truth for both).
+run('pnpm', ['run', 'build:safari']);
+
+// 2. Version from package.json → xcodebuild overrides (no project mutation).
+const version = (
+  JSON.parse(readFileSync(path.join(ROOT, 'package.json'), 'utf8')) as { version: string }
+).version;
+const buildNumber = process.env['MOVAR_BUILD_NUMBER'] ?? '1';
+
+run('xcodebuild', [
+  '-project',
+  PROJECT,
+  '-scheme',
+  SCHEME,
+  '-configuration',
+  'Release',
+  '-derivedDataPath',
+  DERIVED,
+  '-destination',
+  'generic/platform=macOS',
+  `MARKETING_VERSION=${version}`,
+  `CURRENT_PROJECT_VERSION=${buildNumber}`,
+  'CODE_SIGN_STYLE=Manual',
+  'CODE_SIGN_IDENTITY=-',
+  'CODE_SIGNING_REQUIRED=YES',
+  'CODE_SIGNING_ALLOWED=YES',
+  'DEVELOPMENT_TEAM=',
+  'build',
+]);
+
+// 3. Copy the bundle out with ditto (preserves the ad-hoc seal + symlinks).
+rmSync(OUT_APP, { recursive: true, force: true });
+mkdirSync(OUT_DIR, { recursive: true });
+run('ditto', [PRODUCT, OUT_APP]);
+
+process.stdout.write(
+  `\n[movar:safari-app] built Movar ${version} → ${path.relative(process.cwd(), OUT_APP)}\n\n` +
+    `Load it into Safari:\n` +
+    `  1. open "${OUT_APP}"   — run the app once so Safari registers the extension.\n` +
+    `  2. Safari ▸ Settings ▸ Extensions — enable “Movar”.\n` +
+    `  3. First run only: Safari ▸ Settings ▸ Advanced ▸ “Show features for web developers”,\n` +
+    `     then Develop ▸ “Allow Unsigned Extensions” (this build is ad-hoc signed; the\n` +
+    `     toggle resets on each Safari launch).\n`,
+);

--- a/deployment-checklist.md
+++ b/deployment-checklist.md
@@ -26,12 +26,12 @@ Re-used verbatim per store unless a reviewer asks for a longer answer.
 
 All targets ship as **Manifest V3** (`manifestVersion: 3` is forced in [wxt.config.ts](apps/extension/wxt.config.ts) — WXT would otherwise default Firefox to MV2). Firefox floors are pinned to 140 (desktop, July 2025) and 142 (Android, September 2025) — the versions that introduced `browser_specific_settings.gecko.data_collection_permissions`. Older Firefox would silently ignore the declaration, which AMO flags as a `KEY_FIREFOX_*_UNSUPPORTED_BY_MIN_VERSION` warning. The older `declarativeNetRequest` floor (113, May 2023) is now moot.
 
-| Store            | Fee                    | Artifact                                                                                        |
-| ---------------- | ---------------------- | ----------------------------------------------------------------------------------------------- |
-| Chrome Web Store | $5 one-time            | `pnpm --filter @movar/extension zip` output (`.output/chrome-mv3-…zip`)                         |
-| Edge Add-ons     | free                   | same Chrome MV3 zip                                                                             |
-| Firefox AMO      | free                   | `pnpm zip:firefox` output (`.output/*-firefox.zip`) + source bundle from `pnpm pack:amo-source` |
-| Safari (Mac/iOS) | $99/yr Apple Developer | Xcode-converted project, not a zip — separate effort                                            |
+| Store            | Fee                    | Artifact                                                                                                                                                                          |
+| ---------------- | ---------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Chrome Web Store | $5 one-time            | `pnpm --filter @movar/extension zip` output (`.output/chrome-mv3-…zip`)                                                                                                           |
+| Edge Add-ons     | free                   | same Chrome MV3 zip                                                                                                                                                               |
+| Firefox AMO      | free                   | `pnpm zip:firefox` output (`.output/*-firefox.zip`) + source bundle from `pnpm pack:amo-source`                                                                                   |
+| Safari (Mac/iOS) | $99/yr Apple Developer | Xcode wrapper at `apps/extension/safari/`; build + deploy wired ([docs/safari-deploy.md](docs/safari-deploy.md)) — `release-safari` stays dormant until enrolment + Apple secrets |
 
 ## Store listing assets (every store wants these)
 
@@ -56,4 +56,5 @@ Manual — required after the script is green:
 
 - [ ] Smoke test in Chrome — load `.output/chrome-mv3/` unpacked, exercise popup, change a setting in options, visit a Russian-defaulting Ukrainian site, confirm switch
 - [ ] Smoke test in Firefox — same flow against `.output/firefox-mv3/`
+- [ ] Smoke test in Safari (macOS) — `pnpm --filter @movar/extension build:safari:app`, `open apps/extension/.output/safari/Movar.app`, enable Movar in Safari ▸ Settings ▸ Extensions (Develop ▸ Allow Unsigned Extensions for the ad-hoc build), then run the same flow. See [docs/safari-deploy.md](docs/safari-deploy.md).
 - [ ] **iOS Safari MV3 static-import smoke test** — once Movar ships on iOS, confirm the content script's static imports of `@movar/lang-detect/engines/chrome-ai` and `@movar/lang-detect/engines/franc-min` load without runtime error. Visit a page with no `<html lang>` and a known non-English body, verify the tier-7 path fires per [docs/on-device-language-detection.md](docs/on-device-language-detection.md). Validates the static-import assumption made in the ADR — the riskiest unverified claim for that target.

--- a/docs/release-credentials.md
+++ b/docs/release-credentials.md
@@ -105,6 +105,31 @@ There is no tenant ID and no client secret in v1.1 — if you ever see a
 `login.microsoftonline.com/.../oauth2/...` URL in Partner Center,
 you're on the deprecated v1 UI and need to enable the new experience.
 
+## Safari / App Store — `APPLE_*`
+
+The [`release-safari`](../.github/workflows/release.yml) job (macOS runner)
+uploads the iOS + macOS builds to App Store Connect and notarizes a Developer ID
+`.dmg` for direct download. Full walkthrough — enrolment, App IDs, App Store
+Connect app record, certs, and the API key — is in
+[docs/safari-deploy.md](safari-deploy.md). The eight secrets it needs:
+
+| Secret                               | Where to get it                                                                                    |
+| ------------------------------------ | -------------------------------------------------------------------------------------------------- |
+| `APPLE_TEAM_ID`                      | Apple Developer → Membership details → Team ID                                                     |
+| `APPLE_ASC_KEY_ID`                   | App Store Connect → Users and Access → Integrations → App Store Connect API → the key's **Key ID** |
+| `APPLE_ASC_ISSUER_ID`                | Same page → **Issuer ID** (UUID, top of the keys list)                                             |
+| `APPLE_ASC_API_KEY_P8`               | Same page → **Generate** → download the `.p8` (once), base64-encode it                             |
+| `APPLE_DIST_CERT_P12_BASE64`         | Apple **Distribution** cert exported from Keychain Access as `.p12`, base64-encoded                |
+| `APPLE_DIST_CERT_PASSWORD`           | password set when exporting that `.p12`                                                            |
+| `APPLE_DEVELOPER_ID_CERT_P12_BASE64` | **Developer ID Application** cert exported as `.p12`, base64-encoded                               |
+| `APPLE_DEVELOPER_ID_CERT_PASSWORD`   | password set when exporting that `.p12`                                                            |
+
+**Prerequisite:** Apple Developer Program enrolment ($99/yr) and a hand-created
+App Store Connect listing for `fyi.movar.safari` (iOS + macOS), same as the other
+stores' first submission. Until all eight secrets exist, the job skips with a
+warning. To iterate locally without an account, use
+`pnpm --filter @movar/extension build:safari:app` (ad-hoc macOS build).
+
 ## Cutting a release
 
 Once a store's secrets are in place:

--- a/docs/safari-deploy.md
+++ b/docs/safari-deploy.md
@@ -1,0 +1,168 @@
+# Safari (iOS · iPadOS · macOS) build & deploy
+
+Movar's Safari support reuses the same WXT web extension as Chrome/Firefox/Edge,
+wrapped in a native Xcode app (Safari Web Extensions can only ship inside an app
+container). This doc covers the two things that sit on top of that web-extension
+build: the **local installable build** (works today, no Apple account) and the
+**release pipeline** (App Store + notarized download, dormant until the Apple
+Developer account is enrolled).
+
+For the web-extension layer itself (the `-b safari` build, resource sync, dev
+loop) see [apps/extension/wxt.config.ts](../apps/extension/wxt.config.ts) and the
+`*:safari` scripts in [apps/extension/package.json](../apps/extension/package.json).
+
+## What already exists
+
+- WXT `-b safari` target → `.output/safari-mv3/`, synced into the Xcode project's
+  `Shared (Extension)/Resources/` by
+  [sync-safari-resources.mts](../apps/extension/scripts/sync-safari-resources.mts).
+- The Xcode wrapper at `apps/extension/safari/Movar/Movar.xcodeproj` —
+  `safari-web-extension-converter` output — with four targets:
+
+  | Target                    | Type          | Bundle ID                    |
+  | ------------------------- | ------------- | ---------------------------- |
+  | `Movar (iOS)`             | app           | `fyi.movar.safari`           |
+  | `Movar (macOS)`           | app           | `fyi.movar.safari`           |
+  | `Movar Extension (iOS)`   | app-extension | `fyi.movar.safari.Extension` |
+  | `Movar Extension (macOS)` | app-extension | `fyi.movar.safari.Extension` |
+
+  Deployment targets: iOS 15.0, macOS 10.14. iPadOS runs the iOS binary.
+
+- Shared schemes `Movar (iOS)` / `Movar (macOS)` committed under
+  `Movar.xcodeproj/xcshareddata/xcschemes/` so headless `xcodebuild -scheme …` is
+  reproducible.
+
+## Local build — `build:safari:app`
+
+Produces a double-clickable, **ad-hoc-signed** `Movar.app` you can load into
+Safari on your own Mac. No Apple Developer account required.
+
+```sh
+pnpm --filter @movar/extension build:safari:app
+```
+
+What it does ([build-safari-app.mts](../apps/extension/scripts/build-safari-app.mts)):
+
+1. Runs `build:safari` (WXT build + resource sync) — **must** precede xcodebuild,
+   or the compiled `.appex` ships with no manifest.
+2. `xcodebuild build` of the `Movar (macOS)` scheme, ad-hoc signed, with the app
+   version taken from `package.json` (`MARKETING_VERSION` / `CURRENT_PROJECT_VERSION`
+   overrides — the targets use `GENERATE_INFOPLIST_FILE=YES`, so no project edit).
+3. Copies the result to `apps/extension/.output/safari/Movar.app` (`ditto`,
+   bundle-safe).
+
+Then, to load it into Safari:
+
+1. `open apps/extension/.output/safari/Movar.app` — run it once so Safari
+   registers the extension.
+2. **Safari ▸ Settings ▸ Extensions** — enable **Movar**.
+3. First run only: **Safari ▸ Settings ▸ Advanced ▸ "Show features for web
+   developers"**, then **Develop ▸ "Allow Unsigned Extensions"** (the toggle
+   resets each Safari launch; needed because this build is ad-hoc signed).
+
+> iOS/iPadOS can't be "installed" this way — there's no sideloading. To test on a
+> device or Simulator, open the project in Xcode and run the `Movar (iOS)` scheme,
+> or use TestFlight once the release pipeline is live.
+
+## Release pipeline — `release-safari`
+
+The [`release-safari` job](../.github/workflows/release.yml) runs on a macOS
+runner as part of the normal release (published `extension-v*` Release, or a
+`workflow_dispatch` with `dry_run=false`). Like every other store job it **skips
+with a warning when its secrets are absent** — so it is inert until the steps
+below are done. When the secrets exist it:
+
+1. Builds the Safari web extension and syncs resources.
+2. Imports the signing certs into a throwaway keychain and places the App Store
+   Connect API key.
+3. Archives `Movar (iOS)` and `Movar (macOS)` with automatic signing +
+   `-allowProvisioningUpdates` (the ASC key lets Xcode mint profiles).
+4. **App Store:** exports with
+   [exportOptions/app-store.plist](../apps/extension/safari/exportOptions/app-store.plist)
+   and uploads the iOS `.ipa` + macOS `.pkg` to App Store Connect (→ TestFlight /
+   review) via `xcrun altool`.
+5. **Notarized direct download:** exports with
+   [exportOptions/developer-id.plist](../apps/extension/safari/exportOptions/developer-id.plist),
+   notarizes (`xcrun notarytool`), staples, packages a `.dmg`, and attaches it to
+   the GitHub Release for hosting off movar.fyi.
+
+Per-PR CI keeps building the Safari **web extension** on Linux (cheap); the macOS
+native build runs only at release time.
+
+## One-time setup (to make the pipeline live)
+
+### 1. Enrol & register identifiers
+
+1. Join the [Apple Developer Program](https://developer.apple.com/programs/)
+   ($99/yr). Note your **Team ID** (Membership details) → `APPLE_TEAM_ID`.
+2. **Certificates, Identifiers & Profiles → Identifiers → App IDs**, register
+   both bundle IDs as explicit App IDs:
+   - `fyi.movar.safari` (the app — used by both the iOS and macOS targets)
+   - `fyi.movar.safari.Extension` (the Safari web extension appex)
+3. **App Store Connect → Apps → +** → create the Movar app for `fyi.movar.safari`,
+   then add **both** the iOS and macOS platforms to it. Fill the listing metadata
+   (name, description, screenshots, privacy URL `https://movar.fyi/privacy`,
+   category) — the first submission's metadata must be entered by hand, same as
+   the other stores.
+
+### 2. Certificates (export as `.p12`)
+
+Create both in the Developer portal (or via Xcode ▸ Settings ▸ Accounts ▸ Manage
+Certificates), then export each from Keychain Access as a password-protected
+`.p12`:
+
+- **Apple Distribution** — App Store builds.
+- **Developer ID Application** — the notarized direct-download build.
+
+### 3. App Store Connect API key
+
+**App Store Connect → Users and Access → Integrations → App Store Connect API →
+Team Keys → Generate**. Role **App Manager** (enough to upload + manage
+provisioning). Download the `.p8` (offered **once**), and note the **Key ID** and
+**Issuer ID** shown on that page.
+
+### 4. GitHub secrets
+
+Set at **Repo Settings → Secrets and variables → Actions**. Base64-encode the
+binary/`.p8` files first:
+
+```sh
+base64 -i AppleDistribution.p12     | gh secret set APPLE_DIST_CERT_P12_BASE64
+base64 -i DeveloperID.p12           | gh secret set APPLE_DEVELOPER_ID_CERT_P12_BASE64
+base64 -i AuthKey_XXXXXXXXXX.p8     | gh secret set APPLE_ASC_API_KEY_P8
+gh secret set APPLE_DIST_CERT_PASSWORD          # the .p12 export password
+gh secret set APPLE_DEVELOPER_ID_CERT_PASSWORD
+gh secret set APPLE_TEAM_ID
+gh secret set APPLE_ASC_KEY_ID
+gh secret set APPLE_ASC_ISSUER_ID
+```
+
+| Secret                               | Value                                         |
+| ------------------------------------ | --------------------------------------------- |
+| `APPLE_TEAM_ID`                      | 10-char Developer Team ID                     |
+| `APPLE_ASC_KEY_ID`                   | App Store Connect API **Key ID**              |
+| `APPLE_ASC_ISSUER_ID`                | App Store Connect API **Issuer ID** (UUID)    |
+| `APPLE_ASC_API_KEY_P8`               | base64 of the `.p8` private key               |
+| `APPLE_DIST_CERT_P12_BASE64`         | base64 of the Apple Distribution `.p12`       |
+| `APPLE_DIST_CERT_PASSWORD`           | password used when exporting that `.p12`      |
+| `APPLE_DEVELOPER_ID_CERT_P12_BASE64` | base64 of the Developer ID Application `.p12` |
+| `APPLE_DEVELOPER_ID_CERT_PASSWORD`   | password used when exporting that `.p12`      |
+
+Once all eight are set, the next published `extension-v*` Release runs
+`release-safari` for real. To rehearse without publishing: **Actions → Release →
+Run workflow → dry_run: false** on a throwaway run (it still skips if any secret
+is missing).
+
+## Caveats to resolve at first submission
+
+- **macOS App Store requires App Sandbox.** Confirm the app + extension targets
+  carry `com.apple.security.app-sandbox` entitlements before the first Mac App
+  Store upload; the converter does not always add them. (The notarized Developer
+  ID build does not require sandboxing.)
+- **Version source of truth** is `apps/extension/package.json`; the build number
+  is the CI run number. Bump the package version as part of the normal
+  [release ritual](release-credentials.md#cutting-a-release).
+- **After the listing is live**, flip `safari` in
+  [apps/marketing/src/lib/downloads.ts](../apps/marketing/src/lib/downloads.ts)
+  from `'#'` to the App Store URL (and add the `.dmg` link if hosting the direct
+  download).


### PR DESCRIPTION
## Summary

Brings the Safari app extension to parity: an installable build + notarized/App Store deploy job, plus a polished native enablement screen.

### Build & deploy (6d8976c)
- Safari installable build and App Store / notarized deploy job

### Enablement screen (09a5093)
- Redesigned the native macOS/iOS enablement screen (rendered in the app's WKWebView): horizontal brand lockup, icon-led `Safari → Settings → Extensions` steps via an inline lucide sprite, marketing-matching trust footer, and an accent CTA with a launch icon
- Added **Ukrainian localization** (`uk.lproj`) wired into the Xcode project; made the legacy macOS ≤12 "Preferences" swap locale-safe via `data-legacy`
- `ViewController` now opens Safari settings **without quitting**, and refreshes extension state on reactivation so the screen confirms "Movar is on"
- Collapsed the "off" state into the setup state (fixes the fresh-install "switch it **back** on" copy); sized the macOS window to the content
- Accessibility: `lang`, heading hierarchy, `aria-live` for the async state reveal, screen-reader-friendly step path, and `banner`/`main`/`contentinfo` landmarks

## Verification
- Pre-push gates green: build, e2e (23 passed), fallow metrics
- Screen verified across en/uk, light/dark, and all states at the real window size
- ⚠️ The native Xcode/Swift build was **not** compile-verified locally (no Xcode run here); the Xcode/CI build is the gate for `ViewController.swift` + the storyboard change

🤖 Generated with [Claude Code](https://claude.com/claude-code)