### PR TITLE
chore: gitignore vendored Cloudflare platform skills

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,18 @@ storybook-static
 # .nxignore.
 .claude/worktrees/
 
+# Vendored Cloudflare platform skills (installed locally via the skills
+# marketplace, reinstallable anytime). They're generic upstream docs, not
+# movar-specific automation like the tracked add-before-after-case / sync-readme
+# skills, so keep them on disk for local use but out of version control.
+.claude/skills/agents-sdk/
+.claude/skills/cloudflare/
+.claude/skills/cloudflare-email-service/
+.claude/skills/durable-objects/
+.claude/skills/sandbox-sdk/
+.claude/skills/workers-best-practices/
+.claude/skills/wrangler/
+
 # demo-video recording outputs — captured WebM + ffmpeg-derived MP4/GIF
 apps/e2e/demo-results/
 apps/e2e/src/demo/out/


### PR DESCRIPTION
## What

Adds `.gitignore` entries for the 7 Cloudflare platform skills installed locally under `.claude/skills/` (`agents-sdk`, `cloudflare`, `cloudflare-email-service`, `durable-objects`, `sandbox-sdk`, `workers-best-practices`, `wrangler`).

## Why

These are generic upstream docs (~2.2 MB, `cloudflare` alone is 2.0 MB) installed via the skills marketplace and reinstallable anytime. They are **not** movar-specific automation like the tracked `add-before-after-case` / `sync-readme` skills, and most don't even map to movar's actual Cloudflare footprint (Pages + `_middleware.ts`; no Durable Objects / Sandbox / Agents SDK). Keeping them on disk for local use but out of version control avoids permanent git bloat and upstream drift.

## Note

Listed explicitly rather than ignoring all of `.claude/skills/`, so any future bespoke movar skill still shows up in `git status` and can be committed normally. The two existing tracked skills are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)