### PR TITLE
fix(extension): re-render curtains when UI language changes mid-session

### DIFF
--- a/apps/extension/src/entrypoints/content.ts
+++ b/apps/extension/src/entrypoints/content.ts
@@ -28,7 +28,7 @@ import { detectModeForHost } from '@movar/page-mode/registry';
 import { watchPageMode } from '@movar/page-mode/observer';
 import type { PageMode } from '@movar/page-mode/types';
 import { setContentLocale } from '../lib/i18n/content';
-import { resolveLocale } from '../lib/i18n/resolve';
+import { contentLocaleChanged, resolveLocale } from '../lib/i18n/resolve';
 import {
   clearAttempt,
   hasAttemptedNavTo,
@@ -543,31 +543,58 @@ function installMessageBridge(): void {
   });
 }
 
-/** Mirror popup-side setting flips into the page. Without this listener the
- *  held `settings` go stale: the user can uncheck "Hide content in blocked
- *  languages" in the popup and watch nothing happen, because the
- *  MutationObserver loop keeps reading the boot-time value. Today only the
- *  contentModification flip needs an active response (matches a visible bug);
- *  other setting changes reach the next MutationObserver tick via the updated
- *  `live.current`, which is enough for current call sites. */
+/** Mirror popup/options-side setting changes into the already-rendered page.
+ *  Without this listener two things go stale. First the held `settings`: the
+ *  user unchecks "Hide content in blocked languages" and watches nothing happen,
+ *  because the MutationObserver loop keeps reading the boot-time value. Second
+ *  the on-page curtains' language: each curtain bakes its catalogue strings in
+ *  when it's built (no React context to thread through injected DOM), so a
+ *  UI-language switch leaves existing curtains in the old language. Both are
+ *  fixed by re-pointing module state here and, when a rebuild is owed, tearing
+ *  the concealment down so the next apply reconstructs it — applyOnce's
+ *  content-modification pass `await`s `loadContentMessages()` before it builds a
+ *  pill, so it refetches the new locale's curtain strings on its own; no
+ *  string-loading is needed here. */
 function installSettingsListener(live: LiveSettings): void {
   onSettingsChange((next) => {
     const previous = live.current;
     live.current = next;
-    if (previous.contentModification === next.contentModification) return;
-    if (next.contentModification) {
-      // Feature turned back ON — re-apply with the fresh settings. If a prior
-      // "Show everything" had set userOverride, clear it: the user just
-      // explicitly opted back into filtering, so honour that over the
-      // page-scoped override.
-      userOverride = false;
-      void applyOnce(next);
-    } else {
-      // Feature turned OFF — undo every DOM modification we made on the page so
-      // the user sees the original site immediately. We don't touch userOverride
-      // here: that flag belongs to the popup's "Show everything" gesture, not to
-      // a settings flip.
+
+    // Re-point the content-script catalogue when the *resolved* UI locale
+    // changes (an 'auto' → 'auto' edit that resolves the same is a no-op).
+    // setContentLocale drops the cached strings; the rebuild below re-fetches
+    // the new locale via applyOnce's content-modification pass.
+    const browserUiLang = browser.i18n.getUILanguage();
+    const localeChanged = contentLocaleChanged(previous.uiLanguage, next.uiLanguage, browserUiLang);
+    if (localeChanged) setContentLocale(resolveLocale(next.uiLanguage, browserUiLang));
+
+    const cmChanged = previous.contentModification !== next.contentModification;
+
+    // Feature turned OFF — undo every DOM modification so the user sees the
+    // original site immediately (this also subsumes a simultaneous locale
+    // change: nothing stays concealed to re-render). We don't touch userOverride
+    // here: that flag belongs to the popup's "Show everything" gesture, not a
+    // settings flip.
+    if (cmChanged && !next.contentModification) {
       teardownContentModification();
+      return;
+    }
+
+    // Feature turned back ON — the user explicitly opted back into filtering, so
+    // clear any prior page-scoped "Show everything" override.
+    if (cmChanged && next.contentModification) userOverride = false;
+
+    // Curtains exist only while filtering is on, so that's the only state worth
+    // rebuilding. Rebuild when it just turned on (nothing concealed yet — a
+    // plain apply) or the locale changed (tear the stale-language concealment
+    // down first, then re-render). One teardown + apply covers a combined event,
+    // and applyOnce's reentrancy guard coalesces it with any in-flight
+    // MutationObserver tick. Skip while "Show everything" is active — there's
+    // nothing concealed to rebuild.
+    if (next.contentModification && (cmChanged || localeChanged)) {
+      if (userOverride) return;
+      if (localeChanged) teardownContentModification();
+      void applyOnce(next);
     }
   });
 }

--- a/apps/extension/src/entrypoints/content.ts
+++ b/apps/extension/src/entrypoints/content.ts
@@ -29,6 +29,7 @@ import { watchPageMode } from '@movar/page-mode/observer';
 import type { PageMode } from '@movar/page-mode/types';
 import { setContentLocale } from '../lib/i18n/content';
 import { contentLocaleChanged, resolveLocale } from '../lib/i18n/resolve';
+import { reactToSettingsChange } from '../lib/settings-reaction';
 import {
   clearAttempt,
   hasAttemptedNavTo,
@@ -544,58 +545,31 @@ function installMessageBridge(): void {
 }
 
 /** Mirror popup/options-side setting changes into the already-rendered page.
- *  Without this listener two things go stale. First the held `settings`: the
- *  user unchecks "Hide content in blocked languages" and watches nothing happen,
- *  because the MutationObserver loop keeps reading the boot-time value. Second
- *  the on-page curtains' language: each curtain bakes its catalogue strings in
- *  when it's built (no React context to thread through injected DOM), so a
- *  UI-language switch leaves existing curtains in the old language. Both are
- *  fixed by re-pointing module state here and, when a rebuild is owed, tearing
- *  the concealment down so the next apply reconstructs it — applyOnce's
- *  content-modification pass `await`s `loadContentMessages()` before it builds a
- *  pill, so it refetches the new locale's curtain strings on its own; no
- *  string-loading is needed here. */
+ *  Without this listener two things go stale: the held `settings` (the user
+ *  toggles "Hide content in blocked languages" and nothing happens, because the
+ *  MutationObserver loop keeps reading the boot-time value) and the on-page
+ *  curtains' language (each curtain bakes its catalogue strings in at build
+ *  time, so a mid-session UI-language switch strands existing curtains in the
+ *  old language). The branching that decides what to do lives in the pure,
+ *  unit-tested {@link reactToSettingsChange}; here we just re-point the locale
+ *  catalogue and apply its verdict. applyOnce's content-modification pass
+ *  `await`s `loadContentMessages()` before building a pill, so a rebuild
+ *  refetches the new locale's curtain strings on its own — no loading here. */
 function installSettingsListener(live: LiveSettings): void {
   onSettingsChange((next) => {
     const previous = live.current;
     live.current = next;
-
-    // Re-point the content-script catalogue when the *resolved* UI locale
-    // changes (an 'auto' → 'auto' edit that resolves the same is a no-op).
-    // setContentLocale drops the cached strings; the rebuild below re-fetches
-    // the new locale via applyOnce's content-modification pass.
+    // Re-point the catalogue when the *resolved* UI locale changes (an
+    // 'auto' → 'auto' edit that resolves the same is a no-op); setContentLocale
+    // drops the cached strings so a rebuild refetches the new locale.
     const browserUiLang = browser.i18n.getUILanguage();
     const localeChanged = contentLocaleChanged(previous.uiLanguage, next.uiLanguage, browserUiLang);
     if (localeChanged) setContentLocale(resolveLocale(next.uiLanguage, browserUiLang));
 
-    const cmChanged = previous.contentModification !== next.contentModification;
-
-    // Feature turned OFF — undo every DOM modification so the user sees the
-    // original site immediately (this also subsumes a simultaneous locale
-    // change: nothing stays concealed to re-render). We don't touch userOverride
-    // here: that flag belongs to the popup's "Show everything" gesture, not a
-    // settings flip.
-    if (cmChanged && !next.contentModification) {
-      teardownContentModification();
-      return;
-    }
-
-    // Feature turned back ON — the user explicitly opted back into filtering, so
-    // clear any prior page-scoped "Show everything" override.
-    if (cmChanged && next.contentModification) userOverride = false;
-
-    // Curtains exist only while filtering is on, so that's the only state worth
-    // rebuilding. Rebuild when it just turned on (nothing concealed yet — a
-    // plain apply) or the locale changed (tear the stale-language concealment
-    // down first, then re-render). One teardown + apply covers a combined event,
-    // and applyOnce's reentrancy guard coalesces it with any in-flight
-    // MutationObserver tick. Skip while "Show everything" is active — there's
-    // nothing concealed to rebuild.
-    if (next.contentModification && (cmChanged || localeChanged)) {
-      if (userOverride) return;
-      if (localeChanged) teardownContentModification();
-      void applyOnce(next);
-    }
+    const reaction = reactToSettingsChange(previous, next, localeChanged, userOverride);
+    userOverride = reaction.userOverride;
+    if (reaction.teardown) teardownContentModification();
+    if (reaction.apply) void applyOnce(next);
   });
 }
 

--- a/apps/extension/src/lib/content-filter.test.ts
+++ b/apps/extension/src/lib/content-filter.test.ts
@@ -6,6 +6,7 @@ import type { SnippetClassifier } from './content-conceal';
 import '@movar/page-content/google';
 import '@movar/page-content/youtube';
 import { applyContentFilter, clearAllMarks, revealAllNodes } from './content-conceal';
+import { teardownContentModification } from './content-modification';
 import { buildModelForHost, lookupExtractor } from '@movar/page-content/registry';
 import type { PageContentModel } from '@movar/page-content/types';
 import { browser } from 'wxt/browser';
@@ -858,5 +859,47 @@ describe('applyContentFilter — YouTube mobile (ytm-*) selectors', () => {
     expect(hits).toHaveLength(1);
     expect(hits[0]?.kind).toBe('shorts-shelf');
     expect(document.querySelector<HTMLElement>('#shelf')!.style.display).toBe('none');
+  });
+});
+
+// Mid-session UI-language switch: curtains already on the page baked their
+// catalogue strings into shadow DOM at build time, so the content script's
+// relocalise path (setContentLocale → refetch the worker's strings → teardown →
+// re-apply) has to tear the stale-language concealment down and rebuild it. This
+// proves the rebuild re-renders in the new locale and leaves no stale duplicate
+// curtain behind — the DOM half of installSettingsListener's locale-change
+// branch (the decision half — "did the resolved locale change?" — lives in
+// resolve.test.ts).
+describe('locale switch rebuilds existing curtains', () => {
+  afterEach(() => {
+    setContentLocale('en');
+    vi.restoreAllMocks();
+  });
+
+  it('re-renders an English curtain in Ukrainian with no stale duplicate', async () => {
+    setContentLocale('en');
+    setBody(ytCard('Всё, что нужно знать о тестировании'));
+    await runFilter(buildModelForHost('www.youtube.com')!, ['ru']);
+    const card = document.querySelector<HTMLElement>('ytd-video-renderer')!;
+    expect(findRevealButton(card)?.textContent).toBe('Show');
+    expect(document.querySelectorAll('[data-movar-curtain]')).toHaveLength(1);
+
+    // The relocalise sequence the settings listener triggers on a uiLanguage
+    // change: switch locale (drops the cache), refetch the worker's uk strings,
+    // tear the stale concealment down, then re-apply.
+    spySendMessage().mockResolvedValue(contentStringsUk);
+    setContentLocale('uk');
+    await loadContentMessages();
+    teardownContentModification();
+    await runFilter(buildModelForHost('www.youtube.com')!, ['ru']);
+
+    const rebuilt = document.querySelector<HTMLElement>('ytd-video-renderer')!;
+    // Old curtain detached, exactly one fresh curtain in its place.
+    expect(document.querySelectorAll('[data-movar-curtain]')).toHaveLength(1);
+    expect(findRevealButton(rebuilt)?.textContent).toBe('Показати');
+    const desc = rebuilt
+      .querySelector<HTMLElement>('[data-movar-curtain]')!
+      .shadowRoot!.querySelector('.pill__description');
+    expect(desc?.textContent).toContain('Російською');
   });
 });

