### PR TITLE
fix(page-content): classify Google results by content, not injected UI chrome

### DIFF
--- a/packages/page-content/AGENTS.md
+++ b/packages/page-content/AGENTS.md
@@ -8,7 +8,7 @@ Provides the extraction half of the content-filtering pipeline. Each site extrac
 
 A central registry (`registry.ts`) maps hostnames to extractors at runtime. Extractors self-register on import, so callers activate them purely via side-effect imports of deep subpaths.
 
-Text serialization (`serialize.ts`) handles hidden-subtree skipping (`aria-hidden`, `hidden` attr, `display:none`, `<script>/<style>/<noscript>`), nested-match deduplication (ancestor wins over descendant), and whitespace collapse.
+Text serialization (`serialize.ts`) handles hidden-subtree skipping (`aria-hidden`, `hidden` attr, `display:none`, `<script>/<style>/<noscript>`), nested-match deduplication (ancestor wins over descendant), and whitespace collapse. `serializeElementText` takes an optional `excludeSelector` that prunes whole subtrees. `serializeContentText` is the hybrid card serializer: it classifies a result's OWN content from an allow-list of selectors (title + snippet), so injected chrome — even chrome added later — never enters the language sample; it widens to a whole-card-minus-`excludeOnFallback` sample only when the allow-list yields less than `CONTENT_TEXT_MIN_CHARS` (an anchor rotated). Prefer the allow-list over a chrome block-list: an allow-list is a closed set with no ignore-list to grow.
 
 ## Boundaries & invariants
 
