### PR TITLE
fix(safari): normalize extension bundle identifier to lowercase

### DIFF
--- a/apps/extension/safari/Movar/Movar.xcodeproj/project.pbxproj
+++ b/apps/extension/safari/Movar/Movar.xcodeproj/project.pbxproj
@@ -686,7 +686,7 @@
 					"-framework",
 					SafariServices,
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = fyi.movar.safari.Extension;
+				PRODUCT_BUNDLE_IDENTIFIER = fyi.movar.safari.extension;
 				PRODUCT_NAME = "Movar Extension";
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
@@ -719,7 +719,7 @@
 					"-framework",
 					SafariServices,
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = fyi.movar.safari.Extension;
+				PRODUCT_BUNDLE_IDENTIFIER = fyi.movar.safari.extension;
 				PRODUCT_NAME = "Movar Extension";
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
@@ -837,7 +837,7 @@
 					"-framework",
 					SafariServices,
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = fyi.movar.safari.Extension;
+				PRODUCT_BUNDLE_IDENTIFIER = fyi.movar.safari.extension;
 				PRODUCT_NAME = "Movar Extension";
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
@@ -872,7 +872,7 @@
 					"-framework",
 					SafariServices,
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = fyi.movar.safari.Extension;
+				PRODUCT_BUNDLE_IDENTIFIER = fyi.movar.safari.extension;
 				PRODUCT_NAME = "Movar Extension";
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;

--- a/apps/extension/safari/Movar/Shared (App)/ViewController.swift
+++ b/apps/extension/safari/Movar/Shared (App)/ViewController.swift
@@ -16,7 +16,7 @@ import SafariServices
 typealias PlatformViewController = NSViewController
 #endif
 
-let extensionBundleIdentifier = "fyi.movar.safari.Extension"
+let extensionBundleIdentifier = "fyi.movar.safari.extension"
 
 class ViewController: PlatformViewController, WKNavigationDelegate, WKScriptMessageHandler {
 

--- a/docs/safari-deploy.md
+++ b/docs/safari-deploy.md
@@ -23,8 +23,8 @@ loop) see [apps/extension/wxt.config.ts](../apps/extension/wxt.config.ts) and th
   | ------------------------- | ------------- | ---------------------------- |
   | `Movar (iOS)`             | app           | `fyi.movar.safari`           |
   | `Movar (macOS)`           | app           | `fyi.movar.safari`           |
-  | `Movar Extension (iOS)`   | app-extension | `fyi.movar.safari.Extension` |
-  | `Movar Extension (macOS)` | app-extension | `fyi.movar.safari.Extension` |
+  | `Movar Extension (iOS)`   | app-extension | `fyi.movar.safari.extension` |
+  | `Movar Extension (macOS)` | app-extension | `fyi.movar.safari.extension` |
 
   Deployment targets: iOS 15.0, macOS 10.14. iPadOS runs the iOS binary.
 
@@ -98,7 +98,7 @@ native build runs only at release time.
 2. **Certificates, Identifiers & Profiles → Identifiers → App IDs**, register
    both bundle IDs as explicit App IDs:
    - `fyi.movar.safari` (the app — used by both the iOS and macOS targets)
-   - `fyi.movar.safari.Extension` (the Safari web extension appex)
+   - `fyi.movar.safari.extension` (the Safari web extension appex)
 3. **App Store Connect → Apps → +** → create the Movar app for `fyi.movar.safari`,
    then add **both** the iOS and macOS platforms to it. Fill the listing metadata
    (name, description, screenshots, privacy URL `https://movar.fyi/privacy`,


### PR DESCRIPTION
## What

Normalize the Safari web extension appex bundle identifier to match the parent app's lowercase style:

`fyi.movar.safari.Extension` → `fyi.movar.safari.extension`

## Why

The app target uses the lowercase `fyi.movar.safari`, while the extension appex carried a capitalized `…Extension`. Apple bundle identifiers are case-sensitive across Xcode build settings, the App ID registration in App Store Connect, and the runtime `SFSafariExtensionManager` lookup — a casing mismatch between any of these surfaces silently breaks the "enable in Safari" toggle and provisioning. This normalizes to a single lowercase form everywhere.

## Changes (kept in lockstep)

- **Xcode project** (`project.pbxproj`) — `PRODUCT_BUNDLE_IDENTIFIER` in all 4 extension build configs (iOS/macOS × Debug/Release)
- **`ViewController.swift`** — `extensionBundleIdentifier` constant used for the `SFSafariExtensionManager` state lookup / toggle, so the runtime lookup matches the built target
- **`docs/safari-deploy.md`** — App ID registration table and the explicit App ID registration step

No remaining references to the old `.Extension` casing (verified by repo-wide grep).

## Notes

This is a pre-release normalization. Since the extension has not yet been registered with Apple under the capitalized ID (the deploy doc is being corrected before registration), no re-registration is required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)