### PR TITLE
perf(extension): parallelize pause/resume's independent storage + alarm ops

### DIFF
--- a/apps/extension/src/lib/pause.ts
+++ b/apps/extension/src/lib/pause.ts
@@ -44,13 +44,20 @@ export async function pauseFor(duration: PauseDuration): Promise<void> {
     return;
   }
   const until = Date.now() + DURATION_MS[duration];
-  await browser.storage.local.set({ [PAUSED_UNTIL_KEY]: until, [PAUSED_INDEFINITELY_KEY]: false });
-  await browser.alarms.create(RESUME_ALARM, { when: until });
+  // Independent writes — persist the pause window and arm the auto-resume alarm
+  // concurrently.
+  await Promise.all([
+    browser.storage.local.set({ [PAUSED_UNTIL_KEY]: until, [PAUSED_INDEFINITELY_KEY]: false }),
+    browser.alarms.create(RESUME_ALARM, { when: until }),
+  ]);
 }
 
 export async function resume(): Promise<void> {
-  await browser.storage.local.set({ [PAUSED_UNTIL_KEY]: null, [PAUSED_INDEFINITELY_KEY]: false });
-  await browser.alarms.clear(RESUME_ALARM);
+  // Independent — clear the pause window and the auto-resume alarm concurrently.
+  await Promise.all([
+    browser.storage.local.set({ [PAUSED_UNTIL_KEY]: null, [PAUSED_INDEFINITELY_KEY]: false }),
+    browser.alarms.clear(RESUME_ALARM),
+  ]);
 }
 
 /** Subscribe to pause state changes (timed or indefinite). Returns an


### PR DESCRIPTION
Small follow-up to #76. `pauseFor` (timed) and `resume` each ran two independent browser operations sequentially — a storage write plus an alarm create/clear. They have no ordering dependency (the alarm fires far in the future; resume tears both down), so `Promise.all` them.

Verify: 452 unit tests, lint / typecheck / build / e2e / metrics all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)