### PR TITLE
ci(safari): add wrapper-compile and signing-rehearsal gates for the native app

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -434,6 +434,14 @@ jobs:
       - if: steps.check.outputs.skip != 'true'
         run: pnpm --filter @movar/extension build:safari
 
+      # Build + sync the HOST APP's Resources (separate package): host-app.js/.css
+      # and the localized Main.html shells under `Shared (App)/Resources/`, which
+      # the Xcode 'App' target references. build:safari only fills the Extension
+      # Resources, so the archive below fails without this. (Caught by
+      # safari-wrapper.yml, which is the first thing to archive on a fresh runner.)
+      - if: steps.check.outputs.skip != 'true'
+        run: pnpm --filter @movar/safari-host-app build
+
       # Pin the Xcode toolchain to an EXACT version for reproducibility.
       # `runs-on: macos-15` fixes only the image, not its default Xcode, and
       # "newest 16.x" would still drift when the image adds a 16.x point release.

--- a/.github/workflows/safari-signing-rehearsal.yml
+++ b/.github/workflows/safari-signing-rehearsal.yml
@@ -1,0 +1,142 @@
+name: Safari signing rehearsal
+
+# Manual, NON-publishing dry run of the App Store signing path. It archives both
+# schemes with the real Apple Distribution cert, exports the .ipa/.pkg, and runs
+# `altool --validate-app` — which checks the packages against App Store Connect
+# WITHOUT submitting them. This is the pre-release confidence release-safari
+# itself can't give safely: its dispatch path (dry_run=false) publishes for real,
+# so there is no upload-free rehearsal there. Run this before a release whenever
+# you've touched the wrapper, signing config, provisioning, or entitlements.
+#
+# It deliberately does NOT exercise the Developer ID cert / notarization — those
+# only matter for the direct-download .dmg, which has no equivalent App Store
+# pre-flight validator. `safari-wrapper.yml` covers the unsigned compile; this
+# covers signing + export + store validation.
+#
+# It mints/refreshes provisioning profiles in the Apple account (a harmless,
+# reusable side effect of -allowProvisioningUpdates) but submits nothing.
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: safari-signing-rehearsal-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  validate:
+    runs-on: macos-15
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      # Fail loud (not skip-green): you explicitly asked to rehearse signing, so
+      # a missing credential should be an obvious red X, not a silent no-op.
+      - name: Check Apple signing credentials
+        env:
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          APPLE_ASC_KEY_ID: ${{ secrets.APPLE_ASC_KEY_ID }}
+          APPLE_ASC_ISSUER_ID: ${{ secrets.APPLE_ASC_ISSUER_ID }}
+          APPLE_ASC_API_KEY_P8: ${{ secrets.APPLE_ASC_API_KEY_P8 }}
+          APPLE_DIST_CERT_P12_BASE64: ${{ secrets.APPLE_DIST_CERT_P12_BASE64 }}
+          APPLE_DIST_CERT_PASSWORD: ${{ secrets.APPLE_DIST_CERT_PASSWORD }}
+        run: |
+          set -euo pipefail
+          for v in APPLE_TEAM_ID APPLE_ASC_KEY_ID APPLE_ASC_ISSUER_ID \
+            APPLE_ASC_API_KEY_P8 APPLE_DIST_CERT_P12_BASE64 APPLE_DIST_CERT_PASSWORD; do
+            if [ -z "${!v}" ]; then
+              echo "::error::$v is not set — cannot rehearse signing (see docs/safari-deploy.md)"
+              exit 1
+            fi
+          done
+
+      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version-file: .nvmrc
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm --filter @movar/extension build:safari
+
+      # Pin Xcode to the exact version release-safari uses — keep in sync with
+      # release.yml / safari-wrapper.yml (objectVersion 77 = Xcode 16).
+      - name: Select Xcode
+        run: |
+          set -euo pipefail
+          XCODE="/Applications/Xcode_16.4.app"
+          if [ ! -d "$XCODE" ]; then
+            echo "::error::$XCODE not on the runner. Installed:"; ls -d /Applications/Xcode*.app
+            exit 1
+          fi
+          sudo xcode-select -s "$XCODE/Contents/Developer"
+          echo "DEVELOPER_DIR=$XCODE/Contents/Developer" >> "$GITHUB_ENV"
+          xcodebuild -version
+
+      - name: Archive, export, and validate (no upload)
+        env:
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          APPLE_ASC_KEY_ID: ${{ secrets.APPLE_ASC_KEY_ID }}
+          APPLE_ASC_ISSUER_ID: ${{ secrets.APPLE_ASC_ISSUER_ID }}
+          APPLE_ASC_API_KEY_P8: ${{ secrets.APPLE_ASC_API_KEY_P8 }}
+          APPLE_DIST_CERT_P12_BASE64: ${{ secrets.APPLE_DIST_CERT_P12_BASE64 }}
+          APPLE_DIST_CERT_PASSWORD: ${{ secrets.APPLE_DIST_CERT_PASSWORD }}
+          BUILD_NUMBER: ${{ github.run_number }}
+        run: |
+          set -euo pipefail
+          PROJECT="apps/extension/safari/Movar/Movar.xcodeproj"
+          KEY_PATH="$HOME/.private_keys/AuthKey_${APPLE_ASC_KEY_ID}.p8"
+
+          # --- throwaway keychain + Distribution cert (App Store path only) ---
+          KEYCHAIN="$RUNNER_TEMP/movar-signing.keychain-db"
+          KEYCHAIN_PW="$(uuidgen)"
+          security create-keychain -p "$KEYCHAIN_PW" "$KEYCHAIN"
+          security set-keychain-settings -lut 3600 "$KEYCHAIN"
+          security unlock-keychain -p "$KEYCHAIN_PW" "$KEYCHAIN"
+          echo "$APPLE_DIST_CERT_P12_BASE64" | base64 --decode > "$RUNNER_TEMP/dist.p12"
+          security import "$RUNNER_TEMP/dist.p12" -k "$KEYCHAIN" -P "$APPLE_DIST_CERT_PASSWORD" -T /usr/bin/codesign -T /usr/bin/productbuild
+          security set-key-partition-list -S apple-tool:,apple: -k "$KEYCHAIN_PW" "$KEYCHAIN" >/dev/null
+          security list-keychains -d user -s "$KEYCHAIN"
+          security default-keychain -d user -s "$KEYCHAIN"
+
+          # --- App Store Connect API key (profiles + altool validation) ---
+          mkdir -p "$HOME/.private_keys" "$HOME/.appstoreconnect/private_keys"
+          echo "$APPLE_ASC_API_KEY_P8" | base64 --decode > "$KEY_PATH"
+          cp "$KEY_PATH" "$HOME/.appstoreconnect/private_keys/"
+
+          AUTH=( -allowProvisioningUpdates
+            -authenticationKeyPath "$KEY_PATH"
+            -authenticationKeyID "$APPLE_ASC_KEY_ID"
+            -authenticationKeyIssuerID "$APPLE_ASC_ISSUER_ID" )
+          VERSION="$(node -p "require('./apps/extension/package.json').version")"
+          VERS=( MARKETING_VERSION="$VERSION" CURRENT_PROJECT_VERSION="$BUILD_NUMBER" DEVELOPMENT_TEAM="$APPLE_TEAM_ID" )
+
+          # --- archive iOS + macOS ---
+          xcodebuild -project "$PROJECT" -scheme "Movar (iOS)" -configuration Release \
+            -destination 'generic/platform=iOS' -archivePath "$RUNNER_TEMP/Movar-iOS.xcarchive" \
+            "${VERS[@]}" "${AUTH[@]}" archive
+          xcodebuild -project "$PROJECT" -scheme "Movar (macOS)" -configuration Release \
+            -destination 'generic/platform=macOS' -archivePath "$RUNNER_TEMP/Movar-macOS.xcarchive" \
+            "${VERS[@]}" "${AUTH[@]}" archive
+
+          # --- export the App Store packages ---
+          xcodebuild -exportArchive -archivePath "$RUNNER_TEMP/Movar-iOS.xcarchive" \
+            -exportPath "$RUNNER_TEMP/appstore-ios" \
+            -exportOptionsPlist apps/extension/safari/exportOptions/app-store.plist "${AUTH[@]}"
+          xcodebuild -exportArchive -archivePath "$RUNNER_TEMP/Movar-macOS.xcarchive" \
+            -exportPath "$RUNNER_TEMP/appstore-mac" \
+            -exportOptionsPlist apps/extension/safari/exportOptions/app-store.plist "${AUTH[@]}"
+
+          # --- VALIDATE against App Store Connect — the key difference from
+          #     release-safari: --validate-app, never --upload-app. Nothing is
+          #     submitted; this only confirms the packages would be accepted. ---
+          xcrun altool --validate-app -t ios \
+            -f "$(ls "$RUNNER_TEMP"/appstore-ios/*.ipa)" \
+            --apiKey "$APPLE_ASC_KEY_ID" --apiIssuer "$APPLE_ASC_ISSUER_ID"
+          xcrun altool --validate-app -t macos \
+            -f "$(ls "$RUNNER_TEMP"/appstore-mac/*.pkg)" \
+            --apiKey "$APPLE_ASC_KEY_ID" --apiIssuer "$APPLE_ASC_ISSUER_ID"
+
+          echo "Safari signing rehearsal OK — both packages validated against App Store Connect; nothing submitted."

