### PR TITLE
docs(agents): add local workflow skills

### DIFF
--- a/.agents/skills/add-before-after-case/SKILL.md
+++ b/.agents/skills/add-before-after-case/SKILL.md
@@ -1,0 +1,163 @@
+---
+name: add-before-after-case
+description: |
+  Wire a new before/after use case into BOTH the marketplace screenshot
+  carousel and the marketing site diptych — they share backdrops and
+  must stay in sync. Use when the user asks to add a new comparison /
+  demo / before-after example to the extension screenshots, the
+  marketing site's "See it in action" section, or both. Also use when
+  the user mentions adding a new "use case", "scenario", "pair", or
+  "diptych" to the screenshots pipeline. Do NOT use for: tweaking
+  existing screenshots, generating per-locale variants of an existing
+  scene, or marketing copy changes that don't touch the screenshots.
+---
+
+# Add a before/after use case (marketplace + marketing)
+
+Both surfaces narrate the same "what Movar fixes" stories — they just
+deliver them in different shapes:
+
+- **Marketplace** ships one composed 1280×800 diptych PNG per scene
+  (the diptych frame is in the PNG). One numbered file per locale lands
+  in `apps/extension/store-assets/screenshots/{en,uk}/NN-<slug>.png`.
+- **Marketing** ships two single-half PNGs per pair — each captured
+  light **and** `-dark`, at natural content height — and the Astro
+  layer at `apps/marketing/src/components/Examples.astro` composes them
+  at runtime, full-width and stacked, swapping light↔dark with
+  `<picture>` + `prefers-color-scheme`.
+
+Both share backdrop components and the same Playwright capture script
+at `apps/extension/scripts/capture-storybook-assets.mts`. Story title
+prefix routes the output:
+
+| Prefix                      | Output root                          | Story dir                |
+| --------------------------- | ------------------------------------ | ------------------------ |
+| `Marketplace/Screenshots/*` | `store-assets/screenshots/{en,uk}/`  | `storyboards/stories/`   |
+| `Marketing/Screenshots/*`   | `apps/marketing/public/screenshots/` | `storyboards/marketing/` |
+
+## Procedure
+
+**Rule of thumb: every new use case ships in BOTH surfaces** unless the
+demo's premise excludes one (e.g. scene #5 / Knowledge Panel is UK-only
+because Google falls back to English without an `hl` hint — there's no
+observable EN before/after). When you must skip a locale, document why
+in the story file header.
+
+### 1. Shared backdrops
+
+Build the React backdrop(s) under
+`apps/extension/store-assets/storyboards/backdrops/`. Make them accept
+`hideChrome?: boolean` (default `false`) and forward it to the inner
+frame component. The marketplace diptych supplies its own browser
+chrome at the half level; the marketing single-half does not.
+
+Existing backdrop frames to reuse / mirror:
+
+- `before-after-frame.tsx` — diptych composition (`BeforeAfterFrameWithFrame`).
+- `google-serp-frame.tsx` — Google SERP illustration (used by scene #3).
+- `google-knowledge-frame.tsx` — Google entity Knowledge Panel (used by scene #5).
+- `news-{en,uk}.tsx`, `site-{en,uk,ru}.tsx`, `voya-*.tsx` — fictitious-site backdrops.
+
+If you build a new fictitious brand, follow §5 of
+`apps/extension/store-assets/REQUIREMENTS.md`: invented name, `.example`
+TLD, no real third-party logos, no real personal context.
+
+### 2. Marketing single-half stories
+
+Add two stories under
+`apps/extension/store-assets/storyboards/marketing/`:
+
+- `<name>-without.stories.tsx` — title
+  `Marketing/Screenshots/<Name>Without`, output
+  `<name>-without-movar.png`.
+- `<name>-with.stories.tsx` — title
+  `Marketing/Screenshots/<Name>With`, output
+  `<name>-with-movar.png`.
+
+Each story sets `parameters: { layout: 'fullscreen', viewport: { width: <content-width>, height: 800 }, captureOutput: { path: '<file>.png' }, naturalHeight: true, darkVariant: true }`
+and renders the backdrop with its built-in chrome (no `hideChrome`). Set
+`viewport.width` to the scene's **natural content width** (the width at
+which the page content fills the frame edge-to-edge without being
+stretched — e.g. a Google SERP's ~680px column + padding) so the
+marketing layout can scale it to fit; `naturalHeight` then captures the
+full height (not an 800px crop); `darkVariant` emits the `-dark` sibling
+under `prefers-color-scheme: dark` (give the backdrop a dark `@media`
+block over its scoped CSS vars).
+
+### 3. Marketplace diptych story
+
+Add one story under
+`apps/extension/store-assets/storyboards/stories/<scene>.stories.tsx`
+titled `Marketplace/Screenshots/<Scene>` with the next free
+`screenshotIndex`. Compose the two backdrops inside
+`BeforeAfterFrameWithFrame`, passing `hideChrome` on each. Export
+`English` and `Ukrainian` story functions — or, if a locale is
+intentionally skipped, document the reason in the file header and omit
+that export (the capture script throws on stories named anything other
+than `English` / `Ukrainian`, so omitting is cleaner than a renamed
+export).
+
+Caption bodies live inline in the story render functions (search-rewrite
+is the canonical template) — keep them under three lines at the diptych's
+caption width (~540px @ 18px body).
+
+### 4. Marketing site integration
+
+The marketing pairs render in
+`apps/marketing/src/components/Examples.astro`, keyed by the index of
+the matching entry in `strings.examples.entries` (`apps/marketing/src/i18n.ts`):
+
+- Add (or confirm) the `examples.entries` entry for the scene in both
+  `en` and `uk` — each has `site`, `scenario`, `without`, `withMovar`.
+- Add an `imagePairs[<index>]` record in `Examples.astro` with the
+  `without`/`with` light `src` + `alt`. The `-dark` siblings and the
+  `existsSync` gate are handled automatically: a pair renders only when
+  both light PNGs are on disk, and the dark `<picture>` source is added
+  when the `-dark` PNG exists. Missing pairs degrade to text-only.
+
+If `Examples.stories.tsx` mocks the section, keep its layout in step —
+it renders the text-only fallback, since the Storybook canvas has no
+built `public/` dir.
+
+### 5. Docs
+
+Update three docs in lockstep:
+
+- `apps/extension/store-assets/README.md` — add a row to the
+  "Required shots" table (file, locales, backdrop, layout).
+- `apps/extension/store-assets/REQUIREMENTS.md` §5 — add a row to the
+  screenshot-set table; mention any locale skips with the reason.
+- `apps/extension/store-assets/REQUIREMENTS.md` §6 — add asset rows
+  for each per-locale PNG ("Screenshot #N <slug> (UK)", etc.).
+- `apps/marketing/public/screenshots/README.md` — add a row to the
+  filename table.
+
+### 6. Capture and commit
+
+```
+pnpm capture:storybook-assets
+```
+
+Or from a sub-package directory:
+
+```
+pnpm --filter @movar/extension capture:storybook-assets
+```
+
+Commit the resulting PNGs in the same change as the source so PR
+review surfaces the visual diff.
+
+## Concrete example
+
+Scene #5 (Knowledge Panel) is the canonical example of this convention
+applied:
+
+- Backdrops: `apps/extension/store-assets/storyboards/backdrops/google-{god-of-war-with-movar,god-of-war-without-movar,knowledge-frame}.tsx`
+- Marketing stories: `apps/extension/store-assets/storyboards/marketing/google-god-of-war-{with,without}.stories.tsx`
+- Marketplace diptych story: `apps/extension/store-assets/storyboards/stories/knowledge-panel.stories.tsx` (UK-only — see header)
+- Marketing PNGs: `apps/marketing/public/screenshots/google-god-of-war-{with,without}-movar.png`
+- Marketplace PNG: `apps/extension/store-assets/screenshots/uk/05-knowledge-panel.png`
+
+When in doubt, mirror the structure of scene #3 (search-rewrite —
+fully bilingual) or scene #5 (knowledge-panel — UK-only with a
+documented skip).

