### PR TITLE
docs: CONTRIBUTING.md + site-rule contribution guide + registry-invariants test (#121)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -128,6 +128,7 @@ Each member: `package.json` (private, `type: module`, libs map `main`/`types`/`e
 
 ## Key docs
 
+- [`CONTRIBUTING.md`](CONTRIBUTING.md) — human contributor entry point (setup, two-layer model, where a site rule lives, gate commands); links back into this tree. Site-rule walkthrough: [`apps/extension/src/sites/CONTRIBUTING-A-SITE.md`](apps/extension/src/sites/CONTRIBUTING-A-SITE.md).
 - [`docs/glossary.md`](docs/glossary.md) — domain terms (SERP, curtain, rung, the two layers, package map). Start here if the jargon is unfamiliar.
 - [`README.md`](README.md) — public overview + monorepo layout (parity-guarded).
 - [`docs/copy.md`](docs/copy.md) — copy authority (voice, lexicon, mechanics); [`docs/styleguide.md`](docs/styleguide.md) — style.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,125 @@
+# Contributing to Movar
+
+Welcome! Movar is a cross-browser MV3 extension that keeps the internet in your
+language — it asks sites to serve your preferred language (Ukrainian-first,
+English fallback) and hides Russian content. This guide is the human entry point
+for contributors. The deep, per-package detail lives in the
+[`AGENTS.md`](AGENTS.md) tree; this file links **into** it rather than restating
+it, so the docs don't drift.
+
+The single highest-value external contribution is **a new site rule** (teaching
+Movar to fix one more site that defaults to Russian). That has its own worked
+guide: [`apps/extension/src/sites/CONTRIBUTING-A-SITE.md`](apps/extension/src/sites/CONTRIBUTING-A-SITE.md).
+
+## Setup
+
+Requires Node ≥22 and pnpm (see [`AGENTS.md`](AGENTS.md) "Toolchain & commands").
+
+```bash
+git clone https://github.com/rejifald/movar.git
+cd movar
+pnpm install
+pnpm --filter @movar/extension build   # or `pnpm dev` for the dev server
+```
+
+Then load the unpacked build into a Chromium browser:
+
+1. Open `chrome://extensions`.
+2. Enable **Developer mode**.
+3. **Load unpacked** → select **`apps/extension/.output/chrome-mv3`**.
+
+(The Chromium output directory is `chromiumOutputDir` in
+[`apps/extension/wxt.config.ts`](apps/extension/wxt.config.ts). Firefox/Safari
+loading steps are in [`apps/extension/AGENTS.md`](apps/extension/AGENTS.md).)
+
+For fast popup/options iteration without loading into a browser, see the static
+preview in [`apps/extension/AGENTS.md`](apps/extension/AGENTS.md) ("Static
+preview"). For anything touching real `chrome.storage`, the background worker, or
+content scripts, use `pnpm --filter @movar/extension dev:firefox:installed`.
+
+## The mental model (two sequential layers)
+
+Movar runs two layers in order on each page: a **redirect layer** (ask the site
+to serve another language via URL params, picker click, hreflang, or
+cookie/localStorage) and, only if the page didn't navigate, a
+**content-filter layer** (atomically conceal individual Russian content cards
+behind a curtain). A key invariant: **the content layer's verdict never feeds
+back into the redirect layer** (that would cause redirect/bounce hiccups), and
+Movar **blocks, never translates**.
+
+That's the one-paragraph version. The authoritative description — including the
+exact layer boundaries and the "verdict never feeds back" invariant — is in
+[`AGENTS.md`](AGENTS.md) under **"The mental model: two sequential layers."** New
+to the jargon (SERP, curtain, rung)? Start at [`docs/glossary.md`](docs/glossary.md).
+
+## Where a site rule lives
+
+Site rules are co-located per site under
+[`apps/extension/src/sites/`](apps/extension/src/sites/). Adding one touches four
+things:
+
+- **Adapter** — `apps/extension/src/sites/<site>/index.ts` exports a `SiteRule`
+  (the strategy + value maps).
+- **Registry entry** — append the rule to the `rules` array in
+  [`apps/extension/src/sites/registry.ts`](apps/extension/src/sites/registry.ts).
+- **Host predicate** — match by the `match` suffix, or a `matchHost` predicate
+  from [`@movar/host-match`](packages/host-match/AGENTS.md) for multi-ccTLD
+  coverage.
+- **Fixture + test** — a representative sample host in the registry invariants
+  (`apps/extension/src/sites/registry.invariants.test.ts`) plus a focused
+  behavioural test.
+
+The full walkthrough, the `SiteRule`/`LangStrategy` shape, the `electrica-shop`
+worked example, and the safety caveats are in
+[`apps/extension/src/sites/CONTRIBUTING-A-SITE.md`](apps/extension/src/sites/CONTRIBUTING-A-SITE.md).
+**Note:** redirect rules run in the content script on `<all_urls>` and drive
+real navigations, so they get strong test gates and maintainer review.
+
+## Running diagnostics
+
+[`apps/diagnostics`](apps/diagnostics/AGENTS.md) is the private, never-published
+maintainer dev extension (the "shadow oracle"): it re-runs the product's own
+models on a live page and shows classifier-vs-franc divergences in an in-page
+panel. It's the fastest way to see what Movar sees on a page you're adding a rule
+for.
+
+```bash
+pnpm --filter @movar/diagnostics dev   # load .output/chrome-mv3 as above
+```
+
+Its content-card panel has a **"copy as test fixture"** button that formats a
+real-page snippet for `packages/lang-detect/test/fixtures.ts` — handy when a
+card is mis-detected and you want a regression case.
+
+## Validation & gate commands
+
+Run these before opening a PR (the pre-commit hook and CI run them too):
+
+```bash
+pnpm validate       # typecheck + lint + test + publint + check:readme + check:suppressions
+pnpm test           # the test suites (excludes e2e)
+pnpm check:readme    # README tagline + monorepo-layout + product-promise parity guard
+pnpm metrics         # refresh the code-health / coverage / bundle-size snapshots
+```
+
+Scoped runs while iterating: `pnpm --filter @movar/extension test` (one package),
+`nx run extension:typecheck`. The complete command reference is in
+[`AGENTS.md`](AGENTS.md) ("Toolchain & commands").
+
+## Conventions
+
+A few repo-wide rules worth knowing up front (full list in [`AGENTS.md`](AGENTS.md)
+"Conventions & invariants"):
+
+- **The extension stays network-silent** — it sends nothing off-device; issue
+  reporting is a `mailto`, never a backend.
+- **User-facing strings need both `en` and `uk`** (`apps/extension/src/lib/i18n/`).
+- **On-page content filtering is off by default**; Russian is a permanently
+  locked-blocked language.
+- **Icons are lucide** everywhere; never hand-inline SVG paths.
+- **Don't commit observability into the published extension** — it lives in the
+  separate `apps/diagnostics` dev extension.
+- **Don't run `changeset version`** — the release ritual is a hand-bump + tag
+  (see [`AGENTS.md`](AGENTS.md)).
+
+Thanks for contributing!

--- a/README.md
+++ b/README.md
@@ -78,7 +78,9 @@ For anything that touches real `chrome.storage`, the background worker, or
 content scripts, use `pnpm --filter @movar/extension dev:firefox:installed`
 instead.
 
-New to the codebase? [`docs/glossary.md`](docs/glossary.md) defines the domain
+New to the codebase? [`CONTRIBUTING.md`](CONTRIBUTING.md) is the contributor
+entry point (setup, the two-layer mental model, where a site rule lives, the
+gate commands), and [`docs/glossary.md`](docs/glossary.md) defines the domain
 jargon (SERP, curtain, the two layers, the package map) so the rest of the docs
 read clearly.
 

--- a/apps/extension/src/sites/CONTRIBUTING-A-SITE.md
+++ b/apps/extension/src/sites/CONTRIBUTING-A-SITE.md
@@ -1,0 +1,161 @@
+# Contributing a site rule
+
+This is the worked-example guide for adding a **redirect rule** — a per-site
+recipe that asks one site to serve your language instead of Russian. It assumes
+you have the repo set up; if not, start at the root [`CONTRIBUTING.md`](../../../../CONTRIBUTING.md).
+
+A site rule is the highest-value external contribution to Movar, and adding one
+is a good first issue: if you have a Ukrainian (or any non-Russian) site that
+defaults to Russian and ignores your preference, you can teach Movar to fix it.
+
+> **Read this risk note first.** Redirect rules run inside the content script on
+> **`<all_urls>`** ([`../entrypoints/content.ts`](../entrypoints/content.ts)) and
+> can trigger real navigations, behind the loop-guard in
+> [`../lib/loop-guard.ts`](../lib/loop-guard.ts). A wrong rule can bounce users
+> or mis-target locales site-wide. Every new rule needs strong test gates and
+> maintainer review before it ships. See [Risks](#risks-read-before-you-pr) below.
+
+## The two pieces of a rule
+
+Everything lives in [`./types.ts`](./types.ts). A rule is a `SiteRule`
+(`types.ts`, the `SiteRule` interface) that pairs **what host it matches** with
+**how to switch the language** (a `LangStrategy`).
+
+### `SiteRule`: what host it matches
+
+```ts
+export interface SiteRule {
+  match: string; // exact host or dot-anchored suffix; also the label + specificity weight
+  matchHost?: (host: string) => boolean; // optional predicate that REPLACES the match suffix test
+  strategy: LangStrategy; // how to switch the language (below)
+  enforce?: boolean; // fire on every page load, not just when the page is already Russian
+}
+```
+
+- **`match`** is normally the registrable host (`electrica-shop.com.ua`). It is
+  matched as an exact host **or a dot-anchored suffix**, so `www.electrica-shop.com.ua`
+  and any other subdomain resolve, but `fake-electrica-shop.com.ua` does **not**
+  (the dot boundary is what stops infix collisions). It also doubles as the
+  rule's **label** and **specificity weight** — when two rules match a host,
+  [`getRuleForHost`](./registry.ts) breaks the tie by `match` length, so a longer
+  (more specific) suffix wins.
+- **`matchHost`** is for coverage a single suffix can't express — most often a
+  site spread across many ccTLDs. Use a shared predicate from
+  [`@movar/host-match`](../../../../packages/host-match/AGENTS.md)
+  (`isGoogleHost` / `isYouTubeHost`) so the same "is this host site X" answer is
+  used by the redirect layer **and** the page-content extractors. When `matchHost`
+  is set, `match` is **only** the label/weight.
+- **`enforce`** makes the rule fire on every page load instead of only when the
+  page-language signal says the page is already Russian. It's required for search
+  engines: the interface can be Ukrainian while results bleed in from Russian, so
+  the trigger can't rely on the page-language signal. **An `enforce: true`
+  strategy MUST be no-op-safe when already at the target state** — re-running it
+  on an already-correct page must change nothing and must not navigate.
+  `searchParams` is no-op-safe (it rewrites params idempotently); **`cookie` and
+  `localStorage` are not** (re-writing them can drive a reload loop). This is
+  spelled out on the `enforce` doc comment in `types.ts`.
+
+### `LangStrategy`: how to switch the language
+
+The `LangStrategy` discriminated union (`types.ts`) is the menu. Reach for:
+
+| Strategy       | When                                                                             |
+| -------------- | -------------------------------------------------------------------------------- |
+| `cookie`       | Site reads a first-party, non-HttpOnly language cookie on the next request.      |
+| `localStorage` | Site reads a `localStorage` key (almost always needs a reload to take effect).   |
+| `pathSegment`  | Language lives in a URL path segment (`/ua/foo` vs `/ru/foo`).                   |
+| `subdomain`    | Language lives in the leftmost host label (`ua.example.com` ↔ `ru.example.com`). |
+| `query`        | A single query param selects language (`?lang=ua`).                              |
+| `searchParams` | **Search engines** — several params (interface + result language) set together.  |
+| `click`        | Universal fallback: click an in-site link/button matched by a selector.          |
+| `hreflang`     | Follow the page's own `<link rel="alternate" hreflang="…">` for the target.      |
+| `compound`     | Compose several strategies — writes run first, then a single navigation.         |
+
+Most per-language differences (the value a site expects in its URL or storage)
+go in a strategy's `values` map: canonical ISO code → the site's string, e.g.
+`{ uk: 'ua' }`. Encode it with `encodedValue` (`types.ts`), which falls back to
+the canonical code when there's no mapping.
+
+## Worked example: `electrica-shop`
+
+[`./electrica-shop/index.ts`](./electrica-shop/index.ts) is the simplest full
+example — a `compound` strategy:
+
+```ts
+export const electricaRule: SiteRule = {
+  match: 'electrica-shop.com.ua',
+  strategy: {
+    type: 'compound',
+    steps: [{ type: 'cookie', name: 'lang', values: { uk: 'ua' } }, { type: 'hreflang' }],
+  },
+};
+```
+
+This Ukrainian e-commerce site serves RU at the root and UA under `/ua/`. It
+publishes `<link rel="alternate" hreflang="…">` on every page, so the rule:
+
+1. sets a `lang` cookie (`{ uk: 'ua' }`) as a hint to any server-side preference
+   logic, then
+2. follows the page's own `hreflang` alternate to navigate to the UA URL — no
+   per-URL guesswork.
+
+No `enforce`: the page-language signal alone is enough to trigger it (the page is
+genuinely serving Russian), and the strategy is not no-op-safe (the cookie write
+would re-run), so `enforce` would be wrong here.
+
+### Other patterns to copy
+
+- **Multi-ccTLD via predicate + `searchParams` + `enforce`:**
+  [`./google/index.ts`](./google/index.ts) — one rule covers every `google.*`
+  ccTLD through `matchHost: isGoogleHost`, sets `hl` (interface) and `lr`
+  (result-language filter) together, gates the rewrite to `/search` with
+  `onlyOnPath` and to real queries with `onlyWhenParam: 'q'`, and strips an
+  opaque session-bias token (`sei`). `enforce: true` because results can be
+  Russian even when the interface is Ukrainian.
+- **Single interface param:** [`./bing/index.ts`](./bing/index.ts) — one
+  `setlang` param, path-gated to `/search`.
+- **Region+language combined param:** [`./duckduckgo/index.ts`](./duckduckgo/index.ts)
+  — a `kl` param with a per-language `values` map (`DDG_REGION`).
+
+## Wiring steps
+
+1. **Create the adapter.** Add `sites/<site>/index.ts` and export a named
+   `SiteRule` (e.g. `export const acmeRule: SiteRule = { … }`). Add a top
+   comment explaining what the site does wrong and why the strategy is the
+   honest knob — the existing adapters are the template.
+2. **Register it.** Import and append your rule to the `rules` array in
+   [`./registry.ts`](./registry.ts). Order only matters among equal-length
+   `match` values (the resolver sorts by `match` length), so appending is fine.
+3. **Add a fixture/sample host and a test.** Add your rule's representative host
+   to the `SAMPLE_HOSTS` map in
+   [`./registry.invariants.test.ts`](./registry.invariants.test.ts) — this is
+   the lightweight "fixture" the registry invariants iterate, and CI **fails**
+   if a rule has no entry. The invariants then automatically assert your rule
+   resolves for its sample host, rejects a faked-prefix lookalike, and does not
+   overlap another suffix rule. Add a focused behavioural test too (assert the
+   strategy shape, params, and any `enforce`/path gates) alongside the existing
+   per-engine tests.
+4. **For an extractable site only** (page-content content-filter layer): also
+   export a `model` descriptor and add a lazy `model.ts` chunk — see
+   `./google/` and `./youtube/`. Most redirect-only rules do not need this.
+
+## Risks: read before you PR
+
+- **Runs on `<all_urls>`.** The content script is matched on every site
+  (`../entrypoints/content.ts`). Your rule's matcher must be tight: prefer an
+  exact registrable host as `match`, or a vetted `@movar/host-match` predicate.
+  A loose `match` (e.g. a bare TLD-ish suffix) can hijack unrelated hosts.
+- **It drives navigations behind a loop-guard.** A redirect that lands on a page
+  the rule still considers "wrong" will try to redirect again;
+  [`../lib/loop-guard.ts`](../lib/loop-guard.ts) caps the bounce, but a
+  mis-targeted rule still degrades the page. Verify the post-redirect URL is a
+  fixed point (re-running the rule there is a no-op).
+- **`enforce: true` must be no-op-safe.** See the `enforce` section above — only
+  use it with idempotent strategies (`searchParams`), never raw
+  `cookie`/`localStorage`.
+- **No Russian engines, ever.** Movar blocks Russian; it never adds a redirect
+  rule that would route users to a Russian search engine. The invariant test
+  keeps a guard for the well-known ones.
+
+When in doubt, open an issue describing the site's behavior before writing the
+rule — maintainers can point you at the right strategy and the riskier edges.

--- a/apps/extension/src/sites/electrica-shop/index.ts
+++ b/apps/extension/src/sites/electrica-shop/index.ts
@@ -4,6 +4,9 @@ import type { SiteRule } from '../types';
 // /ua/. The site publishes <link rel="alternate" hreflang="..."> on every
 // page, so we follow that for the navigation — no per-URL guesswork. The
 // cookie is set first as a hint to any server-side preference logic.
+//
+// This is the worked example in ../CONTRIBUTING-A-SITE.md — start there to add
+// a new site rule.
 export const electricaRule: SiteRule = {
   match: 'electrica-shop.com.ua',
   strategy: {

--- a/apps/extension/src/sites/registry.invariants.test.ts
+++ b/apps/extension/src/sites/registry.invariants.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it } from 'vitest';
+import type { SiteRule } from './types';
+import { getRuleForHost, rules } from './registry';
+
+/**
+ * Generic registry invariants — the safety net for community site-rule
+ * contributions (see ./CONTRIBUTING-A-SITE.md). Unlike registry.test.ts, which
+ * spot-checks named engines, this file iterates the *whole* `rules` array and
+ * asserts the structural guarantees every rule must keep, so a PR that adds a
+ * rule with a typo'd `match`, an overlapping suffix, or no fixture fails here
+ * rather than shipping a bad redirect onto `<all_urls>`.
+ *
+ * The per-rule "fixture" is the lightweight kind the issue settled on: a
+ * required sample-host entry below, not an HTML capture. It is what makes the
+ * suffix-resolution and no-overlap checks executable — every rule MUST have at
+ * least one sample host here, and CI fails if a new rule is added without one.
+ */
+
+/**
+ * One real, representative host per rule, keyed by the rule's `match` label.
+ * Adding a rule to registry.ts without adding an entry here fails the
+ * "every rule has a fixture" test below.
+ *
+ * - For suffix rules the sample must be a host the rule's `match` is a real
+ *   dot-anchored suffix of (or exactly equals).
+ * - For predicate rules (`matchHost`) the sample must be a host the predicate
+ *   accepts; `match` is only a label there.
+ */
+const SAMPLE_HOSTS: Record<string, string> = {
+  'electrica-shop.com.ua': 'www.electrica-shop.com.ua',
+  google: 'www.google.com',
+  'bing.com': 'www.bing.com',
+  'duckduckgo.com': 'duckduckgo.com',
+  'youtube.com': 'www.youtube.com',
+};
+
+/** Suffix rules: a `match` is a dot-anchored suffix of `host` (or equals it). */
+function isSuffixOf(match: string, host: string): boolean {
+  return host === match || host.endsWith(`.${match}`);
+}
+
+describe('registry invariants — every rule', () => {
+  it('has a registered sample host ("fixture")', () => {
+    // Guards against a rule landing in registry.ts with no test coverage at
+    // all. The sample map below is what the rest of these checks iterate.
+    const missing = rules.map((r) => r.match).filter((m) => !(m in SAMPLE_HOSTS));
+    expect(missing, `rules missing a SAMPLE_HOSTS entry: ${missing.join(', ')}`).toEqual([]);
+  });
+
+  it.each(rules.map((r): [string, SiteRule] => [r.match, r]))(
+    'resolves for its sample host (%s)',
+    (match, rule) => {
+      const sample = SAMPLE_HOSTS[match];
+      expect(sample, `no sample host registered for "${match}"`).toBeDefined();
+      // Predicate rules resolve via matchHost; suffix rules via getRuleForHost.
+      // Either way the registry must return *this* rule for its own sample.
+      expect(getRuleForHost(sample!)).toBe(rule);
+    },
+  );
+
+  it.each(rules.filter((r) => !r.matchHost).map((r): [string, SiteRule] => [r.match, r]))(
+    'rejects a faked-prefix lookalike for suffix rule (%s)',
+    (match) => {
+      // Generalizes the single fake-prefix negative in registry.test.ts: a
+      // `match` must anchor on a dot boundary, so `fake<match>` (an infix, not
+      // a real subdomain) must NOT resolve. Only suffix rules are checked —
+      // predicate rules define their own anti-spoofing (e.g. isGoogleHost).
+      expect(getRuleForHost(`fake${match}`)).toBeUndefined();
+    },
+  );
+
+  it('has a sample host that resolves to exactly one (the intended) rule', () => {
+    // No host in the per-rule sample set resolves ambiguously: each sample
+    // must come back as its own rule, never a different one shadowing it.
+    for (const rule of rules) {
+      const sample = SAMPLE_HOSTS[rule.match];
+      expect(
+        getRuleForHost(sample!),
+        `sample "${sample}" did not resolve to rule "${rule.match}"`,
+      ).toBe(rule);
+    }
+  });
+});
+
+describe('registry invariants — no overlaps between suffix rules', () => {
+  // Two suffix rules where one `match` is a dot-anchored suffix of the other
+  // would make resolution order-dependent and surprising. Predicate rules are
+  // exempt from the suffix-overlap rule (their `match` is only a label), but
+  // they must NOT also be covered by a competing suffix rule — that is checked
+  // separately below.
+  const suffixRules = rules.filter((r) => !r.matchHost);
+
+  it('has no suffix rule whose match is a suffix of another rule', () => {
+    for (const a of suffixRules) {
+      for (const b of suffixRules) {
+        if (a === b) continue;
+        expect(
+          isSuffixOf(a.match, b.match),
+          `rule "${b.match}" overlaps rule "${a.match}" (one is a dot-anchored suffix of the other)`,
+        ).toBe(false);
+      }
+    }
+  });
+
+  it('has no suffix rule that also matches a predicate rule’s sample host', () => {
+    // A predicate rule (e.g. isGoogleHost) must own its hosts outright. If a
+    // suffix rule also resolved one of the predicate's sample hosts, the
+    // sort-by-`match`-length tie-break could hand the host to the wrong rule.
+    const predicateRules = rules.filter((r) => r.matchHost);
+    for (const predicateRule of predicateRules) {
+      const sample = SAMPLE_HOSTS[predicateRule.match];
+      expect(sample, `no sample host for predicate rule "${predicateRule.match}"`).toBeDefined();
+      const suffixHit = suffixRules.find((r) => isSuffixOf(r.match, sample!));
+      expect(
+        suffixHit?.match,
+        `predicate rule "${predicateRule.match}" sample "${sample}" also matches suffix rule "${suffixHit?.match}"`,
+      ).toBeUndefined();
+    }
+  });
+});
+
+describe('registry invariants — Russian search engines stay unregistered', () => {
+  // Retained from registry.test.ts so the guard survives if that file is ever
+  // trimmed: Movar must never register a redirect rule for a Russian engine.
+  it.each(['yandex.ru', 'ya.ru', 'mail.ru', 'rambler.ru'])('does not register %s', (host) => {
+    expect(getRuleForHost(host)).toBeUndefined();
+  });
+});

--- a/apps/extension/src/sites/registry.ts
+++ b/apps/extension/src/sites/registry.ts
@@ -7,6 +7,10 @@
  * This stays eager (and tiny) on purpose: the matchers must run before anything
  * is loaded, and the redirect rule fires even when content-modification is off.
  * Only the per-site extractor chunk it points at is loaded on demand.
+ *
+ * Adding a site rule? See ./CONTRIBUTING-A-SITE.md for the worked example and
+ * the wiring steps (adapter → this `rules` array → a sample host in
+ * ./registry.invariants.test.ts → a behavioural test).
  */
 import type { ModelChunk, SiteModel, SiteRule } from './types';
 import { electricaRule } from './electrica-shop';

--- a/docs/REFACTORING-QUEUE.md
+++ b/docs/REFACTORING-QUEUE.md
@@ -13,7 +13,7 @@ summary: Auto-generated agent task queue from fallow refactoring targets.
 - Source report: [.metrics/fallow.md](../.metrics/fallow.md)
 - Health score: **85 (B)**
 - Targets surfaced: **1** (parsed: 1)
-- Generated: 2026-06-13T17:24:10.433Z
+- Generated: 2026-06-13T17:45:49.497Z
 
 ## How to consume
 

--- a/scripts/readme-metrics.snapshot.json
+++ b/scripts/readme-metrics.snapshot.json
@@ -4,7 +4,7 @@
     "score": 85,
     "grade": "B"
   },
-  "loc": 30236,
+  "loc": 30243,
   "suppressions": {
     "eslint": 35,
     "fallow": 25


### PR DESCRIPTION
Contributor onboarding (from the audit) — docs + a registry-invariants guard.

- `CONTRIBUTING.md` (root): clone → `pnpm install` → load-unpacked, the two-layer model, where a site rule lives, running diagnostics, validate/metrics commands. Links into the `AGENTS.md` tree rather than restating.
- `apps/extension/src/sites/CONTRIBUTING-A-SITE.md`: the `SiteRule` shape + `electrica-shop` as the worked example.
- New `apps/extension/src/sites/registry.invariants.test.ts`: asserts every rule's `match` is a real host suffix, no overlaps, each rule has a fixture/sample host (dead-rule guard).
- Doc-pointer comments in `registry.ts` / `electrica-shop/index.ts` (no behavior change).

Verified: 93 sites tests pass, check:readme green.

Closes #121

🤖 Generated with [Claude Code](https://claude.com/claude-code)