--- a/.github/workflows/safari-signing-rehearsal.yml
+++ b/.github/workflows/safari-signing-rehearsal.yml
@@ -60,6 +60,10 @@ jobs:
 
       - run: pnpm install --frozen-lockfile
       - run: pnpm --filter @movar/extension build:safari
+      # Host-app Resources live in a separate package from the web extension
+      # (host-app.js/.css + localized Main.html under `Shared (App)/Resources/`);
+      # the Xcode 'App' target references them, so archiving needs them synced too.
+      - run: pnpm --filter @movar/safari-host-app build
 
       # Pin Xcode to the exact version release-safari uses — keep in sync with
       # release.yml / safari-wrapper.yml (objectVersion 77 = Xcode 16).

--- a/.github/workflows/safari-wrapper.yml
+++ b/.github/workflows/safari-wrapper.yml
@@ -1,0 +1,99 @@
+name: Safari wrapper
+
+# The native Safari app + extension (Xcode project, schemes, Swift, Info/export
+# plists) is otherwise compiled only by `release-safari` at release time — and
+# that job skips when Apple secrets are absent. That leaves the wrapper with no
+# build coverage between releases: a broken project.pbxproj, a renamed resource
+# folder reference, or Swift that no longer compiles would surface only on
+# release day. This job compiles both schemes (ad-hoc, unsigned) whenever the
+# wrapper or its resource-sync scripts change, turning release-day breakage into
+# PR-time breakage.
+#
+# It's path-filtered because macOS runner minutes cost ~10x Linux (the reason
+# the native build is release-only in the first place). Changes that only touch
+# the web-extension JS are already covered by the Linux `build:safari` leg in
+# ci.yml, so they don't need to spin up a Mac here.
+#
+# NOTE: because it is path-filtered, this workflow does NOT run on every PR. Do
+# not mark it a required status check in branch protection — a required check
+# that never triggers blocks the merge. It is an advisory gate for wrapper edits.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'apps/extension/safari/**'
+      - 'apps/extension/scripts/build-safari-app.mts'
+      - 'apps/extension/scripts/sync-safari-resources.mts'
+      - 'apps/extension/wxt.config.ts'
+      - 'apps/extension/package.json'
+      - '.github/workflows/safari-wrapper.yml'
+  pull_request:
+    paths:
+      - 'apps/extension/safari/**'
+      - 'apps/extension/scripts/build-safari-app.mts'
+      - 'apps/extension/scripts/sync-safari-resources.mts'
+      - 'apps/extension/wxt.config.ts'
+      - 'apps/extension/package.json'
+      - '.github/workflows/safari-wrapper.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+# Cancel superseded runs on the same ref. macOS minutes are the whole reason
+# this workflow is path-filtered, so don't keep burning them on a commit a newer
+# push already obsoletes.
+concurrency:
+  group: safari-wrapper-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: macos-15
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version-file: .nvmrc
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      # Populate the gitignored Extension Resources (empty on a fresh runner):
+      # compiling against an empty folder reference would produce an .appex with
+      # no manifest. Same first step the release job runs.
+      - run: pnpm --filter @movar/extension build:safari
+
+      # Pin Xcode to the exact version release-safari uses — keep in sync with
+      # release.yml / safari-signing-rehearsal.yml (objectVersion 77 = Xcode 16).
+      - name: Select Xcode
+        run: |
+          set -euo pipefail
+          XCODE="/Applications/Xcode_16.4.app"
+          if [ ! -d "$XCODE" ]; then
+            echo "::error::$XCODE not on the runner. Installed:"; ls -d /Applications/Xcode*.app
+            exit 1
+          fi
+          sudo xcode-select -s "$XCODE/Contents/Developer"
+          echo "DEVELOPER_DIR=$XCODE/Contents/Developer" >> "$GITHUB_ENV"
+          xcodebuild -version
+
+      # Unsigned ARCHIVE of both schemes — not just `build`. Archiving runs the
+      # install/packaging and product-validation phases a plain build skips, so
+      # it mirrors what release-safari does minus the signing/upload. No secrets,
+      # no keychain, nothing leaves the runner.
+      - name: Archive macOS + iOS schemes (unsigned)
+        run: |
+          set -euo pipefail
+          PROJECT="apps/extension/safari/Movar/Movar.xcodeproj"
+          for scheme in "Movar (macOS)" "Movar (iOS)"; do
+            dest='generic/platform=macOS'
+            case "$scheme" in *'(iOS)'*) dest='generic/platform=iOS' ;; esac
+            echo "::group::xcodebuild archive $scheme ($dest)"
+            xcodebuild -project "$PROJECT" -scheme "$scheme" -configuration Release \
+              -destination "$dest" -archivePath "$RUNNER_TEMP/${scheme// /_}.xcarchive" \
+              CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO archive
+            echo "::endgroup::"
+          done

