### PR TITLE
refactor(extension): back i18n plurals with Intl.PluralRules

### DIFF
--- a/apps/extension/src/lib/i18n/messages-en.ts
+++ b/apps/extension/src/lib/i18n/messages-en.ts
@@ -1,4 +1,5 @@
 import type { PauseDuration } from '../pause';
+import { plural } from './plural';
 
 /** English string catalogue for Movar's own UI surfaces (popup, options) and
  *  for the content-script's injected curtains. Shape is the canonical one —
@@ -204,8 +205,10 @@ export const messagesEn: Messages = {
   hidden: {
     title: 'On this page',
     fromPickers: 'Hidden from pickers:',
-    collapsed: (n) => `Collapsed ${n} ${n === 1 ? 'picker' : 'pickers'} with only one option left`,
-    feedHidden: (n) => `${n} ${n === 1 ? 'card' : 'cards'} hidden in the feed`,
+    collapsed: (n) =>
+      `Collapsed ${n} ${plural('en', n, { one: 'picker', other: 'pickers' })} with only one option left`,
+    feedHidden: (n) =>
+      `${n} ${plural('en', n, { one: 'card', other: 'cards' })} hidden in the feed`,
     show: 'Show everything on this page',
     reload: 'Reload the page to re-apply Movar.',
     restored: 'Restored on this page — reload to re-apply.',

--- a/apps/extension/src/lib/i18n/messages-uk.ts
+++ b/apps/extension/src/lib/i18n/messages-uk.ts
@@ -1,27 +1,15 @@
 import type { Messages } from './messages-en';
+import { plural } from './plural';
 
 /**
- * Ukrainian one/few/many plural rule (CLDR).
- *  - one: 1, 21, 31, … (mod10 === 1 && mod100 !== 11)
- *  - few: 2-4, 22-24, … (mod10 in 2..4 && mod100 not in 12..14)
- *  - many: everything else (0, 5-20, 25-30, …)
+ * Ukrainian one/few/many noun agreement, via `Intl.PluralRules` (CLDR). Integer
+ * counts only ever land in one/few/many — the 'other' category is for fractions
+ * — so we map 'other' onto the many form. Thin positional (one, few, many)
+ * wrapper kept so the call sites below read cleanly and don't repeat the
+ * other === many mapping.
  */
