### PR TITLE
ci(actions): bump GitHub Actions to Node 24 runtimes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,9 +15,9 @@ jobs:
   verify:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: pnpm/action-setup@v6
+      - uses: actions/setup-node@v6
         with:
           node-version-file: .nvmrc
           cache: pnpm
@@ -65,15 +65,15 @@ jobs:
             output: safari-mv3
             artifact: movar-safari
     steps:
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: pnpm/action-setup@v6
+      - uses: actions/setup-node@v6
         with:
           node-version-file: .nvmrc
           cache: pnpm
       - run: pnpm install --frozen-lockfile
       - run: pnpm --filter @movar/extension ${{ matrix.script }}
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: ${{ matrix.artifact }}
           path: apps/extension/.output/${{ matrix.output }}/
@@ -109,9 +109,9 @@ jobs:
   e2e-offline:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: pnpm/action-setup@v6
+      - uses: actions/setup-node@v6
         with:
           node-version-file: .nvmrc
           cache: pnpm
@@ -123,7 +123,7 @@ jobs:
       # manual key bump.
       - name: Cache Playwright browsers
         id: pw-cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.cache/ms-playwright
           key: pw-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
@@ -144,7 +144,7 @@ jobs:
       # Keep the raw test-results too: traces, videos, attachments.
       - name: Upload Playwright report on failure
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: playwright-report
           path: |
@@ -163,9 +163,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: verify
     steps:
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: pnpm/action-setup@v6
+      - uses: actions/setup-node@v6
         with:
           node-version-file: .nvmrc
           cache: pnpm