--- a/.github/workflows/safari-wrapper.yml
+++ b/.github/workflows/safari-wrapper.yml
@@ -66,6 +66,13 @@ jobs:
       # no manifest. Same first step the release job runs.
       - run: pnpm --filter @movar/extension build:safari
 
+      # Populate the HOST APP's gitignored Resources too. These are a SEPARATE
+      # package from the web extension — host-app.js/.css and the localized
+      # Main.html shells under `Shared (App)/Resources/`, which the Xcode 'App'
+      # target references. build:safari only fills `Shared (Extension)/Resources`,
+      # so without this the archive fails with a missing-resource lstat error.
+      - run: pnpm --filter @movar/safari-host-app build
+
       # Pin Xcode to the exact version release-safari uses — keep in sync with
       # release.yml / safari-signing-rehearsal.yml (objectVersion 77 = Xcode 16).
       - name: Select Xcode


### PR DESCRIPTION
The native Safari app/extension is otherwise built only by `release-safari`, which **skips when Apple secrets are absent** — so wrapper breakage (`project.pbxproj`, resource-folder refs, Swift that no longer compiles) surfaces only on release day. These two gates move that breakage earlier.

## Workflows
- **`safari-wrapper.yml`** — path-filtered, unsigned `xcodebuild archive` of both schemes (macOS + iOS) on `macos-15`, whenever the wrapper or its resource-sync scripts change. Uses `archive` (not `build`) so it exercises the install/packaging/validation phases the release job runs, minus signing/upload. No secrets, no keychain.
  - ⚠️ It's **path-filtered, so it does not run on every PR** — must **not** be marked a required status check (a required check that never triggers blocks merges). Advisory gate for wrapper edits only.
- **`safari-signing-rehearsal.yml`** — manual (`workflow_dispatch`) non-publishing dry run. Archives with the real Distribution cert, exports the `.ipa`/`.pkg`, and runs `altool --validate-app` (**never `--upload-app`**) against App Store Connect, in a throwaway keychain. Fails loud on missing Apple secrets. Mints/refreshes provisioning profiles (harmless side effect of `-allowProvisioningUpdates`) but submits nothing.

## Safety / hygiene
- Both actions are **SHA-pinned**; both `permissions: contents: read`; both pin **Xcode 16.4** to match `release.yml`.
- All referenced paths verified present (`Movar.xcodeproj`, the two `scripts/*.mts`, `exportOptions/app-store.plist`, `build:safari`).

## Verification caveat
These are **macOS-only build gates** — they can't be exercised locally or on the Linux CI. First real proof is a run on GitHub's `macos-15` runners (the wrapper job will trigger on this PR since it touches its own workflow file; the rehearsal is dispatch-only and needs the Apple secrets).

🤖 Generated with [Claude Code](https://claude.com/claude-code)