--- a/apps/extension/src/lib/i18n/resolve.test.ts
+++ b/apps/extension/src/lib/i18n/resolve.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { resolveLocale, uiLanguageFromPriority } from './resolve';
+import { contentLocaleChanged, resolveLocale, uiLanguageFromPriority } from './resolve';
 
 describe('resolveLocale', () => {
   it('honours an explicit en override regardless of browser language', () => {
@@ -47,5 +47,33 @@ describe('uiLanguageFromPriority', () => {
   it("falls back to 'auto' when no priority language is a UI locale", () => {
     expect(uiLanguageFromPriority(['de', 'fr'])).toBe('auto');
     expect(uiLanguageFromPriority([])).toBe('auto');
+  });
+});
+
+describe('contentLocaleChanged', () => {
+  // Browser UI language is irrelevant whenever both sides are explicit.
+  const IRRELEVANT = 'en-US';
+
+  it('is true when the explicit UI language flips between catalogues', () => {
+    expect(contentLocaleChanged('en', 'uk', IRRELEVANT)).toBe(true);
+    expect(contentLocaleChanged('uk', 'en', IRRELEVANT)).toBe(true);
+  });
+
+  it('is false when the setting is unchanged', () => {
+    expect(contentLocaleChanged('en', 'en', IRRELEVANT)).toBe(false);
+    expect(contentLocaleChanged('uk', 'uk', IRRELEVANT)).toBe(false);
+    expect(contentLocaleChanged('auto', 'auto', 'uk-UA')).toBe(false);
+  });
+
+  it('compares the resolved locale, not the raw setting', () => {
+    // 'auto' on an English browser resolves to 'en', so 'auto' → 'en' is a no-op
+    // and must NOT trigger a (visible, flashy) rebuild.
+    expect(contentLocaleChanged('auto', 'en', 'en-US')).toBe(false);
+    // …but the same 'auto' → 'en' edit on a Ukrainian browser DOES change the
+    // catalogue (auto resolved to 'uk'), so it must rebuild.
+    expect(contentLocaleChanged('auto', 'en', 'uk-UA')).toBe(true);
+    // Symmetric case: 'auto' → 'uk' is a no-op on a Ukrainian browser.
+    expect(contentLocaleChanged('auto', 'uk', 'uk-UA')).toBe(false);
+    expect(contentLocaleChanged('auto', 'uk', 'en-US')).toBe(true);
   });
 });

--- a/apps/extension/src/lib/i18n/resolve.ts
+++ b/apps/extension/src/lib/i18n/resolve.ts
@@ -21,6 +21,25 @@ export function resolveLocale(setting: UiLanguage, browserUiLanguage: string): R
 }
 
 /**
+ * Did the *resolved* content-script locale change between two settings
+ * snapshots? Each curtain bakes its catalogue strings into shadow DOM when it's
+ * built (the content script only refetches the worker's strings when the locale
+ * actually changes), so when this returns true the live concealment has to be
+ * torn down and rebuilt to switch language. Compares the resolved locale, not
+ * the raw `uiLanguage`, so an 'auto' → 'auto' edit (or any change that still
+ * resolves to the same catalogue) is correctly a no-op.
+ *
+ * Pure — the caller threads `browser.i18n.getUILanguage()` in.
+ */
+export function contentLocaleChanged(
+  previous: UiLanguage,
+  next: UiLanguage,
+  browserUiLanguage: string,
+): boolean {
+  return resolveLocale(previous, browserUiLanguage) !== resolveLocale(next, browserUiLanguage);
+}
+
+/**
  * Pick the popup's UI language from the user's content-language priority order
  * (`MovarSettings.priority`) rather than a separate picker: the popup speaks the
  * first priority language it has a catalogue for. Falls back to 'auto' (follow

--- a/apps/extension/src/lib/settings-reaction.test.ts
+++ b/apps/extension/src/lib/settings-reaction.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest';
+import { defaultSettings } from '@movar/settings';
+import { reactToSettingsChange } from './settings-reaction';
+
+// reactToSettingsChange only reads `.contentModification`; vary just that.
+const cm = (contentModification: boolean) => ({ ...defaultSettings, contentModification });
+const OFF = cm(false);
+const ON = cm(true);
+
+describe('reactToSettingsChange — filtering off', () => {
+  it('tears down when filtering was just turned off', () => {
+    expect(reactToSettingsChange(ON, OFF, false, false)).toEqual({
+      userOverride: false,
+      teardown: true,
+      apply: false,
+    });
+  });
+
+  it('does nothing when filtering was already off, even on a locale change', () => {
+    // No curtains exist while filtering is off, so a locale switch has nothing
+    // to rebuild here (new curtains, if filtering is later turned on, pick up
+    // the locale the bootstrap/listener already re-pointed).
+    expect(reactToSettingsChange(OFF, OFF, true, false)).toEqual({
+      userOverride: false,
+      teardown: false,
+      apply: false,
+    });
+  });
+
+  it('leaves userOverride untouched when turning off', () => {
+    expect(reactToSettingsChange(ON, OFF, false, true).userOverride).toBe(true);
+  });
+});
+
+describe('reactToSettingsChange — filtering on', () => {
+  it('applies without a teardown when filtering just turned on', () => {
+    expect(reactToSettingsChange(OFF, ON, false, false)).toEqual({
+      userOverride: false,
+      teardown: false,
+      apply: true,
+    });
+  });
+
+  it('clears a prior "Show everything" override when turning on', () => {
+    expect(reactToSettingsChange(OFF, ON, false, true)).toEqual({
+      userOverride: false,
+      teardown: false,
+      apply: true,
+    });
+  });
+
+  it('rebuilds (teardown + apply) on a mid-session locale change', () => {
+    expect(reactToSettingsChange(ON, ON, true, false)).toEqual({
+      userOverride: false,
+      teardown: true,
+      apply: true,
+    });
+  });
+
+  it('does nothing when nothing relevant changed', () => {
+    expect(reactToSettingsChange(ON, ON, false, false)).toEqual({
+      userOverride: false,
+      teardown: false,
+      apply: false,
+    });
+  });
+
+  it('skips the rebuild while "Show everything" is active (nothing concealed)', () => {
+    expect(reactToSettingsChange(ON, ON, true, true)).toEqual({
+      userOverride: true,
+      teardown: false,
+      apply: false,
+    });
+  });
+});

--- a/apps/extension/src/lib/settings-reaction.ts
+++ b/apps/extension/src/lib/settings-reaction.ts
@@ -1,0 +1,46 @@
+import type { MovarSettings } from '@movar/settings';
+
+/** What the content script must do to the page after a settings change. The
+ *  caller (`installSettingsListener`) applies these against module state + DOM. */
+export interface SettingsReaction {
+  /** New value for the page-scoped "Show everything" override (`userOverride`). */
+  userOverride: boolean;
+  /** Tear every Movar concealment off the page first. */
+  teardown: boolean;
+  /** Re-run the content-modification pass (which reloads the active locale's
+   *  curtain strings before rebuilding). */
+  apply: boolean;
+}
+
+/**
+ * Decide how the page reacts to a settings change — pure, so the branching is
+ * unit-tested without a DOM or module state. `installSettingsListener` feeds in
+ * whether the resolved UI locale changed and the current `userOverride`, then
+ * applies the returned actions.
+ *
+ * Curtains exist only while content filtering is on, so that's the only state
+ * worth rebuilding:
+ *  - filtering just turned OFF → tear everything down so the user sees the
+ *    original site immediately; a concurrent locale change is moot with nothing
+ *    concealed.
+ *  - filtering ON and (it just turned on OR the locale changed) → rebuild. A
+ *    locale change tears the stale-language concealment down first so applyOnce
+ *    re-renders it; a plain turn-on just applies.
+ *  - turning filtering on is an explicit opt-in that clears a prior page-scoped
+ *    "Show everything"; while that override is active there's nothing to rebuild.
+ */
+export function reactToSettingsChange(
+  previous: MovarSettings,
+  next: MovarSettings,
+  localeChanged: boolean,
+  userOverride: boolean,
+): SettingsReaction {
+  const filteringOn = next.contentModification;
+  const toggled = previous.contentModification !== filteringOn;
+  if (!filteringOn) {
+    return { userOverride, teardown: toggled, apply: false };
+  }
+  const override = toggled ? false : userOverride;
+  const rebuild = !override && (toggled || localeChanged);
+  return { userOverride: override, teardown: rebuild && localeChanged, apply: rebuild };
+}


### PR DESCRIPTION
## Problem

The content script resolves its curtain locale **once at bootstrap**. When the user switched UI language mid-session (popup/options), curtains already on the page — blur cards, picker chips, survivor tooltips — kept their **old-language strings**; only curtains built afterward picked up the change. The "existing ones don't retro-update, which is acceptable" comment in `content.ts` was that gap.

## Fix

`installSettingsListener` now reacts to a **resolved-locale change**:

1. Re-point the catalogue — `setContentLocale(...)`, which drops the cached worker strings.
2. When content filtering is on, **tear the stale concealment down** so the next `applyOnce` rebuilds it.

No async plumbing in the listener: `applyContentModification` already `await`s `loadContentMessages()` before building a pill (content-modification.ts), so the rebuild **refetches the new locale's strings from the worker on its own**. This composes cleanly with the #75 worker-fetch architecture.

`contentLocaleChanged()` compares the **resolved** locale, so an `'auto' → 'auto'` (or any same-catalogue) edit is a no-op — no flashy rebuild. Curtains only exist while filtering is on, so the rebuild is gated on that; `applyOnce`'s reentrancy guard coalesces it with any in-flight MutationObserver tick.

## Tests

- **Decision** (`resolve.test.ts`): `contentLocaleChanged` incl. the `'auto'` resolution traps.
- **Effect** (`content-filter.test.ts`): a DOM rebuild test — an English curtain re-renders **Ukrainian** with **exactly one** curtain (no stale duplicate), mocking the worker's `movar:contentStrings` reply (reusing #75's pattern).
- Full pre-commit gate green locally (eslint, typecheck, test, prettier, readme-parity, suppressions).

## Note

Touches `content.ts`, which has parallel refactoring in flight — a small rebase on `installSettingsListener` may be needed depending on land order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)