@@ -22,26 +22,29 @@ Text serialization (`serialize.ts`) handles hidden-subtree skipping (`aria-hidde
 
 All symbols below are re-exported from `src/index.ts` (the `.` export, i.e. `@movar/page-content`):
 
-| Export                 | Kind  | Description                                                                              |
-| ---------------------- | ----- | ---------------------------------------------------------------------------------------- |
-| `ContentNode`          | type  | Single filterable DOM card: `el`, `kind`, `hideMode`, `text`                             |
-| `PageContentModel`     | type  | Extraction result: `extractor` id + `nodes: ContentNode[]`                               |
-| `PageExtractor`        | type  | Strategy interface: `id`, `matches(host)`, `extract(root)`                               |
-| `FilteredCard`         | type  | Card that was newly concealed by `applyContentFilter`; `el`, `fromLang`, `kind`          |
-| `CardKind`             | type  | `'video' \| 'channel' \| 'playlist' \| 'shorts-shelf' \| 'shelf' \| 'post' \| 'result'`  |
-| `HideMode`             | type  | `'blur' \| 'hide'`                                                                       |
-| `serializeNodeText`    | fn    | Concatenate text from CSS-selector matches inside a card, skipping hidden subtrees       |
-| `serializeElementText` | fn    | Serialize whole-card `textContent` without selector targeting (used by Google extractor) |
-| `serializeModelText`   | fn    | Join all `node.text` values with newlines; produces a corpus string                      |
-| `registerExtractor`    | fn    | Add a `PageExtractor` to the registry                                                    |
-| `lookupExtractor`      | fn    | Return first extractor whose `matches(host)` is true, or `null`                          |
-| `buildModelForHost`    | fn    | Convenience: `lookupExtractor` + `extract(root)` in one call                             |
-| `GOOGLE_EXTRACTOR`     | const | Google SERP extractor (also self-registers on import)                                    |
-| `YOUTUBE_EXTRACTOR`    | const | YouTube extractor (also self-registers on import)                                        |
+| Export                   | Kind  | Description                                                                                                                              |
+| ------------------------ | ----- | ---------------------------------------------------------------------------------------------------------------------------------------- |
+| `ContentNode`            | type  | Single filterable DOM card: `el`, `kind`, `hideMode`, `text`                                                                             |
+| `PageContentModel`       | type  | Extraction result: `extractor` id + `nodes: ContentNode[]`                                                                               |
+| `PageExtractor`          | type  | Strategy interface: `id`, `matches(host)`, `extract(root)`                                                                               |
+| `FilteredCard`           | type  | Card that was newly concealed by `applyContentFilter`; `el`, `fromLang`, `kind`                                                          |
+| `CardKind`               | type  | `'video' \| 'channel' \| 'playlist' \| 'shorts-shelf' \| 'shelf' \| 'post' \| 'result'`                                                  |
+| `HideMode`               | type  | `'blur' \| 'hide'`                                                                                                                       |
+| `serializeNodeText`      | fn    | Concatenate text from CSS-selector matches inside a card, skipping hidden subtrees                                                       |
+| `serializeElementText`   | fn    | Serialize whole-card `textContent` without selector targeting; optional `excludeSelector` prunes subtrees                                |
+| `serializeContentText`   | fn    | Hybrid: serialize a content allow-list (title+snippet), falling back to whole-card-minus-chrome when too thin (used by Google extractor) |
+| `ContentTextOptions`     | type  | `content` allow-list, `excludeOnFallback` chrome selector, `minChars` floor for `serializeContentText`                                   |
+| `CONTENT_TEXT_MIN_CHARS` | const | Default length floor below which `serializeContentText` falls back to whole-card                                                         |
+| `serializeModelText`     | fn    | Join all `node.text` values with newlines; produces a corpus string                                                                      |
+| `registerExtractor`      | fn    | Add a `PageExtractor` to the registry                                                                                                    |
+| `lookupExtractor`        | fn    | Return first extractor whose `matches(host)` is true, or `null`                                                                          |
+| `buildModelForHost`      | fn    | Convenience: `lookupExtractor` + `extract(root)` in one call                                                                             |
+| `GOOGLE_EXTRACTOR`       | const | Google SERP extractor (also self-registers on import)                                                                                    |
+| `YOUTUBE_EXTRACTOR`      | const | YouTube extractor (also self-registers on import)                                                                                        |
 
 **Deep subpath side-effect imports** (activate self-registering extractors):
 
-- `@movar/page-content/google` — registers `GOOGLE_EXTRACTOR`; use `#rso h3 → [data-hveid]` for organic results, `div.related-question-pair` for People-also-ask rows
+- `@movar/page-content/google` — registers `GOOGLE_EXTRACTOR`; use `#rso h3 → [data-hveid]` for organic results, `div.related-question-pair` for People-also-ask rows. Classifies each organic result from a content allow-list (`h3` + `[data-sncf="1"]` snippet) so Google's injected UI-language chrome (the `[data-sncf="2"]` rich-annotation row, the `a[href*="translate.google.com"]` "Translate this page" link) never enters the language sample and new chrome needs no ignore-list; a whole-card-minus-chrome fallback covers a rotated snippet anchor. Without this, a short foreign result is mislabelled as the UI language
 - `@movar/page-content/youtube` — registers `YOUTUBE_EXTRACTOR`; covers desktop (`ytd-*`) and mobile (`ytm-*`) renderers
 
 ## Layout
@@ -50,7 +53,7 @@ All symbols below are re-exported from `src/index.ts` (the `.` export, i.e. `@mo
 packages/page-content/
   src/
     types.ts          — ContentNode, PageContentModel, PageExtractor, FilteredCard, CardKind, HideMode
-    serialize.ts      — serializeNodeText, serializeElementText, serializeModelText
+    serialize.ts      — serializeNodeText, serializeElementText, serializeContentText, serializeModelText
     registry.ts       — registerExtractor, lookupExtractor, buildModelForHost
     google.ts         — GOOGLE_EXTRACTOR (self-registers)
     youtube.ts        — YOUTUBE_EXTRACTOR (self-registers)

--- a/packages/page-content/src/google.test.ts
+++ b/packages/page-content/src/google.test.ts
@@ -87,6 +87,72 @@ describe('GOOGLE_EXTRACTOR.extract — organic results', () => {
   });
 });
 
+// ─── Content allow-list vs injected UI-language chrome ──────────────────────
+
+describe('GOOGLE_EXTRACTOR.extract — classifies result content, not chrome', () => {
+  it('serializes only the title+snippet, excluding chrome (known or future) for free', () => {
+    // Primary path: a rich result card. Being an allow-list, it drops the known
+    // chrome (translate link, data-sncf="2" annotations) AND a hypothetical
+    // future annotation row — so new chrome needs no ignore-list entry.
+    setBody(`
+      <div id="rso">
+        <div data-hveid="r1">
+          <h3>Заголовок результату</h3>
+          <a href="https://translate.google.com/translate?u=https://example.com&sl=ru&tl=uk">Перекласти цю сторінку</a>
+          <div data-sncf="1">достатньо довгий опис результату власною мовою, що впевнено перевищує поріг довжини у сто символів і веде основним шляхом</div>
+          <div data-sncf="2">4,8 оцінка магазину (49 тис.) · Магазин поблизу (3,6 км) · Безкоштовна доставка</div>
+          <div data-sncf="9">майбутня чужорідна анотація, якої ще немає у блок-листі</div>
+        </div>
+      </div>
+    `);
+    const text = GOOGLE_EXTRACTOR.extract(document).nodes[0]!.text;
+    expect(text).toContain('Заголовок результату');
+    expect(text).toContain('опис результату власною мовою');
+    expect(text).not.toContain('Перекласти'); // translate link
+    expect(text).not.toContain('оцінка магазину'); // data-sncf="2" annotations
+    expect(text).not.toContain('майбутня чужорідна'); // unknown future chrome — excluded for free
+  });
+
+  it('falls back to whole-card-minus-chrome when the snippet anchor is missing', () => {
+    // data-sncf="1" rotated away: the allow-list yields only a short title, so we
+    // widen to the whole card with the KNOWN chrome (translate link, data-sncf=2)
+    // pruned — recovering the body text without re-admitting the chrome.
+    setBody(`
+      <div id="rso">
+        <div data-hveid="r1">
+          <h3>Реле напряжения</h3>
+          <a href="https://translate.google.com/translate?u=https://x&sl=ru&tl=uk">Перекласти цю сторінку</a>
+          <div class="snippet-without-anchor">Реле напряжения отсекатель для защиты приборов в розетку, защита от скачков напряжения в сети</div>
+          <div data-sncf="2">4,8 оцінка магазину (49 тис.) · Магазин поблизу · Безкоштовна доставка</div>
+        </div>
+      </div>
+    `);
+    const text = GOOGLE_EXTRACTOR.extract(document).nodes[0]!.text;
+    expect(text).toContain('защиты приборов'); // body recovered via fallback
+    expect(text).not.toContain('Перекласти'); // known chrome still pruned
+    expect(text).not.toContain('оцінка магазину');
+  });
+
+  it('represents a Rozetka-shaped foreign result by its own content only', () => {
+    // The real bug: a Russian shopping result whose only Ukrainian text is
+    // Google's injected chrome. Classified on the Russian title+snippet alone.
+    setBody(`
+      <div id="rso">
+        <div data-hveid="CCQQAA">
+          <h3>Реле напряжения</h3>
+          <a href="https://translate.google.com/translate?u=https://rozetka.com.ua/rele&sl=ru&tl=uk">Перекласти цю сторінку</a>
+          <div data-sncf="1">Реле напряжения отсекатель для защиты приборов в розетку HLP02 16А до 3500Вт. Защита от скачков напряжения.</div>
+          <div data-sncf="2"><span aria-label="Оцінка 4,8 з 5">4,8</span> оцінка магазину (49 тис.) · Магазин поблизу (3,6 км) · Безкоштовна доставка</div>
+        </div>
+      </div>
+    `);
+    const text = GOOGLE_EXTRACTOR.extract(document).nodes[0]!.text;
+    expect(text).not.toMatch(/Перекласти|оцінка магазину|поблизу|Безкоштовна/);
+    expect(text).toContain('Реле напряжения');
+    expect(text).toContain('защиты приборов');
+  });
+});
+
 // ─── People-also-ask extraction ─────────────────────────────────────────────
 
 describe('GOOGLE_EXTRACTOR.extract — People also ask', () => {

--- a/packages/page-content/src/google.ts
+++ b/packages/page-content/src/google.ts
@@ -2,16 +2,19 @@
  * Google SERP PageExtractor — produces { kind: 'result', hideMode: 'hide' }
  * nodes for Google search result pages.
  *
- * Text is serialized with serializeElementText (whole-card textContent) because
- * SERP cards have no single reliable inner selector — matching the original
- * filterContentByLanguage approach.
+ * Organic-result text is classified from an allow-list of the result's OWN
+ * content (title + snippet — see ORGANIC_CONTENT_SELECTORS), so Google's
+ * injected UI-language chrome never contaminates the language sample and new
+ * chrome needs no ignore-list. A whole-card-minus-chrome fallback
+ * (FALLBACK_CHROME_SELECTOR) covers the rare case where a content anchor
+ * rotates. PAA rows have no inner structure, so they serialize whole.
  *
  * This module registers itself on import. Importers only need:
  *   import './page-content/google';
  */
 import { isGoogleHost } from '@movar/rules';
 import type { ContentNode, PageContentModel, PageExtractor } from './types';
-import { serializeElementText } from './serialize';
+import { serializeContentText, serializeElementText } from './serialize';
 import { registerExtractor } from './registry';
 
 // ─── Selector constants ───────────────────────────────────────────────────
@@ -49,6 +52,37 @@ const ORGANIC_CONTAINER = '[data-hveid]';
  *  question is hidden while a Ukrainian one in the same block stays. */
 const PAA_QUESTION_SELECTOR = 'div.related-question-pair';
 
+/** Allow-list of an organic result's OWN content — the title <h3> and the
+ *  result snippet (`data-sncf="1"`, Google's structured-snippet "format 1"
+ *  slot). These, and only these, drive language classification.
+ *
+ *  Why an allow-list and not whole-card text: Google injects its own chrome
+ *  (the "Translate this page" link, a rich-annotation row) INTO each card,
+ *  rendered in the user's Search language regardless of the result's language.
+ *  Whole-card serialization sweeps that in and mislabels a short foreign result
+ *  as the UI language — e.g. a Russian shopping result whose only distinctive
+ *  Russian letters (`ы`/`э`/`ъ`/`ё`, rare in running text) get outnumbered by
+ *  the Ukrainian chrome's `і`s, so it classifies as Ukrainian and is kept.
+ *  Serializing only the content sidesteps that, AND — being an allow-list — it
+ *  excludes any chrome Google adds LATER for free, with no ignore-list to grow.
+ *  `data-sncf` is the durable `data-sn*` family (cf. the data-hveid/data-ved we
+ *  anchor results on), not a rotating styling hash. */
+const ORGANIC_CONTENT_SELECTORS = ['h3', '[data-sncf="1"]'];
+
+/** Whole-card FALLBACK chrome block-list — consulted by {@link serializeContentText}
+ *  ONLY when {@link ORGANIC_CONTENT_SELECTORS} comes up short (e.g. the snippet
+ *  slot rotated away, leaving a bare title). It widens to the whole card with the
+ *  two injected UI-language regions pruned, so we still get a usable, mostly
+ *  chrome-free sample rather than classifying a title alone:
+ *   - `[data-sncf="2"]` — the rich-annotation row (store rating «оцінка
+ *     магазину», distance «Магазин поблизу», delivery «Безкоштовна доставка»).
+ *   - `a[href*="translate.google.com"]` — the "Translate this page"
+ *     («Перекласти цю сторінку») link, which Google injects precisely because it
+ *     detected the result as foreign (`…&sl=ru&tl=uk`).
+ *  This block-list is the defensive net, not the steady state — so it does not
+ *  need to chase every new chrome type the way whole-card serialization would. */
+const FALLBACK_CHROME_SELECTOR = '[data-sncf="2"], a[href*="translate.google.com"]';
+
 // ─── Extractor implementation ─────────────────────────────────────────────
 //
 // Host gate: SERP structure (#rso h3 → data-hveid, related-question-pair) is
@@ -73,32 +107,40 @@ function organicCardFor(h3: HTMLElement, root: ParentNode): HTMLElement | null {
 
 function extractGoogle(root: ParentNode): PageContentModel {
   // Two reliable sources: organic results (anchor each #rso <h3> to its
-  // data-hveid card) and People-also-ask question rows. A Set dedupes the
-  // common case where several titles resolve to the same card.
-  const els = new Set<HTMLElement>();
-
+  // data-hveid card) and People-also-ask question rows. Tracked in separate
+  // sets because their text is serialized differently (see the map below).
+  const organic = new Set<HTMLElement>();
   for (const h3 of root.querySelectorAll<HTMLElement>(ORGANIC_TITLE_ANCHOR)) {
     const card = organicCardFor(h3, root);
-    if (card) els.add(card);
+    if (card) organic.add(card);
   }
 
+  const paa = new Set<HTMLElement>();
   for (const question of root.querySelectorAll<HTMLElement>(PAA_QUESTION_SELECTOR)) {
-    els.add(question);
+    paa.add(question);
   }
 
   // Drop any element nested inside another selected one — keep the outermost
   // result container, so nested cards (e.g. sitelinks carrying their own
   // data-hveid under a parent result) collapse to one node instead of two.
-  const all = [...els];
+  const all = [...organic, ...paa];
   const nodes: ContentNode[] = all
     .filter((el) => !all.some((other) => other !== el && other.contains(el)))
-    // Whole-card text — SERP blocks have no reliable inner title selector.
     .map(
       (el): ContentNode => ({
         el,
         kind: 'result',
         hideMode: 'hide',
-        text: serializeElementText(el),
+        // Organic cards: classify the result's own title+snippet (allow-list),
+        // widening to the whole card minus injected chrome only if those anchors
+        // come up short. PAA rows have no chrome and no title/snippet split — the
+        // whole row IS the question text.
+        text: organic.has(el)
+          ? serializeContentText(el, {
+              content: ORGANIC_CONTENT_SELECTORS,
+              excludeOnFallback: FALLBACK_CHROME_SELECTOR,
+            })
+          : serializeElementText(el),
       }),
     );
 

--- a/packages/page-content/src/index.ts
+++ b/packages/page-content/src/index.ts
@@ -19,7 +19,14 @@ export type {
   FilteredCard,
 } from './types';
 
-export { serializeNodeText, serializeElementText, serializeModelText } from './serialize';
+export {
+  serializeNodeText,
+  serializeElementText,
+  serializeContentText,
+  serializeModelText,
+  CONTENT_TEXT_MIN_CHARS,
+} from './serialize';
+export type { ContentTextOptions } from './serialize';
 
 export { registerExtractor, lookupExtractor, buildModelForHost } from './registry';
 

--- a/packages/page-content/src/serialize.test.ts
+++ b/packages/page-content/src/serialize.test.ts
@@ -1,5 +1,11 @@
 import { beforeEach, describe, expect, it } from 'vitest';
-import { serializeElementText, serializeNodeText, serializeModelText } from './serialize';
+import {
+  CONTENT_TEXT_MIN_CHARS,
+  serializeContentText,
+  serializeElementText,
+  serializeModelText,
+  serializeNodeText,
+} from './serialize';
 import type { PageContentModel } from './types';
 
 function setBody(html: string): void {
@@ -200,6 +206,112 @@ describe('serializeElementText — whole-card text', () => {
     setBody(`<div id="card" hidden>прихований</div>`);
     const card = document.querySelector<HTMLElement>('#card')!;
     expect(serializeElementText(card)).toBe('');
+  });
+});
+
+describe('serializeElementText — excludeSelector', () => {
+  it('prunes subtrees whose root matches the selector', () => {
+    setBody(`
+      <div id="card">
+        <p>зміст результату</p>
+        <div data-chrome="1">службовий напис</div>
+      </div>
+    `);
+    const card = document.querySelector<HTMLElement>('#card')!;
+    const text = serializeElementText(card, '[data-chrome="1"]');
+    expect(text).toContain('зміст результату');
+    expect(text).not.toContain('службовий напис');
+  });
+
+  it('prunes the whole subtree, including nested text under the matched root', () => {
+    setBody(`
+      <div id="card">
+        <p>основний текст</p>
+        <div class="annotations"><span><a href="x">вкладений</a> напис</span></div>
+      </div>
+    `);
+    const card = document.querySelector<HTMLElement>('#card')!;
+    const text = serializeElementText(card, '.annotations');
+    expect(text).toBe('основний текст');
+  });
+
+  it('supports a grouped selector (any branch prunes its subtree)', () => {
+    setBody(`
+      <div id="card">
+        <p>тіло</p>
+        <div data-x="2">анотація</div>
+        <a href="https://example.com/path">посилання</a>
+      </div>
+    `);
+    const card = document.querySelector<HTMLElement>('#card')!;
+    const text = serializeElementText(card, '[data-x="2"], a[href*="example.com"]');
+    expect(text).toBe('тіло');
+  });
+
+  it('keeps everything when no descendant matches the selector', () => {
+    setBody(`<div id="card"><p>лишається все</p></div>`);
+    const card = document.querySelector<HTMLElement>('#card')!;
+    expect(serializeElementText(card, '[data-chrome]')).toBe('лишається все');
+  });
+});
+
+describe('serializeContentText — allow-list primary + whole-card fallback', () => {
+  // A rich content allow-list (over the length floor) drives classification and,
+  // being an allow-list, excludes BOTH known and unknown chrome for free.
+  it('uses the content allow-list and drops all non-content, known chrome or not', () => {
+    setBody(`
+      <div id="card">
+        <h3>Заголовок результату</h3>
+        <div data-sncf="1">достатньо довгий опис результату власною мовою для проходження порогу</div>
+        <div data-sncf="2">службова анотація магазину</div>
+        <div data-future="x">майбутня чужорідна аннотація</div>
+      </div>
+    `);
+    const card = document.querySelector<HTMLElement>('#card')!;
+    const text = serializeContentText(card, {
+      content: ['h3', '[data-sncf="1"]'],
+      excludeOnFallback: '[data-sncf="2"]', // block-list mentions ONLY the known chrome
+      minChars: 5, // force the primary allow-list path deterministically
+    });
+    expect(text).toContain('Заголовок результату');
+    expect(text).toContain('опис результату власною мовою');
+    expect(text).not.toContain('службова анотація'); // known chrome
+    expect(text).not.toContain('майбутня чужорідна'); // unknown chrome — excluded for free
+  });
+
+  it('falls back to whole-card-minus-chrome when the allow-list is below the floor', () => {
+    // No data-sncf="1" (snippet anchor "rotated") — the allow-list yields only a
+    // short title, so we widen to the whole card with known chrome pruned.
+    setBody(`
+      <div id="card">
+        <h3>Реле</h3>
+        <div class="body">справжній текст результату лежить поза селекторами контенту і має бути врахований</div>
+        <div data-sncf="2">службова анотація магазину</div>
+      </div>
+    `);
+    const card = document.querySelector<HTMLElement>('#card')!;
+    const text = serializeContentText(card, {
+      content: ['h3', '[data-sncf="1"]'],
+      excludeOnFallback: '[data-sncf="2"]',
+    });
+    expect(text).toContain('справжній текст результату'); // recovered via fallback
+    expect(text).not.toContain('службова анотація'); // known chrome still pruned
+  });
+
+  it('respects a custom minChars (forces the allow-list even when short)', () => {
+    setBody(`
+      <div id="card">
+        <h3>Стислий</h3>
+        <div class="body">це тіло не потрапить у вибірку</div>
+      </div>
+    `);
+    const card = document.querySelector<HTMLElement>('#card')!;
+    const text = serializeContentText(card, { content: ['h3'], minChars: 1 });
+    expect(text).toBe('Стислий'); // allow-list met the (tiny) floor; body excluded
+  });
+
+  it('exposes a sane default length floor', () => {
+    expect(CONTENT_TEXT_MIN_CHARS).toBeGreaterThan(0);
   });
 });
 

--- a/packages/page-content/src/serialize.ts
+++ b/packages/page-content/src/serialize.ts
@@ -65,15 +65,22 @@ export function serializeNodeText(card: HTMLElement, textSelectors: readonly str
  * Collect text under `node`, pruning any element subtree that
  * {@link isHiddenElement} treats as invisible — `<script>`/`<style>`/
  * `<noscript>`, `aria-hidden="true"`, the `hidden` attribute, or
- * `display:none`. Mirrors the per-element skip rules of {@link serializeNodeText}
- * so neither serializer leaks script/JSON/offscreen text into the sample.
+ * `display:none` — plus any subtree whose root matches `excludeSelector`.
+ * Mirrors the per-element skip rules of {@link serializeNodeText} so neither
+ * serializer leaks script/JSON/offscreen text into the sample.
  */
-function collectVisibleText(node: Node): string {
+function collectVisibleText(node: Node, excludeSelector: string | undefined): string {
   if (node.nodeType === Node.TEXT_NODE) return node.nodeValue ?? '';
   if (node.nodeType !== Node.ELEMENT_NODE) return '';
-  if (isHiddenElement(node as Element)) return '';
+  const el = node as Element;
+  if (isHiddenElement(el)) return '';
+  // Caller-pruned subtrees: drop the element and everything under it. The
+  // Google extractor uses this to keep its injected UI-language chrome (the
+  // "Translate this page" link, the rich-annotation row) out of the result's
+  // language sample.
+  if (excludeSelector !== undefined && el.matches(excludeSelector)) return '';
   let text = '';
-  for (const child of node.childNodes) text += collectVisibleText(child);
+  for (const child of node.childNodes) text += collectVisibleText(child, excludeSelector);
   return text;
 }
 
@@ -84,10 +91,58 @@ function collectVisibleText(node: Node): string {
  * noscript, aria-hidden, hidden, display:none) — inline scripts and JSON
  * payloads inside SERP cards must not pollute the language sample — then
  * collapses whitespace and trims.
+ *
+ * `excludeSelector` (optional) prunes any subtree whose root matches it — for
+ * callers that need to drop known non-content regions before the text is
+ * language-classified (e.g. Google's injected UI-language chrome).
  */
-export function serializeElementText(card: HTMLElement): string {
+export function serializeElementText(card: HTMLElement, excludeSelector?: string): string {
   if (isHiddenElement(card)) return '';
-  return collectVisibleText(card).replace(/\s+/g, ' ').trim();
+  return collectVisibleText(card, excludeSelector).replace(/\s+/g, ' ').trim();
+}
+
+/** Below this many characters, a content allow-list is treated as having missed
+ *  the result's body (e.g. a card's snippet anchor rotated, leaving only a short
+ *  title), so {@link serializeContentText} widens to the whole-card fallback.
+ *  Sits in the gap between a SERP title alone (tens of chars) and title+snippet
+ *  (~150+). Tunable per caller via {@link ContentTextOptions.minChars}. */
+export const CONTENT_TEXT_MIN_CHARS = 100;
+
+/** Options for {@link serializeContentText}. `content` and `excludeOnFallback`
+ *  must be disjoint — a selector that is both content and chrome makes no sense. */
+export interface ContentTextOptions {
+  /** Allow-list of selectors for the node's OWN content (title, snippet, …).
+   *  Their combined text is the primary, chrome-free classification sample. */
+  content: readonly string[];
+  /** Selector for subtrees to prune from the WHOLE-CARD fallback (injected
+   *  non-content chrome). Ignored on the primary path. */
+  excludeOnFallback?: string;
+  /** Primary text shorter than this triggers the fallback. Default
+   *  {@link CONTENT_TEXT_MIN_CHARS}. */
+  minChars?: number;
+}
+
+/**
+ * Hybrid card-text serializer: classify the result's OWN content, not its
+ * container.
+ *
+ * Primary path — serialize only the `content` allow-list (e.g. title + snippet).
+ * Because it's an allow-list, any chrome the host injects LATER (new annotation
+ * rows, badges, links) is excluded for free — there is no ignore-list to grow.
+ * This is the steady state for a well-formed card.
+ *
+ * Fallback path — when the allow-list yields too little text (`< minChars`: a
+ * content anchor missed/rotated and we'd otherwise classify a bare title),
+ * widen to the whole card with `excludeOnFallback` pruned. That keeps a usable
+ * sample at the cost of re-admitting any chrome the block-list doesn't cover —
+ * the rare, defensive case, not the norm. Returns whichever of the two samples
+ * is longer, so the fallback never yields *less* signal than the allow-list.
+ */
+export function serializeContentText(card: HTMLElement, options: ContentTextOptions): string {
+  const primary = serializeNodeText(card, options.content);
+  if (primary.length >= (options.minChars ?? CONTENT_TEXT_MIN_CHARS)) return primary;
+  const fallback = serializeElementText(card, options.excludeOnFallback);
+  return fallback.length >= primary.length ? fallback : primary;
 }
 
 /**

--- a/scripts/readme-metrics.snapshot.json
+++ b/scripts/readme-metrics.snapshot.json
@@ -4,14 +4,14 @@
     "score": 85,
     "grade": "B"
   },
-  "loc": 27780,
+  "loc": 27847,
   "suppressions": {
     "eslint": 34,
     "fallow": 25
   },
   "coverage": {
     "lines": 92.4,
-    "branches": 85.2
+    "branches": 85.3
   },
   "bundle": {
     "contentKb": 29


### PR DESCRIPTION
## Problem

The content-filtering feature missed a Russian Google result (a Rozetka shopping
result for «реле напруги») — it was classified as Ukrainian and kept.

## Root cause

Google injects its own **UI-language chrome** into each SERP result card — the
"Translate this page" link («Перекласти цю сторінку») and a rich-annotation row
(store rating «оцінка магазину», distance «Магазин поблизу», delivery
«Безкоштовна доставка») — all rendered in the user's *Search* language
regardless of the result's language.

Whole-card serialization swept that chrome into the language sample. Russian
running text is distinctive-character-poor (its unique-vs-Ukrainian letters
`ы`/`э`/`ъ`/`ё` are rare), so for a short result the lone distinctive-Russian
letter got outnumbered by the Ukrainian chrome's `і`s — flipping the rung-1
verdict to Ukrainian (margin 1) and keeping the card.

## Fix

Switch organic-result extraction from whole-card text to a **content allow-list**
— the `<h3>` title plus the `[data-sncf="1"]` snippet — via a new
`serializeContentText` helper, with a **whole-card-minus-chrome fallback** when
those anchors come up short (a snippet anchor rotated).

Why an allow-list and not a chrome block-list: an allow-list is a *closed* set,
so any chrome Google injects later is excluded for free — no ignore-list to grow.
This also aligns Google with the already-allow-list-based YouTube extractor.
`data-sncf` is the durable `data-sn*` family (cf. `data-hveid`), not a rotating
styling hash.

## Verification

Ran the real extractor + classifier against the saved SERP:

- **Rozetka** result now **hides** (`ru`, margin 1) — was wrongly kept.
- All 8 other results keep their correct verdicts (Ukrainian shops kept, Russian
  shops hidden); a fixture with a *novel* annotation not in the block-list
  confirms unknown chrome is excluded for free.
- 70 package tests pass; typecheck + lint clean; the extension consumer typechecks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)