--- a/.github/workflows/deploy-marketing.yml
+++ b/.github/workflows/deploy-marketing.yml
@@ -24,9 +24,9 @@ jobs:
     env:
       HAS_CF_CREDS: ${{ secrets.CLOUDFLARE_API_TOKEN != '' && secrets.CLOUDFLARE_ACCOUNT_ID != '' }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: pnpm/action-setup@v6
+      - uses: actions/setup-node@v6
         with:
           node-version-file: .nvmrc
           cache: pnpm
@@ -70,7 +70,7 @@ jobs:
 
       - name: Deploy to Cloudflare Pages
         if: env.HAS_CF_CREDS == 'true'
-        uses: cloudflare/wrangler-action@v3
+        uses: cloudflare/wrangler-action@v4
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/.github/workflows/metrics-gate.yml
+++ b/.github/workflows/metrics-gate.yml
@@ -46,11 +46,11 @@ jobs:
     steps:
       # Full history: `fallow audit --base <sha>` and `git show <base>:…` both
       # need the base commit present locally.
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v4
+      - uses: pnpm/action-setup@v6
+      - uses: actions/setup-node@v6
         with:
           node-version-file: .nvmrc
           cache: pnpm

--- a/.github/workflows/metrics-override-guard.yml
+++ b/.github/workflows/metrics-override-guard.yml
@@ -30,7 +30,7 @@ jobs:
     if: github.event.label.name == 'accept-metrics-regression'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/github-script@v7
+      - uses: actions/github-script@v9
         with:
           script: |
             // Accounts allowed to accept a metrics regression. Add maintainers

--- a/.github/workflows/regenerate-baselines.yml
+++ b/.github/workflows/regenerate-baselines.yml
@@ -63,12 +63,12 @@ jobs:
       # check out with a PAT (`BASELINE_BOT_PAT`) so the later `git push`
       # is authenticated as a real identity — a GITHUB_TOKEN push would not
       # re-trigger `ci.yml` (loop guard), but a PAT push does.
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           token: ${{ secrets.BASELINE_BOT_PAT }}
 
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v4
+      - uses: pnpm/action-setup@v6
+      - uses: actions/setup-node@v6
         with:
           node-version-file: .nvmrc
           cache: pnpm
@@ -79,7 +79,7 @@ jobs:
       # versa.
       - name: Cache Playwright browsers
         id: pw-cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.cache/ms-playwright
           key: pw-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,10 +68,10 @@ jobs:
     outputs:
       version: ${{ steps.version.outputs.version }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v4
+      - uses: pnpm/action-setup@v6
+      - uses: actions/setup-node@v6
         with:
           node-version-file: .nvmrc
           cache: pnpm
@@ -125,14 +125,14 @@ jobs:
       # Upload the entire .output/ tree (unpacked dirs + all five zips: chrome,
       # firefox, safari, the WXT sources side-effect, and the AMO source
       # bundle) so each store job can pick what it needs without rebuilding.
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: extension-output
           path: apps/extension/.output/
           retention-days: 14
           if-no-files-found: error
           # Required: WXT writes to `.output/`, whose leading dot makes
-          # every file count as "hidden" under v4's default filter.
+          # every file count as "hidden" under the action's default filter.
           include-hidden-files: true
 
       # Attach the chrome / firefox / safari / sources zips to the GitHub
@@ -159,13 +159,13 @@ jobs:
       github.event_name == 'release' ||
       (github.event_name == 'workflow_dispatch' && !inputs.dry_run)
     steps:
-      # Checkout must precede download-artifact: actions/checkout@v4
+      # Checkout must precede download-artifact: actions/checkout@v6
       # cleans the workspace (`git clean -ffdx`) and would otherwise wipe
       # the just-downloaded .output/ tree. We need the repo here for the
       # `.nvmrc` that setup-node reads below.
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           name: extension-output
           path: .output/
@@ -182,7 +182,7 @@ jobs:
           fi
 
       - if: steps.check.outputs.skip != 'true'
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version-file: .nvmrc
 
@@ -225,9 +225,9 @@ jobs:
     steps:
       # Need the repo for scripts/cws-publish.mjs. The script is pure
       # Node — no pnpm install required, just Node 22+.
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           name: extension-output
           path: .output/
@@ -247,7 +247,7 @@ jobs:
           fi
 
       - if: steps.check.outputs.skip != 'true'
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version-file: .nvmrc
 
@@ -279,7 +279,7 @@ jobs:
       github.event_name == 'release' ||
       (github.event_name == 'workflow_dispatch' && !inputs.dry_run)
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           name: extension-output
           path: .output/
@@ -366,7 +366,7 @@ jobs:
       github.event_name == 'release' ||
       (github.event_name == 'workflow_dispatch' && !inputs.dry_run)
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - id: check
         name: Check Apple signing credentials
@@ -387,9 +387,9 @@ jobs:
           fi
 
       - if: steps.check.outputs.skip != 'true'
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
       - if: steps.check.outputs.skip != 'true'
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version-file: .nvmrc
           cache: pnpm


### PR DESCRIPTION
## Why

GitHub forces Actions onto **Node.js 24 starting 2026-06-16** (Node 20 leaves the runners 2026-09-16), and the "Node.js 20 actions are deprecated" annotations were already firing on our runs. This bumps every action across all six workflows to its latest release whose `runs.using` is `node24`.

## What

| Action | From | To |
|---|---|---|
| actions/checkout | v4 | **v6** |
| actions/setup-node | v4 | **v6** |
| pnpm/action-setup | v4 | **v6** |
| actions/upload-artifact | v4 | **v7** |
| actions/download-artifact | v4 | **v8** |
| actions/cache | v4 | **v5** |
| actions/github-script | v7 | **v9** |
| cloudflare/wrangler-action | v3 | **v4** |

`download-artifact` and `wrangler-action` weren't on the original deprecation list but also shipped a Node 20 runtime, so they're included. **No `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24` stopgap needed** — every action has a real node24 release.

## Breaking changes vetted as no-ops for this repo

- **setup-node v6** "limit auto-caching to npm" only affects the *implicit* `package-manager-cache` path; our explicit `cache: pnpm` is still supported.
- **pnpm/action-setup v6** installs the pinned `packageManager: pnpm@11.3.0`, so the pnpm version is unchanged.
- **github-script v9** (ESM) drops `require('@actions/github')` and injects `getOctokit`; the override-guard script uses only `context`/`core`/`github.rest.*`, so it's unaffected.
- **upload-artifact v7 / download-artifact v8** are the matched latest pair; we keep zipped artifacts, and v8 defaulting hash-mismatch to *error* is a correctness win.
- **wrangler-action v4** changes only the default Wrangler version, which we already pin via `wranglerVersion: '4.95.0'`.

## Validation

- `actionlint` clean on all six workflows.
- This PR's own CI run is the live check that the **Node 20 deprecation annotations are gone**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)