-// CLDR plural-operand boundaries for Ukrainian (see the rule summary above).
-const ONES_MODULUS = 10;
-const TENS_MODULUS = 100;
-const TEEN_EXCEPTION = 11; // mod100 === 11 → many, despite mod10 === 1
-const FEW_MAX_ONES = 4; // mod10 in 2..4 → few
-const TEEN_RANGE_MIN = 12; // mod100 in 12..14 → many, despite mod10 in 2..4
-const TEEN_RANGE_MAX = 14;
-
 function ukPlural<T>(n: number, one: T, few: T, many: T): T {
-  const mod10 = n % ONES_MODULUS;
-  const mod100 = n % TENS_MODULUS;
-  if (mod10 === 1 && mod100 !== TEEN_EXCEPTION) return one;
-  if (mod10 >= 2 && mod10 <= FEW_MAX_ONES && (mod100 < TEEN_RANGE_MIN || mod100 > TEEN_RANGE_MAX)) {
-    return few;
-  }
-  return many;
+  return plural('uk', n, { one, few, many, other: many });
 }
 
 export const messagesUk: Messages = {

--- a/apps/extension/src/lib/i18n/plural.test.ts
+++ b/apps/extension/src/lib/i18n/plural.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+import { plural } from './plural';
+
+// Echo the chosen CLDR category so selection is asserted independent of any real
+// translation. Ukrainian exercises the full one/few/many split; English the
+// minimal one/other. These are the same boundaries the old hand-rolled rule
+// targeted — now sourced from Intl.PluralRules (ICU/CLDR) instead.
+const UK = { one: 'one', few: 'few', many: 'many', other: 'other' } as const;
+const EN = { one: 'one', other: 'other' } as const;
+
+describe('plural — Ukrainian (Intl.PluralRules, CLDR one/few/many)', () => {
+  it.each([1, 21, 31, 101, 1001])('n=%i → one', (n) => {
+    expect(plural('uk', n, UK)).toBe('one');
+  });
+
+  it.each([2, 3, 4, 22, 23, 24, 104])('n=%i → few', (n) => {
+    expect(plural('uk', n, UK)).toBe('few');
+  });
+
+  // 11–14 are the trap the naive mod10 rule gets wrong: many, not one/few.
+  it.each([0, 5, 11, 12, 13, 14, 15, 20, 25, 100, 111])('n=%i → many', (n) => {
+    expect(plural('uk', n, UK)).toBe('many');
+  });
+
+  it('non-integer counts fall into the other category', () => {
+    expect(plural('uk', 1.5, UK)).toBe('other');
+  });
+});
+
+describe('plural — English (one/other)', () => {
+  it('uses one only for exactly 1', () => {
+    expect(plural('en', 1, EN)).toBe('one');
+  });
+
+  it.each([0, 2, 3, 11, 21, 100])('n=%i → other', (n) => {
+    expect(plural('en', n, EN)).toBe('other');
+  });
+});
+
+describe('plural — fallback', () => {
+  it('falls back to other for any category the caller omitted', () => {
+    // Ukrainian n=2 selects 'few'; with no few form supplied it must use other.
+    expect(plural('uk', 2, { one: 'one', other: 'other' })).toBe('other');
+    // n=5 selects 'many'; same fallback.
+    expect(plural('uk', 5, { one: 'one', other: 'other' })).toBe('other');
+  });
+});

--- a/apps/extension/src/lib/i18n/plural.ts
+++ b/apps/extension/src/lib/i18n/plural.ts
@@ -1,0 +1,43 @@
+/**
+ * CLDR-correct plural selection backed by `Intl.PluralRules` — the platform's
+ * own ICU/CLDR data — so each locale's one/few/many/other boundaries come from
+ * the runtime instead of a hand-maintained rule. Replaces the bespoke Ukrainian
+ * mod10/mod100 rule the catalogues used to carry, and generalises for free to
+ * any future locale (Belarusian, Polish, …) without a new rule to get right.
+ *
+ * Every browser that runs Movar already ships `Intl.PluralRules` (Chrome 63+,
+ * Firefox 58+, Safari 13+) — strictly wider/older support than the
+ * `Intl.DisplayNames` the popup already depends on, so this adds no platform
+ * risk.
+ */
+
+/**
+ * Forms the caller supplies, keyed by CLDR category. `other` is mandatory: it is
+ * English's plural form, every locale's fraction form, and the fallback for any
+ * category a locale produces that the caller didn't spell out.
+ */
+export type PluralForms<T> = Partial<Record<Intl.LDMLPluralRule, T>> & { other: T };
+
+// One Intl.PluralRules per locale: construction isn't free and each catalogue
+// only ever asks about its own locale, so memoising keeps it to a single build.
+const rulesByLocale = new Map<string, Intl.PluralRules>();
+
+function pluralRulesFor(locale: string): Intl.PluralRules {
+  const cached = rulesByLocale.get(locale);
+  if (cached) return cached;
+  const rules = new Intl.PluralRules(locale);
+  rulesByLocale.set(locale, rules);
+  return rules;
+}
+
+/**
+ * Pick the plural form for `n` in `locale`. Cardinal (counting) rules — the
+ * default — so the result agrees with a counted noun. Falls back to
+ * `forms.other` for any category the locale produces but the caller omitted.
+ *
+ *   plural('uk', 2, { one: 'картка', few: 'картки', many: 'карток', other: 'картки' })  // → 'картки'
+ *   plural('en', 3, { one: 'card', other: 'cards' })                                     // → 'cards'
+ */
+export function plural<T>(locale: string, n: number, forms: PluralForms<T>): T {
+  return forms[pluralRulesFor(locale).select(n)] ?? forms.other;
+}


### PR DESCRIPTION
## What

Replace the hand-rolled Ukrainian `mod10`/`mod100` one/few/many rule and the inline English `n === 1` ternaries with a single `Intl.PluralRules`-backed helper:

```ts
plural(locale, n, forms)   // forms keyed by CLDR category; `other` required as fallback
```

- New `apps/extension/src/lib/i18n/plural.ts` — memoized one `Intl.PluralRules` per locale.
- `messages-uk.ts`: deleted the 6 mod-constants + branching; `ukPlural(n, one, few, many)` is now a one-line wrapper over `plural('uk', …)` (maps `other → many`, since integer counts never hit `other`). **The 3 call sites are untouched.**
- `messages-en.ts`: both `n === 1 ? …` ternaries → `plural('en', n, { one, other })`.

## Why

- **Correctness from the platform, not by hand.** CLDR is the source the hand-rolled rule was copying; `Intl.PluralRules` uses it directly.
- **Free generalisation.** Adding Belarusian/Polish/etc. now needs zero new plural code — `Intl.PluralRules(locale)` supplies the categories.
- **No platform risk.** Every browser that runs the popup already ships `Intl.PluralRules` (Chrome 63+/FF 58+/Safari 13+) — older/wider than the `Intl.DisplayNames` the popup already depends on.

## Verification

- The **existing `messages-uk.test.ts` boundary tests** (the `11` / `12–14` / `21` / `111` traps) pass **byte-identical** — proof the Intl swap produces the same Ukrainian strings as the old rule.
- New `plural.test.ts` covers the helper directly (uk one/few/many + fraction→other; en one/other; omitted-category fallback).
- Full pre-commit gate green locally: eslint, typecheck, test, prettier, readme-parity, suppressions.

No behavior change — pure refactor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)