### PR TITLE
perf(extension): trim the always-on content bundle to ~64 KB (classifier + i18n)

### DIFF
--- a/apps/extension/src/entrypoints/background.ts
+++ b/apps/extension/src/entrypoints/background.ts
@@ -1,7 +1,7 @@
 import { browser } from 'wxt/browser';
 import { defineBackground } from 'wxt/utils/define-background';
-import { getProfiles } from '@movar/lang-detect';
-import { francEngine, francResidualVerdict, warmFranc } from '@movar/lang-detect/franc';
+import { classifyBySnippet, getProfiles } from '@movar/lang-detect';
+import { francEngine, francRung3Resolver, warmFranc } from '@movar/lang-detect/franc';
 import { syncAcceptLanguageRule } from '../lib/dnr';
 import { getPauseState, onPauseChange, RESUME_ALARM, resume } from '../lib/pause';
 import { ensureSettingsInitialised, getSettings, onSettingsChange } from '../lib/settings';
@@ -28,11 +28,12 @@ const FRANC_REQUESTS: {
     const detected = await francEngine.detect(msg.text, ctx);
     return detected;
   },
-  'movar:detectSnippets': (msg) => {
-    // Reconstruct the candidate profiles and run the real franc rung-3 over the
-    // batch — one round-trip per content-filter tick.
+  'movar:classifySnippets': (msg) => {
+    // Reconstruct the candidate profiles and run the full classifier (rungs 1–3,
+    // with franc as the rung-3 backstop) over the batch — one round-trip per
+    // content-filter tick. The profiles + franc live here, not in the content.
     const profiles = getProfiles(msg.candidateCodes);
-    return msg.texts.map((text) => francResidualVerdict(text, profiles));
+    return msg.texts.map((text) => classifyBySnippet(text, profiles, francRung3Resolver));
   },
   'movar:warmFranc': async () => {
     await warmFranc();

--- a/apps/extension/src/lib/content-conceal.test.ts
+++ b/apps/extension/src/lib/content-conceal.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it } from 'vitest';
-import { getProfiles } from '@movar/lang-detect';
-import { francResidualVerdict } from '@movar/lang-detect/franc';
-import type { ResidualRung3Resolver } from './content-conceal';
+import { classifyBySnippet, getProfiles } from '@movar/lang-detect';
+import { francRung3Resolver } from '@movar/lang-detect/franc';
+import type { SnippetClassifier } from './content-conceal';
 import {
   concealNode,
   revealNode,
@@ -13,11 +13,11 @@ import {
 } from './content-conceal';
 import type { ContentNode, PageContentModel } from '@movar/page-content/types';
 
-// Tests run franc's rung-3 directly (no background worker) so the 'unknown'
-// residual behaves exactly as the in-process classifier used to.
-// eslint-disable-next-line @typescript-eslint/require-await -- sync test resolver behind the async ResidualRung3Resolver contract; nothing to await
-const directRung3: ResidualRung3Resolver = async (texts, candidates) =>
-  texts.map((t) => francResidualVerdict(t, candidates));
+// eslint-disable-next-line @typescript-eslint/require-await -- sync in-process classifier behind the async SnippetClassifier contract; nothing to await
+const directClassify: SnippetClassifier = async (texts, candidateCodes) => {
+  const profiles = getProfiles([...candidateCodes]);
+  return texts.map((t) => classifyBySnippet(t, profiles, francRung3Resolver));
+};
 
 // Bridges old blocklist-style call sites to the allowlist filter: conceal iff a
 // card's detected language ∈ `blocked`. candidates = uk/ru/en; enabled =
@@ -28,9 +28,9 @@ async function runFilter(
   blocked: readonly string[],
 ): ReturnType<typeof applyContentFilter> {
   return applyContentFilter(model, {
-    candidates: getProfiles(FILTER_LANGS),
+    candidateCodes: FILTER_LANGS,
     enabled: new Set(FILTER_LANGS.filter((c) => !blocked.includes(c))),
-    rung3: directRung3,
+    classify: directClassify,
   });
 }
 

--- a/apps/extension/src/lib/content-conceal.ts
+++ b/apps/extension/src/lib/content-conceal.ts
@@ -58,7 +58,7 @@ function shouldSkip(node: ContentNode): boolean {
 
 function attachBlurCurtain(el: HTMLElement, language: LanguageCode): void {
   el.setAttribute(BLURRED_ATTR, language);
-  const { content } = getContentMessages();
+  const content = getContentMessages();
   attachCurtain(el, {
     mode: 'cover',
     icon: defaultHiddenIcon(),

--- a/apps/extension/src/lib/content-conceal.ts
+++ b/apps/extension/src/lib/content-conceal.ts
@@ -10,8 +10,7 @@
  * isRevealed       — true when the user clicked "Show" on the curtain.
  * applyContentFilter — the main per-model scan-and-conceal loop.
  */
-import { classifyBySnippet } from '@movar/lang-detect';
-import type { LanguageCode, LanguageProfile, SnippetVerdict } from '@movar/lang-detect';
+import type { LanguageCode, SnippetVerdict } from '@movar/lang-detect';
 import { attachCurtain, defaultHiddenIcon, detachAllCurtains } from './curtain';
 import { getContentMessages } from './i18n/content';
 import { getCurrentColorScheme } from '@movar/page-mode/context';
@@ -159,31 +158,27 @@ export function clearAllMarks(root: ParentNode = document): void {
 
 // ─── Main filter loop ─────────────────────────────────────────────────────
 
-/** Batched async resolver for rung 3 (the franc residual backstop). Receives the
- *  texts of the cards that rungs 1–2 left 'unknown', plus the candidate profiles,
- *  and returns one verdict (or null) per text, in order. The extension wires this
- *  to the background-worker franc; tests inject a direct franc resolver. Omitted
- *  → rung 3 is skipped (rungs 1–2 only) and the residual cards are kept. */
-export type ResidualRung3Resolver = (
+/** Batched snippet classifier (rungs 1–3). Receives every scanned card's text
+ *  plus the candidate language codes, and returns one verdict (or null) per text,
+ *  in order. The whole classifier — the language profiles AND franc — runs behind
+ *  this, off the content thread: the extension wires it to the background worker
+ *  (`classifySnippets`); tests inject a direct in-process classifier. */
+export type SnippetClassifier = (
   texts: readonly string[],
-  candidates: readonly LanguageProfile[],
+  candidateCodes: readonly LanguageCode[],
 ) => Promise<readonly (SnippetVerdict | null)[]>;
 
 /** Inputs for {@link applyContentFilter}. */
 export interface ContentFilterOptions {
   /** Languages to tell apart — the user's enabled languages ∪ the imposed
-   *  overlay (today: priority ∪ blocked). Empty disables the filter. */
-  candidates: readonly LanguageProfile[];
+   *  overlay (today: priority ∪ blocked), as codes. Empty disables the filter. */
+  candidateCodes: readonly LanguageCode[];
   /** Languages the user keeps. A card is concealed only when its detected
    *  language is confidently NOT one of these (the allowlist predicate). */
   enabled: ReadonlySet<LanguageCode>;
-  /** Optional diagnostics hook — receives every classified snippet and its
-   *  rung-1/2 verdict (before the conceal decision). Used by the shadow oracle. */
-  onSnippet?: (text: string, verdict: SnippetVerdict, el: HTMLElement) => void;
-  /** Rung-3 residual resolver (franc, hosted off the content thread). Omit to
-   *  skip rung 3 — the franc-free rungs 1–2 run inline; only the 'unknown'
-   *  residual is sent through this, batched. */
-  rung3?: ResidualRung3Resolver;
+  /** Classifier for the scanned card texts — runs off the content thread (the
+   *  language profiles + franc live in the worker, not the content bundle). */
+  classify: SnippetClassifier;
 }
 
 /** Minimum lead a verdict must clear before a *hide* — a keep needs none. The
@@ -240,59 +235,43 @@ function concealIfBlocked(
 
 /**
  * Scan every node in `model` and conceal any whose detected language is
- * confidently not in `enabled` (classified against `candidates`). Idempotent —
- * nodes already concealed or user-revealed are skipped.
+ * confidently not in `enabled` (classified against `candidateCodes`). Idempotent
+ * — nodes already concealed or user-revealed are skipped.
  *
- * Two phases, because franc (rung 3) now runs off the content thread:
- *  1. sync  — rungs 1–2 (alphabet / words) decide the vast majority of cards
- *             in-process; cards that come back 'unknown' are collected.
- *  2. async — the 'unknown' residual goes through `rung3` (the background franc)
- *             in ONE batch, and any confident hit is concealed. Omit `rung3` to
- *             skip this phase (rungs 1–2 only; residual cards are kept).
- *
- * The color scheme for blur curtains is read from the page-mode context. Returns
- * the nodes newly concealed on this call, so the caller can log one correction
- * event per card without spamming the dashboard.
+ * Classification (rungs 1–3 — the language profiles and franc) runs off the
+ * content thread via `classify`: collect every scanned card's text, classify the
+ * batch in ONE round-trip, then conceal the confident, non-enabled hits. The
+ * conceal decision (the block-only margin gate) stays here. The blur curtains'
+ * color scheme is read from the page-mode context. Returns the nodes newly
+ * concealed on this call, so the caller can log one correction event per card.
  */
-// Two sequential phases (sync rungs 1–2, async batched rung 3); the count is
-// phases, not nested branching.
-// fallow-ignore-next-line complexity
 export async function applyContentFilter(
   model: PageContentModel,
-  { candidates, enabled, onSnippet, rung3 }: ContentFilterOptions,
+  { candidateCodes, enabled, classify }: ContentFilterOptions,
 ): Promise<FilteredCard[]> {
-  if (candidates.length === 0) return [];
+  if (candidateCodes.length === 0) return [];
 
-  const hits: FilteredCard[] = [];
-  const residual: { node: ContentNode; text: string }[] = [];
-
-  // Phase 1 (sync): rungs 1–2. Decide confident cards now; defer 'unknown' to
-  // the async rung-3 pass (only when a resolver is supplied).
+  // Collect every scannable card (marking it CHECKED so the next pass skips it).
+  const cards: { node: ContentNode; text: string }[] = [];
   for (const node of model.nodes) {
     if (shouldSkip(node)) continue;
     // Lazy-load: card is in DOM but text not yet populated. Skip without
     // marking — the next mutation pass will see it again once text hydrates.
     if (!node.text) continue;
     node.el.setAttribute(CHECKED_ATTR, 'true');
-    const verdict = classifyBySnippet(node.text, candidates);
-    onSnippet?.(node.text, verdict, node.el);
-    if (verdict.language === 'unknown') {
-      if (rung3) residual.push({ node, text: node.text });
-      continue;
-    }
-    concealIfBlocked(node, verdict, enabled, hits);
+    cards.push({ node, text: node.text });
   }
+  if (cards.length === 0) return [];
 
-  // Phase 2 (async): one batched round-trip resolves rung 3 for every residual.
-  if (rung3 && residual.length > 0) {
-    const verdicts = await rung3(
-      residual.map((r) => r.text),
-      candidates,
-    );
-    residual.forEach(({ node }, i) => {
-      const verdict = verdicts[i];
-      if (verdict) concealIfBlocked(node, verdict, enabled, hits);
-    });
-  }
+  // One batched classification round-trip, then conceal the confident hits.
+  const verdicts = await classify(
+    cards.map((c) => c.text),
+    candidateCodes,
+  );
+  const hits: FilteredCard[] = [];
+  cards.forEach(({ node }, i) => {
+    const verdict = verdicts[i];
+    if (verdict) concealIfBlocked(node, verdict, enabled, hits);
+  });
   return hits;
 }

--- a/apps/extension/src/lib/content-filter.test.ts
+++ b/apps/extension/src/lib/content-filter.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
-import { getProfiles } from '@movar/lang-detect';
-import { francResidualVerdict } from '@movar/lang-detect/franc';
-import type { ResidualRung3Resolver } from './content-conceal';
+import { classifyBySnippet, getProfiles } from '@movar/lang-detect';
+import { francRung3Resolver } from '@movar/lang-detect/franc';
+import type { SnippetClassifier } from './content-conceal';
 import '@movar/page-content/google';
 import '@movar/page-content/youtube';
 import { applyContentFilter, clearAllMarks, revealAllNodes } from './content-conceal';
@@ -11,9 +11,11 @@ import { setContentLocale } from './i18n/content';
 
 // Tests run franc's rung-3 directly (no background worker) so the 'unknown'
 // residual behaves exactly as the in-process classifier used to.
-// eslint-disable-next-line @typescript-eslint/require-await -- sync test resolver behind the async ResidualRung3Resolver contract; nothing to await
-const directRung3: ResidualRung3Resolver = async (texts, candidates) =>
-  texts.map((t) => francResidualVerdict(t, candidates));
+// eslint-disable-next-line @typescript-eslint/require-await -- sync in-process classifier behind the async SnippetClassifier contract; nothing to await
+const directClassify: SnippetClassifier = async (texts, candidateCodes) => {
+  const profiles = getProfiles([...candidateCodes]);
+  return texts.map((t) => classifyBySnippet(t, profiles, francRung3Resolver));
+};
 
 // Bridges old blocklist-style call sites to the allowlist filter: conceal iff a
 // card's detected language ∈ `blocked`. candidates = uk/ru/en; enabled =
@@ -24,9 +26,9 @@ async function runFilter(
   blocked: readonly string[],
 ): ReturnType<typeof applyContentFilter> {
   return applyContentFilter(model, {
-    candidates: getProfiles(FILTER_LANGS),
+    candidateCodes: FILTER_LANGS,
     enabled: new Set(FILTER_LANGS.filter((c) => !blocked.includes(c))),
-    rung3: directRung3,
+    classify: directClassify,
   });
 }
 

--- a/apps/extension/src/lib/content-modification.ts
+++ b/apps/extension/src/lib/content-modification.ts
@@ -24,7 +24,6 @@
  * safe no-ops when nothing has been concealed — which is also what lets them be
  * called unconditionally from the orchestrator.
  */
-import { getProfiles } from '@movar/lang-detect';
 import type { LanguageCode } from '@movar/lang-detect';
 import type { CorrectionEvent } from '@movar/events';
 import type { MovarSettings } from '@movar/settings';
@@ -34,7 +33,7 @@ import type { PageMode } from '@movar/page-mode/types';
 import { filterPickers } from './picker-filter';
 import { detachAllTooltips, setAllTooltipsColorScheme } from './tooltip';
 import { applyContentFilter, clearAllMarks, revealAllNodes } from './content-conceal';
-import { classifyResidualSnippets } from './lang-detect-bridge';
+import { classifySnippets } from './lang-detect-bridge';
 import { detachAllCurtains, setAllCurtainsColorScheme } from './curtain';
 import { buildModelForHost } from '@movar/page-content/registry';
 import '@movar/page-content/google';
@@ -121,14 +120,14 @@ async function filterAndRecordContent(
   // enabled. With priority ∪ blocked as candidates this matches "hide iff the
   // card reads as a blocked language", now via the set-difference classifier.
   const enabled = new Set(settings.priority);
-  const candidates = getProfiles([...new Set([...settings.priority, ...settings.blocked])]);
-  if (candidates.length === 0) return;
+  const candidateCodes = [...new Set([...settings.priority, ...settings.blocked])];
+  if (candidateCodes.length === 0) return;
   const blurred = await applyContentFilter(contentModel, {
-    candidates,
+    candidateCodes,
     enabled,
-    // Rung 3 (franc) runs in the background worker; the content filter sends it
-    // only the cards rungs 1–2 left 'unknown', batched once per tick.
-    rung3: classifyResidualSnippets,
+    // Classification (the language profiles + franc) runs in the background
+    // worker; the content filter sends it the card texts, batched once per tick.
+    classify: classifySnippets,
   });
   const toLang = target ?? pageLang ?? '';
   for (const card of blurred) {

--- a/apps/extension/src/lib/google-conceal.test.ts
+++ b/apps/extension/src/lib/google-conceal.test.ts
@@ -1,15 +1,17 @@
 import { beforeEach, describe, expect, it } from 'vitest';
-import { getProfiles } from '@movar/lang-detect';
-import { francResidualVerdict } from '@movar/lang-detect/franc';
-import type { ResidualRung3Resolver } from './content-conceal';
+import { classifyBySnippet, getProfiles } from '@movar/lang-detect';
+import { francRung3Resolver } from '@movar/lang-detect/franc';
+import type { SnippetClassifier } from './content-conceal';
 import { GOOGLE_EXTRACTOR } from '@movar/page-content/google';
 import { applyContentFilter } from './content-conceal';
 
 // Tests run franc's rung-3 directly (no background worker) so the 'unknown'
 // residual behaves exactly as the in-process classifier used to.
-// eslint-disable-next-line @typescript-eslint/require-await -- sync test resolver behind the async ResidualRung3Resolver contract; nothing to await
-const directRung3: ResidualRung3Resolver = async (texts, candidates) =>
-  texts.map((t) => francResidualVerdict(t, candidates));
+// eslint-disable-next-line @typescript-eslint/require-await -- sync in-process classifier behind the async SnippetClassifier contract; nothing to await
+const directClassify: SnippetClassifier = async (texts, candidateCodes) => {
+  const profiles = getProfiles([...candidateCodes]);
+  return texts.map((t) => classifyBySnippet(t, profiles, francRung3Resolver));
+};
 
 // Bridges old blocklist-style call sites to the allowlist filter: conceal iff a
 // card's detected language ∈ `blocked`. candidates = uk/ru/en; enabled =
@@ -20,9 +22,9 @@ async function runFilter(
   blocked: readonly string[],
 ): ReturnType<typeof applyContentFilter> {
   return applyContentFilter(model, {
-    candidates: getProfiles(FILTER_LANGS),
+    candidateCodes: FILTER_LANGS,
     enabled: new Set(FILTER_LANGS.filter((c) => !blocked.includes(c))),
-    rung3: directRung3,
+    classify: directClassify,
   });
 }
 

--- a/apps/extension/src/lib/i18n/content-messages-en.ts
+++ b/apps/extension/src/lib/i18n/content-messages-en.ts
@@ -1,0 +1,74 @@
+/**
+ * Content-script curtain strings (English) — the canonical shape.
+ *
+ * Split out of the full {@link Messages} catalogue (popup + options) so the
+ * always-on content script bundles ONLY these few injected-curtain strings,
+ * not Movar's entire UI copy. The content script loads on every page; the
+ * popup/options strings it never renders were ~20 KB of dead weight there, and
+ * that figure grows with every locale added. The full catalogue composes this
+ * subset back in (`messagesEn.content = contentMessagesEn`) so popup-side code
+ * still sees one `Messages` object.
+ *
+ * Strings stay TS functions (not ICU/`_locales` placeholders) so each locale
+ * applies its own plural/branching rules at the call site — the same choice the
+ * parent catalogue documents.
+ */
+import type { LanguageCode } from '@movar/lang-detect';
+
+/** Injected-curtain strings for the content script (picker chips, survivor
+ *  tooltips, blur cards). The Ukrainian catalogue is typed against this so
+ *  missing keys surface at build time. */
+export interface ContentMessages {
+  pickerHidden: {
+    /**
+     * Hover/screen-reader sentence for the picker-hidden chip. Takes the
+     * surviving language's endonym (already localised by the caller via
+     * `Intl.DisplayNames`) or `null` when no language survived — the
+     * sigil-only state where the chip degrades to icon-without-label.
+     */
+    chipLabel: (endonym: string | null) => string;
+    show: string;
+  };
+  /**
+   * Custom-styled tooltip applied to every surviving link in a picker
+   * where Movar hid at least one option. Three slots: a short title,
+   * the body listing the hidden languages by endonym (in original
+   * picker order), and a button label for the in-place "show hidden
+   * options" action.
+   */
+  pickerSurvivor: {
+    title: string;
+    body: (hiddenEndonyms: string[]) => string;
+    show: string;
+  };
+  contentHidden: {
+    title: string;
+    /** Description varies by detected language ('ru' is the only one with
+     *  a tailored message today; others use a generic fallback). */
+    descriptionForLanguage: (code: LanguageCode) => string;
+    ariaLabelForLanguage: (code: LanguageCode) => string;
+    show: string;
+  };
+}
+
+export const contentMessagesEn: ContentMessages = {
+  pickerHidden: {
+    chipLabel: (endonym) =>
+      endonym === null
+        ? 'Movar hid this language picker — click to show'
+        : `Movar — ${endonym}. Click to show the language picker.`,
+    show: 'Show',
+  },
+  pickerSurvivor: {
+    title: 'Some options hidden',
+    body: (hidden) => `Movar hid: ${hidden.join(', ')}.`,
+    show: 'Show hidden options',
+  },
+  contentHidden: {
+    title: 'Content hidden',
+    descriptionForLanguage: (code) => (code === 'ru' ? 'In Russian' : 'Language not in your list'),
+    ariaLabelForLanguage: (code) =>
+      code === 'ru' ? 'Movar: Russian content hidden' : 'Movar: content hidden',
+    show: 'Show',
+  },
+};

--- a/apps/extension/src/lib/i18n/content-messages-uk.ts
+++ b/apps/extension/src/lib/i18n/content-messages-uk.ts
@@ -1,0 +1,27 @@
+import type { ContentMessages } from './content-messages-en';
+
+/** Ukrainian content-script curtain strings. Typed against {@link ContentMessages}
+ *  (the English canonical shape) so missing keys fail the build. See
+ *  content-messages-en.ts for why this subset is split from the full catalogue. */
+export const contentMessagesUk: ContentMessages = {
+  pickerHidden: {
+    chipLabel: (endonym) =>
+      endonym === null
+        ? 'Movar приховав перемикач мов — натисніть, щоб показати'
+        : `Movar — ${endonym}. Натисніть, щоб показати перемикач мов.`,
+    show: 'Показати',
+  },
+  pickerSurvivor: {
+    title: 'Деякі варіанти приховано',
+    body: (hidden) => `Movar приховав: ${hidden.join(', ')}.`,
+    show: 'Показати приховані варіанти',
+  },
+  contentHidden: {
+    title: 'Приховано вміст',
+    descriptionForLanguage: (code) =>
+      code === 'ru' ? 'Російською мовою' : 'Мова не у вашому списку',
+    ariaLabelForLanguage: (code) =>
+      code === 'ru' ? 'Movar: приховано російськомовний вміст' : 'Movar: приховано вміст',
+    show: 'Показати',
+  },
+};

--- a/apps/extension/src/lib/i18n/content.ts
+++ b/apps/extension/src/lib/i18n/content.ts
@@ -18,13 +18,13 @@
  */
 
 import type { ResolvedLocale } from './resolve';
-import { messagesEn } from './messages-en';
-import type { Messages } from './messages-en';
-import { messagesUk } from './messages-uk';
+import { contentMessagesEn } from './content-messages-en';
+import type { ContentMessages } from './content-messages-en';
+import { contentMessagesUk } from './content-messages-uk';
 
-const CATALOGUES: Record<ResolvedLocale, Messages> = {
-  en: messagesEn,
-  uk: messagesUk,
+const CATALOGUES: Record<ResolvedLocale, ContentMessages> = {
+  en: contentMessagesEn,
+  uk: contentMessagesUk,
 };
 
 let currentLocale: ResolvedLocale = 'en';
@@ -33,6 +33,6 @@ export function setContentLocale(locale: ResolvedLocale): void {
   currentLocale = locale;
 }
 
-export function getContentMessages(): Messages {
+export function getContentMessages(): ContentMessages {
   return CATALOGUES[currentLocale];
 }

--- a/apps/extension/src/lib/i18n/messages-en.ts
+++ b/apps/extension/src/lib/i18n/messages-en.ts
@@ -1,5 +1,6 @@
-import type { LanguageCode } from '@movar/lang-detect';
 import type { PauseDuration } from '../pause';
+import type { ContentMessages } from './content-messages-en';
+import { contentMessagesEn } from './content-messages-en';
 
 /** English string catalogue for Movar's own UI surfaces (popup, options) and
  *  for the content-script's injected curtains. Shape is the canonical one —
@@ -174,38 +175,10 @@ export interface Messages {
   };
 
   // ─── Content-script curtains ───────────────────────────────────────────
-  content: {
-    pickerHidden: {
-      /**
-       * Hover/screen-reader sentence for the picker-hidden chip. Takes the
-       * surviving language's endonym (already localised by the caller via
-       * `Intl.DisplayNames`) or `null` when no language survived — the
-       * sigil-only state where the chip degrades to icon-without-label.
-       */
-      chipLabel: (endonym: string | null) => string;
-      show: string;
-    };
-    /**
-     * Custom-styled tooltip applied to every surviving link in a picker
-     * where Movar hid at least one option. Three slots: a short title,
-     * the body listing the hidden languages by endonym (in original
-     * picker order), and a button label for the in-place "show hidden
-     * options" action.
-     */
-    pickerSurvivor: {
-      title: string;
-      body: (hiddenEndonyms: string[]) => string;
-      show: string;
-    };
-    contentHidden: {
-      title: string;
-      /** Description varies by detected language ('ru' is the only one with
-       *  a tailored message today; others use a generic fallback). */
-      descriptionForLanguage: (code: LanguageCode) => string;
-      ariaLabelForLanguage: (code: LanguageCode) => string;
-      show: string;
-    };
-  };
+  /** Injected-curtain strings for the content script (picker chips, survivor
+   *  tooltips, blur cards), split into their own catalogue so the always-on
+   *  content bundle carries only these — not the popup/options copy above. */
+  content: ContentMessages;
 }
 
 export const messagesEn: Messages = {
@@ -323,26 +296,5 @@ export const messagesEn: Messages = {
       toggleLabel: 'Allow Movar to modify page content on visited sites.',
     },
   },
-  content: {
-    pickerHidden: {
-      chipLabel: (endonym) =>
-        endonym === null
-          ? 'Movar hid this language picker — click to show'
-          : `Movar — ${endonym}. Click to show the language picker.`,
-      show: 'Show',
-    },
-    pickerSurvivor: {
-      title: 'Some options hidden',
-      body: (hidden) => `Movar hid: ${hidden.join(', ')}.`,
-      show: 'Show hidden options',
-    },
-    contentHidden: {
-      title: 'Content hidden',
-      descriptionForLanguage: (code) =>
-        code === 'ru' ? 'In Russian' : 'Language not in your list',
-      ariaLabelForLanguage: (code) =>
-        code === 'ru' ? 'Movar: Russian content hidden' : 'Movar: content hidden',
-      show: 'Show',
-    },
-  },
+  content: contentMessagesEn,
 };

--- a/apps/extension/src/lib/i18n/messages-uk.ts
+++ b/apps/extension/src/lib/i18n/messages-uk.ts
@@ -1,4 +1,5 @@
 import type { Messages } from './messages-en';
+import { contentMessagesUk } from './content-messages-uk';
 
 /**
  * Ukrainian one/few/many plural rule (CLDR).
@@ -151,26 +152,5 @@ export const messagesUk: Messages = {
       toggleLabel: 'Дозволити Movar змінювати вміст сторінок на відвіданих сайтах.',
     },
   },
-  content: {
-    pickerHidden: {
-      chipLabel: (endonym) =>
-        endonym === null
-          ? 'Movar приховав перемикач мов — натисніть, щоб показати'
-          : `Movar — ${endonym}. Натисніть, щоб показати перемикач мов.`,
-      show: 'Показати',
-    },
-    pickerSurvivor: {
-      title: 'Деякі варіанти приховано',
-      body: (hidden) => `Movar приховав: ${hidden.join(', ')}.`,
-      show: 'Показати приховані варіанти',
-    },
-    contentHidden: {
-      title: 'Приховано вміст',
-      descriptionForLanguage: (code) =>
-        code === 'ru' ? 'Російською мовою' : 'Мова не у вашому списку',
-      ariaLabelForLanguage: (code) =>
-        code === 'ru' ? 'Movar: приховано російськомовний вміст' : 'Movar: приховано вміст',
-      show: 'Показати',
-    },
-  },
+  content: contentMessagesUk,
 };

--- a/apps/extension/src/lib/lang-detect-bridge.test.ts
+++ b/apps/extension/src/lib/lang-detect-bridge.test.ts
@@ -1,13 +1,8 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import type { MockInstance } from 'vitest';
 import { browser } from 'wxt/browser';
-import { getProfiles } from '@movar/lang-detect';
 import type { DetectedLanguage, SnippetVerdict } from '@movar/lang-detect';
-import {
-  backgroundFrancEngine,
-  classifyResidualSnippets,
-  warmBackgroundFranc,
-} from './lang-detect-bridge';
+import { backgroundFrancEngine, classifySnippets, warmBackgroundFranc } from './lang-detect-bridge';
 
 afterEach(() => {
   vi.restoreAllMocks();
@@ -20,8 +15,8 @@ function spySendMessage(): MockInstance<(message: unknown) => Promise<unknown>> 
   return vi.spyOn(browser.runtime, 'sendMessage');
 }
 
-// getProfiles preserves input order, so codes come back ['ru', 'uk'].
-const ruUk = getProfiles(['ru', 'uk']);
+// Candidate language codes the content filter sends for classification.
+const ruUk = ['ru', 'uk'];
 
 describe('backgroundFrancEngine (tier-7 bridge)', () => {
   it('is always available with id "franc" (telemetry parity)', () => {
@@ -67,21 +62,21 @@ describe('backgroundFrancEngine (tier-7 bridge)', () => {
   });
 });
 
-describe('classifyResidualSnippets (rung-3 batch bridge)', () => {
+describe('classifySnippets (batch classifier bridge)', () => {
   it('returns [] without messaging for an empty batch', async () => {
     const send = spySendMessage();
-    expect(await classifyResidualSnippets([], ruUk)).toEqual([]);
+    expect(await classifySnippets([], ruUk)).toEqual([]);
     expect(send).not.toHaveBeenCalled();
   });
 
   it('sends ONE batched message with candidate codes and returns the verdicts in order', async () => {
     const verdicts: (SnippetVerdict | null)[] = [{ language: 'ru', margin: 0.3, rung: 3 }, null];
     const send = spySendMessage().mockResolvedValue(verdicts);
-    const result = await classifyResidualSnippets(['a', 'b'], ruUk);
+    const result = await classifySnippets(['a', 'b'], ruUk);
     expect(result).toEqual(verdicts);
     expect(send).toHaveBeenCalledTimes(1);
     expect(send).toHaveBeenCalledWith({
-      type: 'movar:detectSnippets',
+      type: 'movar:classifySnippets',
       texts: ['a', 'b'],
       candidateCodes: ['ru', 'uk'],
     });
@@ -89,7 +84,7 @@ describe('classifyResidualSnippets (rung-3 batch bridge)', () => {
 
   it('falls back to all-null (keep every card) when the worker errors', async () => {
     spySendMessage().mockRejectedValue(new Error('no receiver'));
-    expect(await classifyResidualSnippets(['a', 'b', 'c'], ruUk)).toEqual([null, null, null]);
+    expect(await classifySnippets(['a', 'b', 'c'], ruUk)).toEqual([null, null, null]);
   });
 });
 

--- a/apps/extension/src/lib/lang-detect-bridge.ts
+++ b/apps/extension/src/lib/lang-detect-bridge.ts
@@ -12,11 +12,11 @@ import { browser } from 'wxt/browser';
 import type {
   DetectContext,
   DetectedLanguage,
+  LanguageCode,
   LanguageDetectionEngine,
-  LanguageProfile,
   SnippetVerdict,
 } from '@movar/lang-detect';
-import type { DetectSnippetsMessage, DetectTextMessage, WarmFrancMessage } from './messaging';
+import type { ClassifySnippetsMessage, DetectTextMessage, WarmFrancMessage } from './messaging';
 
 /** Resolve `p`, or `null` as soon as `signal` aborts. In-flight background work
  *  keeps running (warming franc for the next tick) — we just stop awaiting it. */
@@ -63,20 +63,21 @@ export const backgroundFrancEngine: LanguageDetectionEngine = {
 };
 
 /**
- * Batched rung-3 residual resolver for the content filter. Sends the cards that
- * rungs 1–2 left 'unknown' (plus the candidate codes) to the background franc in
- * ONE message per tick, and returns one verdict (or null) per text, in order. On
- * any failure every text resolves to null (abstain → keep the card).
+ * Batched snippet classifier for the content filter. Sends every scanned card's
+ * text (plus the candidate language codes) to the worker, which runs the full
+ * classifier (rungs 1–3) and returns one verdict (or null) per text, in order —
+ * keeping the language profiles + franc out of the content bundle. One message
+ * per tick. On any failure every text resolves to null (abstain → keep the card).
  */
-export async function classifyResidualSnippets(
+export async function classifySnippets(
   texts: readonly string[],
-  candidates: readonly LanguageProfile[],
+  candidateCodes: readonly LanguageCode[],
 ): Promise<readonly (SnippetVerdict | null)[]> {
   if (texts.length === 0) return [];
-  const message: DetectSnippetsMessage = {
-    type: 'movar:detectSnippets',
+  const message: ClassifySnippetsMessage = {
+    type: 'movar:classifySnippets',
     texts: [...texts],
-    candidateCodes: candidates.map((c) => c.code),
+    candidateCodes: [...candidateCodes],
   };
   try {
     const raw: unknown = await browser.runtime.sendMessage(message);

--- a/apps/extension/src/lib/messaging.ts
+++ b/apps/extension/src/lib/messaging.ts
@@ -36,11 +36,13 @@ export interface DetectTextMessage {
   maxChars?: number;
 }
 
-/** Batched rung-3 residual classification for the content filter, served by the
- *  background-worker franc — one verdict (or null) per text, in order.
+/** Batched per-snippet classification for the content filter — the worker runs
+ *  the full classifier (rungs 1–3, franc + the language profiles) over each card
+ *  text against the candidate languages, so neither the profiles nor franc ship
+ *  in the content bundle. One verdict (or null) per text, in order.
  *  Response: `(SnippetVerdict | null)[]` (from @movar/lang-detect). */
-export interface DetectSnippetsMessage {
-  type: 'movar:detectSnippets';
+export interface ClassifySnippetsMessage {
+  type: 'movar:classifySnippets';
   texts: string[];
   candidateCodes: LanguageCode[];
 }
@@ -53,11 +55,11 @@ export interface WarmFrancMessage {
 
 /** Message protocol across the content script, popup/options, and background.
  *  getHidden/restoreHidden are popup→content (tabs.sendMessage); detectText/
- *  detectSnippets/warmFranc are content→background (runtime.sendMessage). Each
+ *  classifySnippets/warmFranc are content→background (runtime.sendMessage). Each
  *  listener ignores the types it doesn't own. */
 export type MovarMessage =
   | { type: 'movar:getHidden' }
   | { type: 'movar:restoreHidden' }
   | DetectTextMessage
-  | DetectSnippetsMessage
+  | ClassifySnippetsMessage
   | WarmFrancMessage;

--- a/apps/extension/src/lib/picker-filter.ts
+++ b/apps/extension/src/lib/picker-filter.ts
@@ -331,7 +331,7 @@ function restorePickerInPlace(picker: Picker): void {
  */
 function annotateSurvivingLinks(picker: Picker, hiddenLanguages: LanguageCode[]): void {
   if (hiddenLanguages.length === 0) return;
-  const { content } = getContentMessages();
+  const content = getContentMessages();
   const endonyms = hiddenLanguages.map((c) => endonym(c));
   const title = content.pickerSurvivor.title;
   const body = content.pickerSurvivor.body(endonyms);
@@ -406,7 +406,7 @@ function attachPickerContainerCurtain(
   container: HTMLElement,
   survivingLang: LanguageCode | null,
 ): void {
-  const { content } = getContentMessages();
+  const content = getContentMessages();
   const label = survivingLang === null ? '' : endonym(survivingLang);
   const description = content.pickerHidden.chipLabel(label || null);
   const handle = attachCurtain(container, {

--- a/packages/lang-detect/package.json
+++ b/packages/lang-detect/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.0",
   "private": true,
   "type": "module",
+  "sideEffects": false,
   "main": "./src/index.ts",
   "types": "./src/index.ts",
   "exports": {


### PR DESCRIPTION
Two-commit follow-up to the franc→worker move (#67), continuing to shrink the **always-on content script** (loads on every page, `<all_urls>`, off-by-default hiding feature).

## What

**`cc7350e` — classification → background worker.** Content-hiding is off by default, yet the content script shipped the full per-snippet classifier (language profiles + franc) to every page. It now sends card texts to the worker (batched once per filter tick); the worker rebuilds the candidate profiles and runs the classifier. The conceal/margin decision stays content-side. Adding `"sideEffects": false` to `@movar/lang-detect` lets the bundler drop the eagerly-evaluated `PROFILES` table (23.6 KB) that nothing in the content graph actually imports.

**`2c9e5b2` — split content curtain strings out of the UI catalogue.** The content script renders only `content.*` (picker chips, survivor tooltips, blur cards) but bundled the entire `Messages` object — every popup + options string, both locales. Extracted into `ContentMessages` (`content-messages-{en,uk}.ts`); the full catalogues compose it back in, so popup/options are unchanged. Strings stay TS function-catalogues; the `uiLanguage` override is preserved.

## Bundle impact (`content.js`)

| stage | size | what left |
|---|---|---|
| after #67 (franc → worker) | ~106 KB | — |
| + classify→worker + `sideEffects` | 78 KB | profiles/classifier (`@movar/lang-detect` 30.3 → 3.7 KB) |
| + i18n split | **60 KB** (source-graph guard) | popup/options strings (`app` 57.9 → 39.9 KB) |

Real WXT build: `content.js` = **64 KB** (chrome/firefox/safari identical), franc-free; `background.js` = 388 KB — the worker now hosts franc + profiles + classifier (one instance, off the page critical path).

## Note on "ship only specific locales"

This removes the popup/options copy (the bulk, and the fastest-growing-per-locale part) but still bundles both locales of the small curtain subset (~0.5 KB each) — not literally single-locale. A worker-hosted active-locale-only fetch would buy true zero-bytes-for-inactive-locales, at the cost of an async bootstrap + restructuring the curtain string functions into serializable data. Deferred as not-yet-worth-it; straightforward follow-up if wanted.

## Test plan
- [x] `pnpm --filter @movar/extension typecheck && test && lint` — 436 tests green
- [x] `pnpm metrics:audit` — 0 issues in changed files
- [x] `pnpm --filter @movar/extension check:content-bundle` — franc-free, 60 KB (budget 175)
- [x] Real WXT build (chrome/firefox/safari) — `build:done` slim-guard passed; `content.js` franc-free, curtain strings present, popup/options strings absent (now in the popup chunk)

🤖 Generated with [Claude Code](https://claude.com/claude-code)