--- a/.agents/skills/sync-readme/SKILL.md
+++ b/.agents/skills/sync-readme/SKILL.md
@@ -1,0 +1,81 @@
+---
+name: sync-readme
+description: |
+  Fix drift between the root README.md and its sources of truth — the
+  marketing hero tagline (apps/marketing/src/i18n.ts), the workspace layout
+  (apps/* + packages/*), and the generated metrics badge block (code health,
+  test coverage, permissions, license, and verified product promises). Use when
+  `pnpm check:readme` fails, when the README parity guard reports a tagline,
+  monorepo-layout, or broken-product-promise mismatch, or after you add
+  / remove / rename a workspace package or change the marketing tagline and the
+  README must follow. Also use when manually auditing README.md for drift from
+  the product or marketing site. Do NOT use for before/after screenshot use
+  cases (that's add-before-after-case) or for editing marketing copy itself —
+  the README mirrors the marketing app, not the other way around.
+---
+
+# Keep README.md in sync with marketing + the workspace
+
+`README.md` is hand-written prose that must not contradict the product. Several
+facts are machine-enforced by a guard; the rest is your judgment.
+
+## The guard
+
+`pnpm check:readme` runs in `pnpm validate`, lefthook pre-commit, and CI's
+`verify` job. It chains two scripts (`scripts/check-readme-parity.mts` and
+`scripts/gen-readme-metrics.mts --check`) and fails the commit/build on any of
+four machine-checkable mismatches:
+
+1. **Tagline** — the README's first blockquote must equal the marketing hero
+   headline.
+2. **Monorepo layout** — the `## Monorepo layout` block must list every
+   `apps/*` and `packages/*` member (each dir with a `package.json`), and
+   nothing that no longer exists.
+3. **Metrics block** — the generated `<!-- METRICS:START … -->` badge row must
+   match a fresh render from its committed sources. Unlike 1 & 2, drift here is
+   **auto-fixed**: just run `pnpm gen:readme` (then `pnpm metrics` to refresh the
+   snapshotted health + coverage numbers).
+4. **Product promises** — marketing claims from `i18n.ts` are verified against
+   the code (LICENSE, the extension manifest + source, `defaultSettings`). A
+   **broken** promise is NOT auto-fixable: `pnpm gen:readme` renders the ✗, but
+   `--check` still fails until you restore the invariant — or update the
+   promise/marketing copy if the product genuinely changed.
+
+## Sources of truth
+
+| README element       | Canonical source                                                                                                                                      |
+| -------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Tagline (blockquote) | `strings.en.hero.headlineLine1 + ' ' + headlineLine2` in `apps/marketing/src/i18n.ts`                                                                 |
+| Monorepo layout      | `apps/*` + `packages/*` dirs on disk                                                                                                                  |
+| Feature claims, copy | `docs/copy.md` (voice + claims) and the marketing `i18n.ts`                                                                                           |
+| Default behaviours   | `packages/settings/src/index.ts` (`defaultSettings`)                                                                                                  |
+| Tech stack / deps    | the actual `package.json` dependency trees                                                                                                            |
+| Metrics badges       | `pnpm gen:readme` ← wxt manifest permissions + LICENSE (live); fallow health + Vitest coverage (snapshot via `pnpm metrics`)                          |
+| Product promises     | `collectPromises()` in `gen-readme-metrics.mts` ← marketing claims (`i18n.ts`) checked vs LICENSE, the extension manifest + source, `defaultSettings` |
+
+## Procedure
+
+1. Run `pnpm check:readme` and read exactly what it reports.
+2. **Tagline mismatch** → set the README blockquote to the marketing hero
+   headline verbatim. If `design-brief.md`'s tagline diverges too, fix it in
+   the same pass (it's the brand spec; not machine-checked).
+3. **Layout mismatch** → add every missing `apps/<x>` / `packages/<x>`, drop
+   any that no longer exist, and keep the comment column aligned.
+4. Re-run `pnpm check:readme` until green.
+
+## Not machine-checked — eyeball these too
+
+The guard can't catch prose drift. While you're in the README, confirm:
+
+- **Feature list matches reality.** Off-by-default capabilities (e.g.
+  `contentModification` in `packages/settings`) must say "Beta, off by default".
+  Don't list features that were removed (the old "usefulness dashboard" was).
+- **Tech stack lists only real deps.** If a library isn't in any
+  `package.json` / lockfile (Tremor was a stale entry), drop it.
+- **Browser targets match the marketing download buttons** (Chrome, Firefox,
+  Edge, Opera, Brave, Safari).
+- **Claims match `docs/copy.md`** — it's the copy authority.
+
+## Verify
+
+`pnpm check:readme` is green, and `pnpm exec prettier --check README.md` passes.


### PR DESCRIPTION
Adds project-local Codex skills for before/after screenshot cases and README sync drift.\n\nChecks: pre-push build, e2e-fast, metrics.