### PR TITLE
docs(readme): correct pause durations to 1h / until resumed

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Ukrainian locale. Movar fixes that automatically, so you never have to choose.
 - Automatic language switching driven by a priority list (default: UA → EN → browser)
 - Extension settings override browser language settings
 - On-page content filtering — hides unwanted-language picker options and content cards (Beta, off by default)
-- Temporary pause (1h / 24h / session / 1 week)
+- Temporary pause (1h / until resumed)
 - Per-site disable (allowlist)
 - "Correction applied" indicator
 


### PR DESCRIPTION
The README Features list claimed `Temporary pause (1h / 24h / session / 1 week)`, but the extension only ever offered two pause options:

```ts
export const PAUSE_DURATIONS: readonly PauseDuration[] = ['1h', 'indefinite'];
```

(`apps/extension/src/lib/pause.ts` — `indefinite` is "paused until you resume"). This corrects the Features line to `1h / until resumed` so the README matches the shipped UI.

Docs-only; no code change. The generated metrics badge block is intentionally left untouched (its values reflect `main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)