### PR TITLE
Adopt langtell 0.4.0 in diagnostics (drop the rung-3 adapter)

### DIFF
--- a/apps/diagnostics/package.json
+++ b/apps/diagnostics/package.json
@@ -22,6 +22,7 @@
     "@movar/page-language": "workspace:*",
     "@movar/page-mode": "workspace:*",
     "@movar/settings": "workspace:*",
+    "langtell": "^0.3.0",
     "lucide-react": "^1.17.0",
     "react": "^19.2.6",
     "react-dom": "^19.2.6"

--- a/apps/diagnostics/package.json
+++ b/apps/diagnostics/package.json
@@ -22,7 +22,7 @@
     "@movar/page-language": "workspace:*",
     "@movar/page-mode": "workspace:*",
     "@movar/settings": "workspace:*",
-    "langtell": "^0.3.0",
+    "langtell": "^0.4.0",
     "lucide-react": "^1.17.0",
     "react": "^19.2.6",
     "react-dom": "^19.2.6"

--- a/apps/diagnostics/src/lib/langtell-equivalence.test.ts
+++ b/apps/diagnostics/src/lib/langtell-equivalence.test.ts
@@ -1,0 +1,84 @@
+/**
+ * Dogfood equivalence guard: `langtell/classify`'s `classifyBySnippet` (the
+ * published, zero-dependency port) must agree with `@movar/lang-detect`'s
+ * `classifyBySnippet` on the `{ language, margin, rung }` triple this app
+ * consumes — across all rungs, including the franc rung-3 backstop reached via
+ * the injected resolver. If a future langtell release diverges, this fails loudly
+ * here rather than silently changing what the diagnostics panel reports.
+ *
+ * langtell additionally carries a `discriminating` flag that movar's verdict
+ * lacks; the diagnostics panel reads only language/margin/rung, so the
+ * comparison is deliberately scoped to that triple.
+ */
+import { classifyBySnippet as movarClassify, getProfiles } from '@movar/lang-detect';
+import { francRung3Resolver } from '@movar/lang-detect/franc';
+import type { LanguageProfile, SnippetVerdict } from '@movar/lang-detect';
+import { classifyBySnippet as langtellClassify } from 'langtell/classify';
+import type { Rung3Resolver as LangtellRung3Resolver } from 'langtell/classify';
+import { describe, expect, it } from 'vitest';
+
+// The full Cyrillic roster the product tells apart, plus en so a Latin title
+// scopes to a lone Latin candidate (the `discriminating: false` case).
+const candidates: readonly LanguageProfile[] = getProfiles(['uk', 'ru', 'be', 'bg', 'en']);
+
+// Same adapter the consumer (page-diagnostics.ts) uses: movar's resolver requires
+// `words`, langtell hands profiles where it is optional — bridge by defaulting it.
+const rung3: LangtellRung3Resolver = (text, scoped) =>
+  francRung3Resolver(
+    text,
+    scoped.map((p) => ({ ...p, words: p.words ?? { function: [], frequent: [] } })),
+  );
+
+/** The triple the diagnostics panel actually consumes off a verdict. */
+const triple = (v: { language: string; margin: number; rung: SnippetVerdict['rung'] }) => ({
+  language: v.language,
+  margin: v.margin,
+  rung: v.rung,
+});
+
+// Representative inputs across the rung ladder + the requested languages.
+const SAMPLES: ReadonlyArray<{ label: string; text: string; expectLang: string }> = [
+  // Rung 1 — distinctive letters.
+  { label: 'uk (ї, distinctive letter)', text: 'Їжак Сонік', expectLang: 'uk' },
+  { label: 'ru (ы/ё distinctive)', text: 'Новый сезон уже вышел', expectLang: 'ru' },
+  { label: 'be (ў uniquely Belarusian)', text: 'Магчыма ўсё атрымаецца', expectLang: 'be' },
+  { label: 'uk slogan (distinctive і/ї)', text: 'Слава Україні', expectLang: 'uk' },
+  // Rung 2a — function-word marker (no distinctive letter in scope).
+  { label: 'ru function word', text: 'Кофе и чай', expectLang: 'ru' },
+  // Latin → lone candidate (en) by script alone.
+  { label: 'en (Latin, lone candidate)', text: 'The quick brown fox', expectLang: 'en' },
+  // bg — ъ-as-vowel density in longer text.
+  { label: 'bg (ъ density)', text: 'Държавата приъ голъмия мостъ', expectLang: 'bg' },
+  // Rung 3 — distinctive-free Cyrillic residual long enough to reach franc.
+  {
+    label: 'ru residual (rung-3 franc backstop)',
+    text: 'Сегодня состоялась большая встреча представителей различных компаний',
+    expectLang: 'ru',
+  },
+  // Unknown — no letters / no evidence.
+  { label: 'unknown (digits/symbols only)', text: '12345 — !!!', expectLang: 'unknown' },
+  { label: 'unknown (empty)', text: '', expectLang: 'unknown' },
+];
+
+describe('langtell/classify ↔ @movar/lang-detect classifyBySnippet equivalence', () => {
+  it.each(SAMPLES)('agrees on the verdict triple for $label', ({ text, expectLang }) => {
+    const movar = movarClassify(text, candidates, francRung3Resolver);
+    const langtell = langtellClassify(text, candidates, rung3);
+
+    // The two ports must produce the same language/margin/rung the panel reads.
+    expect(triple(langtell)).toEqual(triple(movar));
+    // And that verdict must be the expected one (so the test still bites if BOTH
+    // ports regressed identically).
+    expect(movar.language).toBe(expectLang);
+  });
+
+  it('agrees with rung-3 disabled (no injected resolver)', () => {
+    // The residual sample needs franc; without a resolver BOTH must abstain to
+    // 'unknown' identically — proving the ladder up to rung 2 is also in lockstep.
+    const text = 'Сегодня состоялась большая встреча представителей различных компаний';
+    const movar = movarClassify(text, candidates);
+    const langtell = langtellClassify(text, candidates);
+    expect(triple(langtell)).toEqual(triple(movar));
+    expect(movar.rung).toBeNull();
+  });
+});

