### PR TITLE
perf(extension): parallelize content-modification passes + batch the corrections log

### DIFF
--- a/apps/extension/src/entrypoints/background.ts
+++ b/apps/extension/src/entrypoints/background.ts
@@ -13,8 +13,8 @@ import type { MovarMessage } from '../lib/messaging';
 
 /** Recompute the DNR rule from current settings + pause state. */
 async function resync(): Promise<void> {
-  const settings = await getSettings();
-  const { paused } = await getPauseState();
+  // Independent reads — fetch settings and pause state concurrently.
+  const [settings, { paused }] = await Promise.all([getSettings(), getPauseState()]);
   await syncAcceptLanguageRule(settings, !paused);
 }
 

--- a/apps/extension/src/entrypoints/content.ts
+++ b/apps/extension/src/entrypoints/content.ts
@@ -8,7 +8,7 @@ import type { LanguageCode } from '@movar/lang-detect';
 import { backgroundFrancEngine, warmBackgroundFranc } from '../lib/lang-detect-bridge';
 import { getRuleForHost } from '@movar/rules';
 import type { SiteRule } from '@movar/rules';
-import { logCorrection } from '../lib/events';
+import { logCorrection, logCorrections } from '../lib/events';
 import { classifyLanguageElement } from '@movar/lang-pickers/classify';
 import { findLanguagePickers } from '@movar/lang-pickers/extract';
 import { pickRedirectTarget } from '@movar/lang-pickers/redirect';
@@ -22,6 +22,7 @@ import {
   setContentModificationColorScheme,
   teardownContentModification,
 } from '../lib/content-modification';
+import type { ContentCorrection } from '../lib/content-modification';
 import { setCurrentColorScheme } from '@movar/page-mode/context';
 import { detectModeForHost } from '@movar/page-mode/registry';
 import { watchPageMode } from '@movar/page-mode/observer';
@@ -188,11 +189,11 @@ let currentDetectionEngine: string | null = null;
  *  reads it synchronously when the popup asks. */
 let lastPageLang: LanguageCode | null = null;
 
