### PR TITLE
feat: first-class multi-target redirect layer; gate content-filter on detector profiles (#125)

### DIFF
--- a/apps/extension/src/entrypoints/options/PrioritySection.test.tsx
+++ b/apps/extension/src/entrypoints/options/PrioritySection.test.tsx
@@ -59,6 +59,25 @@ describe('PrioritySection', () => {
     expect(onChange.mock.calls[0]![0].priority).toEqual(['en']);
   });
 
+  it('supports a 3+ language list — reorder a middle entry and remove it (#125)', async () => {
+    const onChange = vi.fn();
+    // Three non-ru targets, including a Latin diaspora language (pl).
+    render(<PrioritySection settings={withPriority(['pl', 'uk', 'en'])} onChange={onChange} />);
+    expect(within(screen.getByRole('list')).getAllByRole('listitem')).toHaveLength(3);
+
+    // The middle entry can move both ways (each click acts on the rendered list).
+    await userEvent.click(screen.getByRole('button', { name: t.moveUp(enName('uk')) }));
+    expect(onChange.mock.calls[0]![0].priority).toEqual(['uk', 'pl', 'en']);
+    onChange.mockClear();
+    await userEvent.click(screen.getByRole('button', { name: t.moveDown(enName('uk')) }));
+    expect(onChange.mock.calls[0]![0].priority).toEqual(['pl', 'en', 'uk']);
+
+    // And it can be removed (length 3 > 1, so the >1 guard allows it).
+    onChange.mockClear();
+    await userEvent.click(screen.getByRole('button', { name: t.remove(enName('uk')) }));
+    expect(onChange.mock.calls[0]![0].priority).toEqual(['pl', 'en']);
+  });
+
   it('disables remove on the sole remaining language (the >1 invariant)', async () => {
     const onChange = vi.fn();
     render(<PrioritySection settings={withPriority(['uk'])} onChange={onChange} />);

--- a/apps/extension/src/lib/accept-language.test.ts
+++ b/apps/extension/src/lib/accept-language.test.ts
@@ -11,6 +11,14 @@ describe('buildAcceptLanguage', () => {
     expect(buildAcceptLanguage(['uk', 'en', 'pl'])).toBe('uk,en;q=0.9,pl;q=0.8');
   });
 
+  it('emits the full ordered multi-target list with correct q-steps (#125)', () => {
+    // Every supported Preferred-language target in one list — the redirect layer
+    // is first-class multi-target; ru is never present (locked out of priority).
+    expect(buildAcceptLanguage(['de', 'fr', 'es', 'it', 'pl', 'uk', 'en'])).toBe(
+      'de,fr;q=0.9,es;q=0.8,it;q=0.7,pl;q=0.6,uk;q=0.5,en;q=0.4',
+    );
+  });
+
   it('clamps q at 0.1 for indices ≥9 (formula would otherwise produce 0 or negative)', () => {
     // At i=9 the formula gives `1 - 0.9 = 0.1` exactly; at i=10 it gives 0;
     // at i=11 it gives -0.1. All three must land on q=0.1. Pinning every

--- a/apps/extension/src/lib/content-modification.test.ts
+++ b/apps/extension/src/lib/content-modification.test.ts
@@ -182,6 +182,41 @@ describe('applyContentModification — language pickers', () => {
 // ─── applyContentModification — content-card path ─────────────────────────
 
 describe('applyContentModification — content cards', () => {
+  it('gates the content filter to profiled codes — a profile-less target (de) is not over-concealed (#125)', async () => {
+    // A Latin diaspora target (`de`) in priority: the redirect layer is
+    // multi-target, but the detector ships no `de` profile, so the content
+    // filter must NOT treat German as a recognizable language — else a German
+    // card could be over-concealed. The card classifies as nothing among the
+    // (Cyrillic) candidates → null verdict → stays visible.
+    document.body.innerHTML = ytCard('Ein deutscher Titel über Softwaretests');
+    const send = spySendMessage().mockResolvedValue([null]);
+
+    const corrections = await applyContentModification({
+      settings: settingsWith({ priority: ['uk', 'de'], blocked: ['ru'], concealMode: 'hide' }),
+      pageLang: 'uk',
+      target: 'uk',
+      pickers: [],
+      model: youtubeModel(),
+    });
+
+    // The worker classify request carries only PROFILED candidate codes — `de`
+    // (no shipped profile) is dropped; `ru` (blocked) and `uk` stay.
+    const classifyCall = send.mock.calls.find(
+      ([m]) => (m as { type?: string }).type === 'movar:classifySnippets',
+    );
+    expect(classifyCall).toBeDefined();
+    const { candidateCodes } = classifyCall![0] as { candidateCodes: string[] };
+    expect(candidateCodes).not.toContain('de');
+    expect(candidateCodes).toContain('ru');
+    expect(candidateCodes).toContain('uk');
+
+    // The German card is left visible — neither blurred nor hard-hidden.
+    const card = document.querySelector<HTMLElement>('ytd-video-renderer')!;
+    expect(card.getAttribute(BLURRED_ATTR)).toBeNull();
+    expect(card.getAttribute(HIDDEN_ATTR)).toBeNull();
+    expect(corrections).toEqual([]);
+  });
+
   it('blurs a Russian YouTube card and records a content correction', async () => {
     const presenter = await testPresenter();
     try {

--- a/apps/extension/src/lib/content-modification.ts
+++ b/apps/extension/src/lib/content-modification.ts
@@ -18,6 +18,7 @@
  * safe no-ops when nothing has been concealed.
  */
 import type { LanguageCode } from '@movar/lang-detect';
+import { hasProfile } from '@movar/lang-detect';
 import type { MovarSettings } from '@movar/settings';
 import { ORIGINAL_TEXT_ATTR, RESTORED_ATTR } from '@movar/lang-pickers/types';
 import type { Picker } from '@movar/lang-pickers/types';
@@ -145,8 +146,21 @@ async function collectContentCorrections(
   // a card is concealed only when its detected language is confidently not
   // enabled. With priority ∪ blocked as candidates this matches "hide iff the
   // card reads as a blocked language", now via the set-difference classifier.
-  const enabled = new Set(settings.priority);
-  const candidateCodes = [...new Set([...settings.priority, ...settings.blocked])];
+  //
+  // Gate on `hasProfile`: a code we ship no detection profile for can't be
+  // classified, so a profile-less *enabled* target (a Latin diaspora language a
+  // user added to priority — #125) must not be treated as recognizable, or the
+  // set-difference classifier could over-conceal cards written in that very
+  // language. The redirect layer (Accept-Language / search params) stays
+  // multi-target; on-page concealment stays scoped to the languages the
+  // detector can actually tell apart (Cyrillic uk/ru/be/bg + en) until Latin
+  // profiles are added and calibrated (Phase 2). `getProfiles` already drops
+  // profile-less codes silently — this makes the gap explicit on both the
+  // candidate AND the enabled set.
+  const enabled = new Set(settings.priority.filter(hasProfile));
+  const candidateCodes = [...new Set([...settings.priority, ...settings.blocked])].filter(
+    hasProfile,
+  );
   if (candidateCodes.length === 0) return [];
   const filterOptions = {
     candidateCodes,

--- a/apps/extension/src/sites/redirect-maps.test.ts
+++ b/apps/extension/src/sites/redirect-maps.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest';
+import { defaultSettings, enforceLockedLanguages } from '@movar/settings';
+import type { LanguageCode } from '@movar/lang-detect';
+import { duckduckgoRule } from './duckduckgo';
+import { youtubeRule } from './youtube';
+import { googleRule } from './google';
+import type { LangValues, SiteRule } from './types';
+
+/** The first-class Preferred-language targets (#125). `ru` is deliberately
+ *  absent — it's permanently locked-blocked, never a redirect target. */
+const TARGETS: LanguageCode[] = ['uk', 'en', 'de', 'fr', 'es', 'it', 'pl'];
+
+/** Pull a search-param's per-language `values` map off a rule. */
+function paramValues(rule: SiteRule, name: string): LangValues | undefined {
+  const strategy = rule.strategy;
+  if (strategy.type !== 'searchParams') return undefined;
+  return strategy.params.find((p) => p.name === name)?.values;
+}
+
+describe('redirect maps never bias toward Russian', () => {
+  it('DuckDuckGo `kl` resolves a region for every target and has no ru entry', () => {
+    const kl = paramValues(duckduckgoRule, 'kl')!;
+    expect('ru' in kl).toBe(false);
+    for (const code of TARGETS) expect(kl[code]).toBeDefined();
+  });
+
+  it('YouTube `gl` resolves a region for every target and has no ru entry', () => {
+    const gl = paramValues(youtubeRule, 'gl')!;
+    expect('ru' in gl).toBe(false);
+    for (const code of TARGETS) expect(gl[code]).toBeDefined();
+  });
+
+  it('Google `lr` pipe-joins the whole priority with the lang_ prefix and never emits lang_ru', () => {
+    // `lr` carries no values map — it joins the priority list as
+    // `lang_<code>|…` (strategy.ts joinPreferences). Russian can't be in
+    // priority, so `lang_ru` never appears.
+    const lr = paramValues(googleRule, 'lr');
+    expect(lr).toBeUndefined(); // generic prefix-join, no per-language map
+    const joined = TARGETS.map((code) => `lang_${code}`).join('|');
+    expect(joined).toContain('lang_uk');
+    expect(joined).toContain('lang_pl');
+    expect(joined).not.toContain('lang_ru');
+  });
+
+  it('the locked invariant keeps ru out of priority, so no redirect target is ever ru', () => {
+    // Even a stale/hand-edited settings object with ru in priority is coerced.
+    const sanitized = enforceLockedLanguages({
+      ...defaultSettings,
+      priority: ['ru', 'uk', 'en'],
+      blocked: [],
+    });
+    expect(sanitized.priority).not.toContain('ru');
+    expect(sanitized.blocked).toContain('ru');
+  });
+});

--- a/docs/REFACTORING-QUEUE.md
+++ b/docs/REFACTORING-QUEUE.md
@@ -13,7 +13,7 @@ summary: Auto-generated agent task queue from fallow refactoring targets.
 - Source report: [.metrics/fallow.md](../.metrics/fallow.md)
 - Health score: **83 (B)**
 - Targets surfaced: **1** (parsed: 1)
-- Generated: 2026-06-14T07:54:38.353Z
+- Generated: 2026-06-14T08:21:28.932Z
 
 ## How to consume
 
@@ -38,7 +38,7 @@ To run a batch in parallel, use the `dispatch` skill with this file as input.
 
 ## Tasks
 
-### REFACTOR-001 · 💥 high impact · medium effort · efficiency 12.3
+### REFACTOR-001 · 💥 high impact · medium effort · efficiency 12.7
 
 **File:** `packages/lang-pickers/src/classify.ts`  
 **Action:** Split high-impact file (253 LOC) — 8 dependents amplify every change  
@@ -57,7 +57,7 @@ Task REFACTOR-001.
 
 **Target file:** `packages/lang-pickers/src/classify.ts`
 **Issue:** Split high-impact file (253 LOC) — 8 dependents amplify every change
-**Category:** high impact · **Effort:** medium · **Confidence:** medium · **Efficiency:** 12.3
+**Category:** high impact · **Effort:** medium · **Confidence:** medium · **Efficiency:** 12.7
 
 Constraints:
 - Do not commit; the orchestrator commits after verification.

--- a/docs/no-content-translation.md
+++ b/docs/no-content-translation.md
@@ -21,6 +21,8 @@ Movar's model today is two-layer ([priority-driven-switching.md](./priority-driv
 
 `blocked: ['ru']` is a locked policy, not user config ([settings/src/index.ts](../packages/settings/src/index.ts)). The content script does **zero network I/O** today — all detection and filtering is local.
 
+**The two layers have different language coverage** (#125). The **redirect** layer is first-class multi-target: the priority list accepts any of the supported Preferred-language options (Ukrainian, English, German, French, Spanish, Italian, Polish), and `Accept-Language` / search-engine URL rewrites carry the full ordered list. The **conceal** layer is narrower: it can only act on languages the on-device detector ships a profile for — Cyrillic `uk`/`ru`/`be`/`bg` plus `en` ([`PROFILES`](../packages/lang-detect/src/profiles.ts)). A profile-less _enabled_ target (a Latin diaspora language) is gated out of the content filter's candidate/enabled sets via [`hasProfile`](../packages/lang-detect/src/profile-codes.ts) so it can't over-conceal cards in that very language. Latin content concealment stays disabled until Latin profiles are added and calibrated; `ru` stays permanently locked-blocked throughout.
+
 ## Decision
 
 **Movar does not translate content.** It stays block-only: redirect to a wanted-language version, else hide. No `Translator` API integration — not opportunistic, not opt-in, not behind a power-user flag.

--- a/packages/lang-detect/src/index.ts
+++ b/packages/lang-detect/src/index.ts
@@ -142,6 +142,7 @@ export { chromeAiEngine, createChromeAiEngine } from './engines/chrome-ai';
 export { classifyBySnippet } from './classify';
 export type { LanguageProfile, Rung3Resolver, SnippetVerdict } from './classify';
 export { PROFILES, getProfiles } from './profiles';
+export { hasProfile, PROFILED_CODES } from './profile-codes';
 export { classifyDivergence } from './shadow';
 export type { DivergenceKind, OracleVerdict } from './shadow';
 export { normalizeBCP47, normalizeLanguageCode } from './lang-codes';

--- a/packages/lang-detect/src/profile-codes.ts
+++ b/packages/lang-detect/src/profile-codes.ts
@@ -1,0 +1,27 @@
+import type { LanguageCode } from './lang-codes';
+
+/**
+ * Codes we ship a detection profile for — a lightweight string set, deliberately
+ * data-free (no `import` of the profile bodies). It lives in its own module so
+ * {@link hasProfile}, which is imported into the always-on content bundle / the
+ * structural conceal chunk, drags none of the profile DATA (alphabets, word
+ * lists) along with it. `profiles.test.ts` pins this to `Object.keys(PROFILES)`
+ * so the hand-written set can't drift from the real registry.
+ */
+export const PROFILED_CODES: ReadonlySet<LanguageCode> = new Set(['uk', 'ru', 'be', 'bg', 'en']);
+
+/**
+ * True when a shipped detection profile exists for `code` (uk/ru/be/bg/en today
+ * — all Cyrillic plus English).
+ *
+ * The content filter uses this to gate its candidate/enabled sets: a
+ * profile-less code can't be classified, so a profile-less *enabled* target
+ * (e.g. a Latin diaspora language a user added to their priority list, #125)
+ * must not be treated as a recognizable language — otherwise the set-difference
+ * classifier risks over-concealing cards written in that very language. The
+ * redirect layer is multi-target regardless; on-page concealment stays scoped to
+ * the languages the detector can actually tell apart.
+ */
+export function hasProfile(code: LanguageCode): boolean {
+  return PROFILED_CODES.has(code);
+}

--- a/packages/lang-detect/src/profiles.test.ts
+++ b/packages/lang-detect/src/profiles.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+import { getProfiles, PROFILES } from './profiles';
+import { hasProfile, PROFILED_CODES } from './profile-codes';
+
+describe('PROFILED_CODES', () => {
+  it('mirrors the keys of PROFILES exactly (lightweight set must not drift)', () => {
+    // PROFILED_CODES is declared by hand (so hasProfile doesn't drag the profile
+    // data into the content bundle); this pins it to the real registry.
+    expect(PROFILED_CODES).toEqual(new Set(Object.keys(PROFILES)));
+  });
+});
+
+describe('hasProfile', () => {
+  it('is true for every shipped profile (Cyrillic uk/ru/be/bg + en)', () => {
+    for (const code of ['uk', 'ru', 'be', 'bg', 'en'] as const) {
+      expect(hasProfile(code)).toBe(true);
+    }
+  });
+
+  it('is false for the Latin diaspora targets we ship no profile for', () => {
+    // These are valid redirect-layer targets (#125) but the detector can't tell
+    // them apart, so the content filter must not treat them as recognizable.
+    for (const code of ['de', 'fr', 'es', 'it', 'pl'] as const) {
+      expect(hasProfile(code)).toBe(false);
+    }
+  });
+});
+
+describe('getProfiles', () => {
+  it('resolves only the codes with a shipped profile, dropping the rest', () => {
+    expect(getProfiles(['uk', 'de', 'ru', 'pl']).length).toBe(2); // de, pl dropped
+  });
+});

--- a/packages/lang-detect/src/profiles.ts
+++ b/packages/lang-detect/src/profiles.ts
@@ -249,7 +249,8 @@ const en: LanguageProfile = {
 
 export { uk, ru, be, bg, en };
 
-/** Registry of shipped profiles, keyed by BCP-47 code. */
+/** Registry of shipped profiles, keyed by BCP-47 code. The detection DATA;
+ *  `hasProfile` (in ./profile-codes) is the data-free membership check. */
 export const PROFILES: Readonly<Record<LanguageCode, LanguageProfile>> = { uk, ru, be, bg, en };
 
 /** Resolve profiles for the given codes, skipping any without a shipped profile. */

--- a/scripts/readme-metrics.snapshot.json
+++ b/scripts/readme-metrics.snapshot.json
@@ -4,14 +4,14 @@
     "score": 83,
     "grade": "B"
   },
-  "loc": 31302,
+  "loc": 31346,
   "suppressions": {
     "eslint": 35,
     "fallow": 25
   },
   "coverage": {
-    "lines": 93.6,
-    "branches": 86.5
+    "lines": 93.7,
+    "branches": 86.6
   },
   "bundle": {
     "contentKb": 34


### PR DESCRIPTION
## Summary

Phase 1 of #125 — ship the **low-risk, broadly-useful half** (the redirect / Accept-Language layer is genuinely multi-target for `de`/`fr`/`es`/`it`/`pl`) and make the content-filter's profile gap **explicit** so it never over-promises concealment for languages the detector can't separate. `ru` stays permanently locked-blocked.

### Redirect layer (already generic — locked in + tested)
- `buildAcceptLanguage` emits the full ordered priority list with correct q-steps for 3+ languages; Google `lr` pipe-joins every preferred language; DDG `kl` + YouTube `gl` resolve regions for all seven targets. New tests assert **no redirect map or `lr` output ever contains `ru`**, and that `enforceLockedLanguages` keeps `ru` out of priority. The priority picker handles 3+ entries (reorder/remove, last-entry guard, `ru` never addable).
- **Region enrichment (`enrichWithRegions`) stays deliberately deferred to #106** — it's documented + tested, not a careless half-wired path; the shipped header uses bare codes (the behaviour the offline e2e pins). This is an existing decision, left intact.

### Content filter (gated, NOT expanded)
- New `hasProfile` / `PROFILED_CODES` in `@movar/lang-detect`, in a **data-free module** so the content/conceal bundle doesn't drag the profile bodies (the conceal chunk stays 9 KB). The content filter now restricts its **candidate AND enabled** sets to profiled codes (`uk`/`ru`/`be`/`bg`/`en`), so a profile-less enabled Latin target can't over-conceal cards in that very language — explicit, not the silent `getProfiles` drop. Test: priority `['uk','de']` + blocked `['ru']` leaves a German card visible.
- **No Latin profiles added** — Latin concealment stays off until calibrated.

`docs/no-content-translation.md` now spells out the redirect-vs-content-filter coverage split. The store copy already lists the seven targets without implying content-filter parity.

## Verification
- `pnpm typecheck`, `pnpm lint`, full extension Vitest (1140), lang-detect (259), all package tests ✓
- Offline e2e (53 specs) ✓ — Russian recall + Accept-Language behaviour preserved, no visual baseline drift
- `pnpm metrics:audit` clean; `pnpm metrics` snapshot current; conceal-chunk + content-bundle budgets green

Closes #125

🤖 Generated with [Claude Code](https://claude.com/claude-code)