--- a/apps/diagnostics/src/lib/langtell-equivalence.test.ts
+++ b/apps/diagnostics/src/lib/langtell-equivalence.test.ts
@@ -14,20 +14,16 @@ import { classifyBySnippet as movarClassify, getProfiles } from '@movar/lang-det
 import { francRung3Resolver } from '@movar/lang-detect/franc';
 import type { LanguageProfile, SnippetVerdict } from '@movar/lang-detect';
 import { classifyBySnippet as langtellClassify } from 'langtell/classify';
-import type { Rung3Resolver as LangtellRung3Resolver } from 'langtell/classify';
 import { describe, expect, it } from 'vitest';
 
 // The full Cyrillic roster the product tells apart, plus en so a Latin title
 // scopes to a lone Latin candidate (the `discriminating: false` case).
 const candidates: readonly LanguageProfile[] = getProfiles(['uk', 'ru', 'be', 'bg', 'en']);
 
-// Same adapter the consumer (page-diagnostics.ts) uses: movar's resolver requires
-// `words`, langtell hands profiles where it is optional — bridge by defaulting it.
-const rung3: LangtellRung3Resolver = (text, scoped) =>
-  francRung3Resolver(
-    text,
-    scoped.map((p) => ({ ...p, words: p.words ?? { function: [], frequent: [] } })),
-  );
+// As of langtell@0.4.0 `classifyBySnippet`/`Rung3Resolver` are generic over the
+// profile type, so the consumer (page-diagnostics.ts) — and this guard — hand
+// movar's `francRung3Resolver` straight to langtell with no adapter: `P` infers
+// from `candidates` (movar's stricter `LanguageProfile`, `words` required).
 
 /** The triple the diagnostics panel actually consumes off a verdict. */
 const triple = (v: { language: string; margin: number; rung: SnippetVerdict['rung'] }) => ({
@@ -37,7 +33,7 @@ const triple = (v: { language: string; margin: number; rung: SnippetVerdict['run
 });
 
 // Representative inputs across the rung ladder + the requested languages.
-const SAMPLES: ReadonlyArray<{ label: string; text: string; expectLang: string }> = [
+const SAMPLES: readonly { label: string; text: string; expectLang: string }[] = [
   // Rung 1 — distinctive letters.
   { label: 'uk (ї, distinctive letter)', text: 'Їжак Сонік', expectLang: 'uk' },
   { label: 'ru (ы/ё distinctive)', text: 'Новый сезон уже вышел', expectLang: 'ru' },
@@ -63,7 +59,7 @@ const SAMPLES: ReadonlyArray<{ label: string; text: string; expectLang: string }
 describe('langtell/classify ↔ @movar/lang-detect classifyBySnippet equivalence', () => {
   it.each(SAMPLES)('agrees on the verdict triple for $label', ({ text, expectLang }) => {
     const movar = movarClassify(text, candidates, francRung3Resolver);
-    const langtell = langtellClassify(text, candidates, rung3);
+    const langtell = langtellClassify(text, candidates, francRung3Resolver);
 
     // The two ports must produce the same language/margin/rung the panel reads.
     expect(triple(langtell)).toEqual(triple(movar));

--- a/apps/diagnostics/src/lib/page-diagnostics.ts
+++ b/apps/diagnostics/src/lib/page-diagnostics.ts
@@ -20,12 +20,13 @@ import { classifyDivergence } from '@movar/lang-detect';
 // rung ladder, same candidate-relative set-difference). Diagnostics is the safest
 // consumer to swap: a maintainer-only dev extension, not the production conceal path.
 import { classifyBySnippet } from 'langtell/classify';
-import type { Rung3Resolver as LangtellRung3Resolver } from 'langtell/classify';
 // Diagnostics is the maintainer-only dev extension — it keeps franc in-process
 // (the published extension hosts it in the background worker instead), so it
 // pulls the franc oracle + rung-3 resolver from the opt-in /franc subpath. langtell
-// stays franc-free; movar's `francRung3Resolver` is injected into langtell's
-// classifier via its structurally-compatible `Rung3Resolver` seam.
+// stays franc-free; movar's `francRung3Resolver` is injected straight into langtell's
+// classifier. As of langtell@0.4.0 `classifyBySnippet`/`Rung3Resolver` are generic
+// over the profile type, so `P` infers from the `candidates` (movar's stricter
+// `LanguageProfile`, `words` required) and the resolver is assignable with no adapter.
 import { francOracle, francRung3Resolver } from '@movar/lang-detect/franc';
 import type { LanguageCode, LanguageProfile, SnippetVerdict } from '@movar/lang-detect';
 import { buildModelForHost } from '@movar/page-content/registry';
@@ -184,21 +185,6 @@ function francCheck(
   return { agree: classifyDivergence(v, oracle) !== 'contradict', language: oracle.language };
 }
 
-/**
- * Adapt `@movar/lang-detect`'s {@link francRung3Resolver} to langtell's
- * {@link LangtellRung3Resolver} seam. The two resolver types differ only in their
- * `scoped` parameter: langtell hands its classifier's profiles (where `words` is
- * optional), while movar's resolver signature requires `words` — a contravariant
- * mismatch that `exactOptionalPropertyTypes` (correctly) rejects, even though
- * `francRung3Resolver` reads only `iso6393` at runtime. We bridge it soundly by
- * defaulting the optional `words` before delegating; no `as`/`any` silencing.
- */
-const rung3Resolver: LangtellRung3Resolver = (text, scoped) =>
-  francRung3Resolver(
-    text,
-    scoped.map((p) => ({ ...p, words: p.words ?? { function: [], frequent: [] } })),
-  );
-
 /** Classify the page-content model's cards; tally languages + the blocked count. */
 function buildCards(
   model: ReturnType<typeof buildModelForHost>,
@@ -210,7 +196,7 @@ function buildCards(
   const cardLangCounts: Record<string, number> = {};
   let blockedCount = 0;
   for (const node of model?.nodes ?? []) {
-    const v = classifyBySnippet(node.text, candidates, rung3Resolver);
+    const v = classifyBySnippet(node.text, candidates, francRung3Resolver);
     const isBlocked = v.language !== 'unknown' && blocked.has(v.language);
     if (isBlocked) blockedCount += 1;
     const franc = francCheck(node.text, v, candidates);

--- a/apps/diagnostics/src/lib/page-diagnostics.ts
+++ b/apps/diagnostics/src/lib/page-diagnostics.ts
@@ -14,10 +14,18 @@
  * Local-only: holds a `WeakRef<Element>` highlight map and a current-snapshot
  * store with a subscriber. Nothing is persisted or networked.
  */
-import { classifyBySnippet, classifyDivergence } from '@movar/lang-detect';
+import { classifyDivergence } from '@movar/lang-detect';
+// Dogfooding: the per-snippet classifier comes from the published, zero-dependency
+// `langtell/classify` (ported from `@movar/lang-detect`'s `classifyBySnippet` — same
+// rung ladder, same candidate-relative set-difference). Diagnostics is the safest
+// consumer to swap: a maintainer-only dev extension, not the production conceal path.
+import { classifyBySnippet } from 'langtell/classify';
+import type { Rung3Resolver as LangtellRung3Resolver } from 'langtell/classify';
 // Diagnostics is the maintainer-only dev extension — it keeps franc in-process
 // (the published extension hosts it in the background worker instead), so it
-// pulls the franc oracle + rung-3 resolver from the opt-in /franc subpath.
+// pulls the franc oracle + rung-3 resolver from the opt-in /franc subpath. langtell
+// stays franc-free; movar's `francRung3Resolver` is injected into langtell's
+// classifier via its structurally-compatible `Rung3Resolver` seam.
 import { francOracle, francRung3Resolver } from '@movar/lang-detect/franc';
 import type { LanguageCode, LanguageProfile, SnippetVerdict } from '@movar/lang-detect';
 import { buildModelForHost } from '@movar/page-content/registry';
@@ -176,6 +184,21 @@ function francCheck(
   return { agree: classifyDivergence(v, oracle) !== 'contradict', language: oracle.language };
 }
 
+/**
+ * Adapt `@movar/lang-detect`'s {@link francRung3Resolver} to langtell's
+ * {@link LangtellRung3Resolver} seam. The two resolver types differ only in their
+ * `scoped` parameter: langtell hands its classifier's profiles (where `words` is
+ * optional), while movar's resolver signature requires `words` — a contravariant
+ * mismatch that `exactOptionalPropertyTypes` (correctly) rejects, even though
+ * `francRung3Resolver` reads only `iso6393` at runtime. We bridge it soundly by
+ * defaulting the optional `words` before delegating; no `as`/`any` silencing.
+ */
+const rung3Resolver: LangtellRung3Resolver = (text, scoped) =>
+  francRung3Resolver(
+    text,
+    scoped.map((p) => ({ ...p, words: p.words ?? { function: [], frequent: [] } })),
+  );
+
 /** Classify the page-content model's cards; tally languages + the blocked count. */
 function buildCards(
   model: ReturnType<typeof buildModelForHost>,
@@ -187,7 +210,7 @@ function buildCards(
   const cardLangCounts: Record<string, number> = {};
   let blockedCount = 0;
   for (const node of model?.nodes ?? []) {
-    const v = classifyBySnippet(node.text, candidates, francRung3Resolver);
+    const v = classifyBySnippet(node.text, candidates, rung3Resolver);
     const isBlocked = v.language !== 'unknown' && blocked.has(v.language);
     if (isBlocked) blockedCount += 1;
     const franc = francCheck(node.text, v, candidates);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -84,6 +84,9 @@ importers:
       '@movar/settings':
         specifier: workspace:*
         version: link:../../packages/settings
+      langtell:
+        specifier: ^0.3.0
+        version: 0.3.0(franc@6.2.0)
       lucide-react:
         specifier: ^1.17.0
         version: 1.17.0(react@19.2.6)
@@ -4629,6 +4632,7 @@ packages:
   git-raw-commits@5.0.1:
     resolution: {integrity: sha512-Y+csSm2GD/PCSh6Isd/WiMjNAydu0VBiG9J7EdQsNA5P9uXvLayqjmTsNlK5Gs9IhblFZqOU0yid5Il5JPoLiQ==}
     engines: {node: '>=18'}
+    deprecated: Deprecated and no longer maintained. Use @conventional-changelog/git-client instead.
     hasBin: true
 
   github-slugger@2.0.0:
@@ -5191,6 +5195,15 @@ packages:
   ky@1.14.3:
     resolution: {integrity: sha512-9zy9lkjac+TR1c2tG+mkNSVlyOpInnWdSMiue4F+kq8TwJSgv6o8jhLRg8Ho6SnZ9wOYUq/yozts9qQCfk7bIw==}
     engines: {node: '>=18'}
+
+  langtell@0.3.0:
+    resolution: {integrity: sha512-d3BOKJvwLdU7/X9E+6YJa4wzGcWgvfRtaoUCcHrWgWzqZwUGuQxXwoMHSiLh2nDOuUoG4IoUzefBKKRbkYVzvA==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      franc: ^6.2.0
+    peerDependenciesMeta:
+      franc:
+        optional: true
 
   language-subtag-registry@0.3.23:
     resolution: {integrity: sha512-0K65Lea881pHotoGEa5gDlMxt3pctLi2RplBb7Ezh4rRdLEOtgi7n4EwK9lamnUCkKBqaeKRVebTq6BAxSkpXQ==}
@@ -6817,6 +6830,7 @@ packages:
   tsconfck@3.1.6:
     resolution: {integrity: sha512-ks6Vjr/jEw0P1gmOVwutM3B7fWxoWBL2KRDb1JfqGVawBmO5UsvmWOQFGHBPl5yxYz4eERr19E6L7NMv+Fej4w==}
     engines: {node: ^18 || >=20}
+    deprecated: unmaintained
     hasBin: true
     peerDependencies:
       typescript: ^5.0.0
@@ -12308,6 +12322,10 @@ snapshots:
   kleur@4.1.5: {}
 
   ky@1.14.3: {}
+
+  langtell@0.3.0(franc@6.2.0):
+    optionalDependencies:
+      franc: 6.2.0
 
   language-subtag-registry@0.3.23: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -85,8 +85,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/settings
       langtell:
-        specifier: ^0.3.0
-        version: 0.3.0(franc@6.2.0)
+        specifier: ^0.4.0
+        version: 0.4.0(franc@6.2.0)
       lucide-react:
         specifier: ^1.17.0
         version: 1.17.0(react@19.2.6)
@@ -5196,8 +5196,8 @@ packages:
     resolution: {integrity: sha512-9zy9lkjac+TR1c2tG+mkNSVlyOpInnWdSMiue4F+kq8TwJSgv6o8jhLRg8Ho6SnZ9wOYUq/yozts9qQCfk7bIw==}
     engines: {node: '>=18'}
 
-  langtell@0.3.0:
-    resolution: {integrity: sha512-d3BOKJvwLdU7/X9E+6YJa4wzGcWgvfRtaoUCcHrWgWzqZwUGuQxXwoMHSiLh2nDOuUoG4IoUzefBKKRbkYVzvA==}
+  langtell@0.4.0:
+    resolution: {integrity: sha512-QDMo++XTXc3Vxs6Kn2sbeaok67eM0AuryQ0EdLHcgNAeVQHzwOMhYG5eSc7yZp1P5Dnp6G0rcnnwrpwAakQN6Q==}
     engines: {node: '>=20'}
     peerDependencies:
       franc: ^6.2.0
@@ -12323,7 +12323,7 @@ snapshots:
 
   ky@1.14.3: {}
 
-  langtell@0.3.0(franc@6.2.0):
+  langtell@0.4.0(franc@6.2.0):
     optionalDependencies:
       franc: 6.2.0
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -14,6 +14,7 @@ allowBuilds:
 minimumReleaseAgeExclude:
   - miniflare@4.20260526.0
   - wrangler@4.95.0
+  - langtell@0.3.0
 overrides:
   eslint: ^9.39.4
   # @vitejs/plugin-react@6 is the rolldown-vite-only build: its top-level

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -14,7 +14,7 @@ allowBuilds:
 minimumReleaseAgeExclude:
   - miniflare@4.20260526.0
   - wrangler@4.95.0
-  - langtell@0.3.0
+  - langtell@0.4.0
 overrides:
   eslint: ^9.39.4
   # @vitejs/plugin-react@6 is the rolldown-vite-only build: its top-level


### PR DESCRIPTION
Adopts the published [`langtell`](https://www.npmjs.com/package/langtell) detector in the diagnostics app, replacing the in-repo `@movar/lang-detect` `classifyBySnippet` for that one consumer.

## What changed
- `apps/diagnostics/src/lib/page-diagnostics.ts` now imports `classifyBySnippet` from `langtell/classify` (`langtell@^0.4.0`). `classifyDivergence` / `francOracle` / `francRung3Resolver` still come from `@movar/lang-detect`.
- The franc rung-3 resolver (`francRung3Resolver`) is passed **directly** — langtell 0.4.0 made `classifyBySnippet<P>` / `Rung3Resolver<P>` generic over the profile type, so the earlier typed adapter (which defaulted `words` to dodge a contravariance mismatch under `exactOptionalPropertyTypes`) is gone. No `as`, no `any`.
- Added `apps/diagnostics/src/lib/langtell-equivalence.test.ts` asserting langtell ≡ `@movar/lang-detect` on the `{ language, margin, rung }` verdict across uk/ru/be/bg/en/rung-3/unknown.

## Scope / safety
- **Diagnostics only.** The production conceal path (`content-conceal.ts`, `background.ts`) and `@movar/lang-detect` itself are untouched.
- Verdicts are byte-equivalent (langtell's classifier is a port of `@movar/lang-detect`'s).
- `pnpm --filter @movar/diagnostics typecheck` clean; `test` → **29 passed**.

## Note
`pnpm-workspace.yaml` adds `langtell@0.4.0` to `minimumReleaseAgeExclude` because 0.4.0 is newly published and the supply-chain maturity policy would otherwise block install. Remove that exclude line once 0.4.0 clears the maturity window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