-async function record(
+function buildCorrectionEvent(
   mechanism: CorrectionEvent['mechanism'],
   fromLang: LanguageCode,
   toLang: LanguageCode,
-): Promise<void> {
+): CorrectionEvent {
   const event: CorrectionEvent = {
     timestamp: Date.now(),
     domain: location.hostname,
@@ -201,7 +202,21 @@ async function record(
     toLang,
   };
   if (currentDetectionEngine != null) event.detectionEngine = currentDetectionEngine;
-  await logCorrection(event);
+  return event;
+}
+
+async function record(
+  mechanism: CorrectionEvent['mechanism'],
+  fromLang: LanguageCode,
+  toLang: LanguageCode,
+): Promise<void> {
+  await logCorrection(buildCorrectionEvent(mechanism, fromLang, toLang));
+}
+
+/** Batch-log the corrections from one content-modification pass (all 'dom'
+ *  mechanism) in a single serialized write. */
+async function recordContentCorrections(corrections: readonly ContentCorrection[]): Promise<void> {
+  await logCorrections(corrections.map((c) => buildCorrectionEvent('dom', c.fromLang, c.toLang)));
 }
 
 async function whenDomReady(): Promise<void> {
@@ -451,7 +466,8 @@ async function applyOnceInner(settings: MovarSettings): Promise<boolean> {
   if (await attemptLanguageSwitch(settings, rule, pageLang, target, pickers)) return true;
 
   if (settings.contentModification) {
-    await applyContentModification({ settings, pageLang, target, pickers, record });
+    const corrections = await applyContentModification({ settings, pageLang, target, pickers });
+    await recordContentCorrections(corrections);
   }
 
   return false;

--- a/apps/extension/src/lib/content-modification.ts
+++ b/apps/extension/src/lib/content-modification.ts
@@ -25,7 +25,6 @@
  * called unconditionally from the orchestrator.
  */
 import type { LanguageCode } from '@movar/lang-detect';
-import type { CorrectionEvent } from '@movar/events';
 import type { MovarSettings } from '@movar/settings';
 import { ORIGINAL_TEXT_ATTR, RESTORED_ATTR } from '@movar/lang-pickers/types';
 import type { Picker } from '@movar/lang-pickers/types';
@@ -45,13 +44,13 @@ import '@movar/page-content/youtube';
  *  the conceal module just for a string literal). */
 const HIDDEN_ATTR = 'data-movar-hidden';
 
-/** Correction-event logger, owned by the orchestrator (it carries per-tick
- *  detection-engine state) and injected so this module stays stateless. */
-export type RecordCorrection = (
-  mechanism: CorrectionEvent['mechanism'],
-  fromLang: LanguageCode,
-  toLang: LanguageCode,
-) => Promise<void>;
+/** One correction the hiding feature wants logged. The orchestrator stamps the
+ *  rest (domain, timestamp, detection engine, mechanism) and batches the write,
+ *  so this module stays stateless and never touches the corrections log itself. */
+export interface ContentCorrection {
+  fromLang: LanguageCode;
+  toLang: LanguageCode;
+}
 
 /** Everything {@link applyContentModification} needs for one orchestrator tick. */
 export interface ContentModificationContext {
@@ -59,22 +58,22 @@ export interface ContentModificationContext {
   pageLang: LanguageCode | null;
   target: LanguageCode | undefined;
   pickers: Picker[];
-  record: RecordCorrection;
 }
 
-/** Strip unwanted-language entries from any visible language pickers and log
- *  one correction event per distinct hidden language. */
+/** Strip unwanted-language entries from any visible language pickers; return one
+ *  correction per distinct hidden language (the orchestrator logs them). Synchronous
+ *  — `filterPickers` is pure DOM work — so it runs during the content pass's worker
+ *  round-trip when the two are kicked off together. */
 // Set-dedup loop + early returns; cyclomatic count comes from short-circuits,
 // not nested logic.
 // fallow-ignore-next-line complexity
-async function filterAndRecordPickers(
+function collectPickerCorrections(
   settings: MovarSettings,
   pageLang: LanguageCode | null,
   target: LanguageCode | undefined,
   pickers: Picker[],
-  record: RecordCorrection,
-): Promise<void> {
-  if (pickers.length === 0) return;
+): ContentCorrection[] {
+  if (pickers.length === 0) return [];
 
   // Blocked-only mode is the default: strip languages the user explicitly
   // blocked, leave everything else visible — including languages outside
@@ -92,37 +91,40 @@ async function filterAndRecordPickers(
   // future MutationObserver re-runs. The popup's "Show everything on
   // this page" stays available as the page-wide global sweep.
   const result = filterPickers(pickers, settings.priority, { blocked: settings.blocked });
-  if (result.hiddenLinks.length === 0) return;
+  if (result.hiddenLinks.length === 0) return [];
 
   const preferred = target ?? pageLang ?? '';
+  const corrections: ContentCorrection[] = [];
   const seen = new Set<LanguageCode>();
   for (const link of result.hiddenLinks) {
     if (seen.has(link.language)) continue;
     seen.add(link.language);
-    await record('dom', link.language, preferred);
+    corrections.push({ fromLang: link.language, toLang: preferred });
   }
+  return corrections;
 }
 
-/** Blur content cards whose title/channel reads as a blocked language
- *  (YouTube + similar — sites with no usable language picker for results). */
+/** Blur content cards whose title/channel reads as a blocked language (YouTube +
+ *  similar — sites with no usable language picker for results); return one
+ *  correction per blurred card. The classification is a background-worker
+ *  round-trip, so the caller kicks this off before the synchronous picker pass. */
 // Guards + per-card loop; counts above threshold because of the early-returns,
 // not nested branches.
 // fallow-ignore-next-line complexity
-async function filterAndRecordContent(
+async function collectContentCorrections(
   settings: MovarSettings,
   pageLang: LanguageCode | null,
   target: LanguageCode | undefined,
-  record: RecordCorrection,
-): Promise<void> {
+): Promise<ContentCorrection[]> {
   const contentModel = buildModelForHost(location.hostname);
-  if (!contentModel || settings.blocked.length === 0) return;
+  if (!contentModel || settings.blocked.length === 0) return [];
   // Candidates = languages the user cares about (enabled ∪ blocked overlay);
   // a card is concealed only when its detected language is confidently not
   // enabled. With priority ∪ blocked as candidates this matches "hide iff the
   // card reads as a blocked language", now via the set-difference classifier.
   const enabled = new Set(settings.priority);
   const candidateCodes = [...new Set([...settings.priority, ...settings.blocked])];
-  if (candidateCodes.length === 0) return;
+  if (candidateCodes.length === 0) return [];
   const blurred = await applyContentFilter(contentModel, {
     candidateCodes,
     enabled,
@@ -131,24 +133,28 @@ async function filterAndRecordContent(
     classify: classifySnippets,
   });
   const toLang = target ?? pageLang ?? '';
-  for (const card of blurred) {
-    await record('dom', card.fromLang, toLang);
-  }
+  return blurred.map((card) => ({ fromLang: card.fromLang, toLang }));
 }
 
 /**
- * Gated entry point — run one content-modification pass for the current tick.
- * The orchestrator calls this only when `settings.contentModification` is on.
- * Pickers first, then content cards, matching the original orchestrator order.
+ * Gated entry point — run one content-modification pass for the current tick. The
+ * orchestrator calls this only when `settings.contentModification` is on, and logs
+ * the returned corrections (this module never touches the log).
+ *
+ * The picker pass (synchronous DOM) and the content pass (an async worker
+ * classification round-trip) are independent — disjoint elements, neither writes
+ * the log — so the content pass is kicked off first and the picker pass runs
+ * during its round-trip. Curtain strings must be loaded before either builds a
+ * pill, so that await stays in front.
  */
-export async function applyContentModification(ctx: ContentModificationContext): Promise<void> {
-  const { settings, pageLang, target, pickers, record } = ctx;
-  // Ensure the active locale's curtain strings are loaded before any curtain is
-  // built — the worker hosts non-English catalogues; English is the bundled
-  // fallback. Idempotent + cached after the first successful fetch.
+export async function applyContentModification(
+  ctx: ContentModificationContext,
+): Promise<ContentCorrection[]> {
+  const { settings, pageLang, target, pickers } = ctx;
   await loadContentMessages();
-  await filterAndRecordPickers(settings, pageLang, target, pickers, record);
-  await filterAndRecordContent(settings, pageLang, target, record);
+  const contentDone = collectContentCorrections(settings, pageLang, target);
+  const pickerCorrections = collectPickerCorrections(settings, pageLang, target, pickers);
+  return [...pickerCorrections, ...(await contentDone)];
 }
 
 /**

--- a/apps/extension/src/lib/events.test.ts
+++ b/apps/extension/src/lib/events.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it } from 'vitest';
 import type { CorrectionEvent } from '@movar/events';
-import { __internal } from './events';
+import { __internal, logCorrection, logCorrections } from './events';
 
-const { prune, EVENT_TTL_MS, MAX_EVENTS } = __internal;
+const { prune, getEvents, EVENT_TTL_MS, MAX_EVENTS } = __internal;
 
 function event(timestamp: number): CorrectionEvent {
   return {
@@ -59,5 +59,42 @@ describe('events prune', () => {
     const events = [event(NOW)];
     const result = prune(events, NOW);
     expect(result).not.toBe(events);
+  });
+});
+
+// Storage isn't reset between tests, so assert on the DELTA rather than absolute
+// counts (the cap test, which IS absolute, runs last).
+const count = async (): Promise<number> => (await getEvents()).length;
+
+describe('logCorrections', () => {
+  it('appends a whole batch in one write', async () => {
+    const before = await count();
+    await logCorrections([event(Date.now()), event(Date.now())]);
+    expect(await count()).toBe(before + 2);
+  });
+
+  it('is a no-op for an empty batch', async () => {
+    const before = await count();
+    await logCorrections([]);
+    expect(await count()).toBe(before);
+  });
+
+  it('appends without clobbering existing events', async () => {
+    const before = await count();
+    await logCorrections([event(Date.now())]);
+    await logCorrections([event(Date.now()), event(Date.now())]);
+    expect(await count()).toBe(before + 3);
+  });
+
+  it('logCorrection logs a single event via the batch path', async () => {
+    const before = await count();
+    await logCorrection(event(Date.now()));
+    expect(await count()).toBe(before + 1);
+  });
+
+  it('caps the stored log at MAX_EVENTS', async () => {
+    const now = Date.now();
+    await logCorrections(Array.from({ length: MAX_EVENTS + 10 }, (_, i) => event(now - i)));
+    expect(await count()).toBe(MAX_EVENTS);
   });
 });

--- a/apps/extension/src/lib/events.ts
+++ b/apps/extension/src/lib/events.ts
@@ -26,13 +26,27 @@ async function getEvents(): Promise<CorrectionEvent[]> {
   return (stored[EVENTS_KEY] as CorrectionEvent[] | undefined) ?? [];
 }
 
+/**
+ * Append correction events to the rolling log in ONE read-modify-write. Empty
+ * batches are a no-op.
+ *
+ * This is safe against the lost-update hazard not by locking but by design: the
+ * only writers are the orchestrator's `record`/content-modification paths, which
+ * run inside the per-tick `applyingInFlight` guard, and the content-modification
+ * pass now RETURNS its corrections to be logged here once — never inline per item.
+ * So there is exactly one write per tick; nothing races this read-modify-write.
+ */
+export async function logCorrections(events: readonly CorrectionEvent[]): Promise<void> {
+  if (events.length === 0) return;
+  const stored = await getEvents();
+  stored.push(...events);
+  await browser.storage.local.set({ [EVENTS_KEY]: prune(stored, Date.now()) });
+}
+
 export async function logCorrection(event: CorrectionEvent): Promise<void> {
-  const events = await getEvents();
-  events.push(event);
-  const trimmed = prune(events, Date.now());
-  await browser.storage.local.set({ [EVENTS_KEY]: trimmed });
+  await logCorrections([event]);
 }
 
 /** Test seam — exposes the pruning policy for unit tests without forcing
  *  them through `chrome.storage.local`. Not part of the public runtime API. */
-export const __internal = { prune, EVENT_TTL_MS, MAX_EVENTS };
+export const __internal = { prune, getEvents, EVENT_TTL_MS, MAX_EVENTS };


### PR DESCRIPTION
Acts on the `applyContentModification` parallelization idea — but the naive version was unsafe, so this does it correctly.

## The hazard
The two passes — picker filtering (synchronous DOM) and content-card filtering (async worker classification) — touch disjoint elements, but both logged corrections inline via `record` → `logCorrection`, a storage **read-modify-write** (`get → push → set`). Parallelizing them would race the log and lose events. The per-item `for … await record(…)` loops also did N serial storage round-trips.

## The fix — eliminate the concurrency, don't guard it
- The filters now **return** their corrections instead of logging inline; `collectPickerCorrections` is synchronous, `collectContentCorrections` is the async pass.
- `applyContentModification` kicks off the content pass first, runs the sync picker pass **during its round-trip**, and returns the combined list. Curtain-string loading stays in front (pills read it).
- The orchestrator logs the returned corrections in **one** batched `logCorrections()` write — so there's exactly one writer per tick. N+M serial storage writes collapse to 1, and the race is gone by design.
- `resync()` (background) now reads settings + pause state with `Promise.all`.

## On `require-atomic-updates`
I tried enabling it (as agreed) — it surfaced 5 spots, but on review **all were benign or false-positive**: `applyingInFlight` is a correct synchronous mutex (the rule famously false-positives on those), and the rest are idempotent memoization caches (double-create, not data loss). It also structurally **can't** see the storage read-modify-write that motivated the discussion. So it'd be 5 disables for zero real catches — I reverted it. The design fix above is what actually prevents lost events.

## Verify
- 452 unit tests — new `logCorrections` batch / cap / no-clobber coverage
- content.js steady at 59 KB; `build:done` guard + e2e + metrics green

🤖 Generated with [Claude Code](https://claude.com/claude-code)