### PR TITLE
feat(redirect): recover from a stuck language switch (guard TTL + popup retry)

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 [![Stand With Ukraine](https://raw.githubusercontent.com/vshymanskyy/StandWithUkraine/main/badges/StandWithUkraine.svg)](https://stand-with-ukraine.pp.ua)
 ![code health: 82 (B)](https://img.shields.io/badge/code_health-82_%28B%29-green)
 ![coverage: 94% lines · 86% branches](https://img.shields.io/badge/coverage-94%25_lines_%C2%B7_86%25_branches-green)
-![content.js: 35 KB (source graph)](https://img.shields.io/badge/content.js-35_KB_%28source_graph%29-blue)
+![content.js: 36 KB (source graph)](https://img.shields.io/badge/content.js-36_KB_%28source_graph%29-blue)
 ![license: MIT](https://img.shields.io/badge/license-MIT-green)
 ![promises: 3/3 kept](https://img.shields.io/badge/promises-3%2F3_kept-brightgreen)
 
@@ -100,7 +100,7 @@ length-and-register caps.
 
 - **Code health** `82 (B)` — fallow maintainability score, 0-100 with an A-F grade, over complexity, duplication, dead code, and churn; refreshed by `pnpm metrics`.
 - **Coverage** `94% lines · 86% branches` — Vitest (v8) line and branch coverage, aggregated across the test-bearing workspace projects weighted by size; snapshotted by `pnpm metrics`.
-- **Content.js** `35 KB (source graph)` — source-graph size of the always-on content script (the esbuild import graph of content.ts, measured by `check:content-bundle`; the real emitted artifact is ~31 KB, gated at 40 KB by wxt.config.ts) — franc and the language profiles live in the background worker, not here; snapshotted by `pnpm metrics`.
+- **Content.js** `36 KB (source graph)` — source-graph size of the always-on content script (the esbuild import graph of content.ts, measured by `check:content-bundle`; the real emitted artifact is ~31 KB, gated at 40 KB by wxt.config.ts) — franc and the language profiles live in the background worker, not here; snapshotted by `pnpm metrics`.
 - **License** `MIT` — SPDX identifier read from the root `LICENSE` file.
 - **Promises** `3/3 kept` — public claims from movar.fyi (apps/marketing) verified against the code each build — `pnpm check:readme` fails if any breaks:
   - ✓ **Open source** — root LICENSE is MIT, an OSI-approved open-source license _(marketing: hero badge + footer)_

--- a/apps/extension/src/entrypoints/__tests__/content.test.ts
+++ b/apps/extension/src/entrypoints/__tests__/content.test.ts
@@ -12,7 +12,7 @@ import type {
 } from '../../lib/capability-loader';
 import type { ContentRuntime } from '../../lib/content-runtime';
 import { isSupportedProtocol } from '../../lib/content-runtime';
-import { getPickerChoice } from '../../lib/session-choice';
+import { getPickerChoice, recordPickerChoice } from '../../lib/session-choice';
 import { clearAttempt, getAttemptedUrls, markAttempt } from '../../lib/loop-guard';
 import type { Picker } from '@movar/lang-pickers/types';
 
@@ -210,6 +210,30 @@ describe('popup ↔ content message bridge', () => {
     const sendResponse = vi.fn();
     triggerMessage({ type: 'movar:restoreHidden' }, {}, sendResponse);
     expect((sendResponse.mock.calls[0]![0] as HiddenSummary).userOverride).toBe(true);
+  });
+
+  it('reports switchSuppressed while the loop guard holds attempt history', () => {
+    sessionStorage.clear();
+    expect(runtime.getHiddenSummary().switchSuppressed).toBe(false);
+    markAttempt('https://example.com/ru');
+    expect(runtime.getHiddenSummary().switchSuppressed).toBe(true);
+  });
+
+  it('movar:retrySwitch clears both session guards so the switch can retry', () => {
+    // Arm both suppressors, as a prior redirect "hiccup" + a manual picker
+    // click to the blocked language would.
+    sessionStorage.clear();
+    markAttempt('https://example.com/ru');
+    recordPickerChoice(location.hostname, 'ru');
+
+    runtime.installMessageBridge();
+    const sendResponse = vi.fn();
+    triggerMessage({ type: 'movar:retrySwitch' }, {}, sendResponse);
+
+    expect(getAttemptedUrls()).toEqual([]);
+    expect(getPickerChoice(location.hostname)).toBeNull();
+    expect(sendResponse).toHaveBeenCalledOnce();
+    expect((sendResponse.mock.calls[0]![0] as HiddenSummary).switchSuppressed).toBe(false);
   });
 
   it('ignores message types it does not own', () => {

--- a/apps/extension/src/entrypoints/popup/App.test.tsx
+++ b/apps/extension/src/entrypoints/popup/App.test.tsx
@@ -59,6 +59,7 @@ const fullHidden: HiddenSummary = {
   feedHidden: 0,
   pageLang: 'ru',
   userOverride: false,
+  switchSuppressed: false,
 };
 
 const NO_PAUSE: PauseState = { paused: false, until: null, indefinite: false };
@@ -73,6 +74,7 @@ function hid(o: Partial<HiddenSummary> = {}): HiddenSummary {
     feedHidden: 0,
     pageLang: null,
     userOverride: false,
+    switchSuppressed: false,
     ...o,
   };
 }
@@ -179,6 +181,27 @@ describe('App', () => {
     expect(report).toBeTruthy();
     // It's a mailto with the blocked-site prompt — no network.
     expect(report.closest('a')?.getAttribute('href')).toMatch(/^mailto:/);
+    // switchSuppressed is false here (fullHidden default) → no retry button; the
+    // site simply has no target language to switch to.
+    expect(screen.queryByRole('button', { name: messagesEn.pageStatus.retrySwitch })).toBeNull();
+  });
+
+  it('offers "Try switching again" on a blocked page when a session guard is suppressing the switch', async () => {
+    // switchSuppressed → a prior hiccup or a manual pick is holding the switch
+    // back, so the retry (clear the guards + reload) can actually do something.
+    spyTabsSendMessage().mockResolvedValue({
+      ...fullHidden,
+      languages: [],
+      pageLang: 'ru',
+      switchSuppressed: true,
+    });
+    await seed({ priority: ['en'], blocked: ['ru'], contentModification: false }, 'https://x.com/');
+
+    render(<App />);
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: messagesEn.pageStatus.retrySwitch })).toBeTruthy();
+    });
   });
 
   it('hides the contextual report when the page is served (not blocked)', async () => {

--- a/apps/extension/src/entrypoints/popup/App.tsx
+++ b/apps/extension/src/entrypoints/popup/App.tsx
@@ -1,4 +1,4 @@
-import { Bug, Flag, Settings } from 'lucide-react';
+import { Bug, Flag, RotateCw, Settings } from 'lucide-react';
 import { browser } from 'wxt/browser';
 import type { MovarSettings } from '@movar/settings';
 import { FEEDBACK_URL, SUPPORT_EMAIL } from '@movar/brand';
@@ -12,6 +12,7 @@ import type { HeroState } from './StatusHeader';
 import { HiddenPanel } from './HiddenPanel';
 import { PauseControls } from './PauseControls';
 import { ContentToggle } from '@movar/options-ui';
+import { Button } from '@movar/ui';
 import { browserInfo, buildReportMailto, osInfo } from './report-mailto';
 import type { ReportContext } from './report-mailto';
 import { usePopupController } from './use-popup-controller';
@@ -157,6 +158,7 @@ function PopupBody({
   onPause,
   onResume,
   onRestore,
+  onRetrySwitch,
   onReloadTab,
   onEnableForSite,
   onOpenSettings,
@@ -194,6 +196,8 @@ function PopupBody({
         <BlockedSiteReport
           t={t}
           ctx={buildReportContext({ settings, pause, reportUrl, locale, exempt })}
+          switchSuppressed={hidden?.switchSuppressed ?? false}
+          onRetrySwitch={onRetrySwitch}
         />
       ) : null}
 
@@ -291,16 +295,35 @@ function GearIcon() {
   return <Settings size={12} aria-hidden="true" className="flex-shrink-0" />;
 }
 
-/** Contextual "this site ignored my language" report — rendered only on a
- *  `blocked` hero (see PopupBody). Reuses {@link buildReportMailto} with the
- *  blocked-site prompt; still `mailto:`-only, no network. The footer keeps the
- *  generic report link for every other state. */
-function BlockedSiteReport({ t, ctx }: Readonly<{ t: Messages; ctx: ReportContext }>) {
+/** Contextual band rendered only on a `blocked` hero (see PopupBody). When a
+ *  session guard is actively suppressing the switch (`switchSuppressed`), it
+ *  leads with a "Try switching again" button that clears the guard and reloads
+ *  the tab; the site simply having no target language leaves only the mailto
+ *  report. The report reuses {@link buildReportMailto} with the blocked-site
+ *  prompt — still `mailto:`-only, no network. The footer keeps the generic
+ *  report link for every other state. */
+function BlockedSiteReport({
+  t,
+  ctx,
+  switchSuppressed,
+  onRetrySwitch,
+}: Readonly<{
+  t: Messages;
+  ctx: ReportContext;
+  switchSuppressed: boolean;
+  onRetrySwitch: () => void;
+}>) {
   const href = buildReportMailto(SUPPORT_EMAIL, t.report, ctx, {
     bodyPrompt: t.report.blockedSite.prompt,
   });
   return (
-    <div className="border-border border-b px-[18px] py-2.5">
+    <div className="border-border flex flex-col gap-2.5 border-b px-[18px] py-2.5">
+      {switchSuppressed ? (
+        <Button variant="secondary" size="sm" fullWidth onClick={onRetrySwitch}>
+          <RotateCw size={13} aria-hidden="true" className="flex-shrink-0" />
+          {t.pageStatus.retrySwitch}
+        </Button>
+      ) : null}
       <a
         href={href}
         className="text-ink-soft hover:text-ink-strong inline-flex items-center gap-1.5 text-[12.5px] transition-colors"

--- a/apps/extension/src/entrypoints/popup/HiddenPanel.test.tsx
+++ b/apps/extension/src/entrypoints/popup/HiddenPanel.test.tsx
@@ -22,6 +22,7 @@ function summary(overrides: Partial<HiddenSummary> = {}): HiddenSummary {
     feedHidden: 0,
     pageLang: null,
     userOverride: false,
+    switchSuppressed: false,
     ...overrides,
   };
 }

--- a/apps/extension/src/entrypoints/popup/StatusHeader.test.tsx
+++ b/apps/extension/src/entrypoints/popup/StatusHeader.test.tsx
@@ -25,6 +25,7 @@ function hiddenSummary(overrides: Partial<HiddenSummary> = {}): HiddenSummary {
     feedHidden: 0,
     pageLang: null,
     userOverride: false,
+    switchSuppressed: false,
     ...overrides,
   };
 }

--- a/apps/extension/src/entrypoints/popup/use-popup-controller.test.ts
+++ b/apps/extension/src/entrypoints/popup/use-popup-controller.test.ts
@@ -27,6 +27,7 @@ const hiddenSummary: HiddenSummary = {
   feedHidden: 0,
   pageLang: 'ru',
   userOverride: false,
+  switchSuppressed: false,
 };
 
 /** Read the enforced settings back out of sync storage. */
@@ -279,6 +280,24 @@ describe('onReloadTab', () => {
     await waitFor(() => {
       expect(closeSpy).toHaveBeenCalledTimes(1);
     });
+  });
+});
+
+describe('onRetrySwitch', () => {
+  it('asks the content script to clear its guards, then reloads and closes', async () => {
+    const { result } = await mount({ priority: ['en'] });
+
+    result.current.onRetrySwitch();
+    await flushEffects();
+
+    await waitFor(() => {
+      expect(sendMessageSpy).toHaveBeenCalledWith(expect.any(Number), {
+        type: 'movar:retrySwitch',
+      });
+    });
+    // A fresh document_start pass (post-reload) is what re-runs the switch ladder.
+    expect(reloadSpy).toHaveBeenCalledTimes(1);
+    expect(closeSpy).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/apps/extension/src/entrypoints/popup/use-popup-controller.ts
+++ b/apps/extension/src/entrypoints/popup/use-popup-controller.ts
@@ -68,6 +68,15 @@ async function reloadActiveTab(): Promise<void> {
   window.close();
 }
 
+// "Try switching again": clear the active tab's session guards (loop-guard
+// history + this host's picker choice) via the content script, then reload so a
+// fresh document_start pass re-runs the switch ladder. Module-scoped — closes
+// over no component state; mirrors reloadActiveTab.
+async function retrySwitchInActiveTab(): Promise<void> {
+  await sendToActiveTab({ type: 'movar:retrySwitch' });
+  await reloadActiveTab();
+}
+
 /** The popup's live read-model: the four state slots plus the setters the
  *  mutation layer writes through. Separated from the controller so the
  *  bootstrap-on-mount wiring is one cohesive unit and the handlers below read
@@ -154,6 +163,8 @@ export interface PopupController {
   onPause: (duration: PauseDuration) => void;
   onResume: () => void;
   onRestore: () => void;
+  /** Clear the tab's session guards and reload so Movar re-attempts the switch. */
+  onRetrySwitch: () => void;
   onReloadTab: () => void;
   onEnableForSite: () => void;
   onOpenSettings: () => void;
@@ -250,6 +261,7 @@ export function usePopupController(): PopupController {
     onPause: (duration) => void handlePause(duration),
     onResume: () => void handleResume(),
     onRestore: () => void handleRestore(),
+    onRetrySwitch: () => void retrySwitchInActiveTab(),
     onReloadTab: () => void reloadActiveTab(),
     onEnableForSite: () => void handleEnableForSite(),
     onOpenSettings: () => void openSettings(),

--- a/apps/extension/src/lib/content-runtime.ts
+++ b/apps/extension/src/lib/content-runtime.ts
@@ -25,9 +25,15 @@ import type { ConcealFeatureModule, ProvisionedCapabilityModules } from './capab
 import { resolveNeeds } from './capabilities';
 import type { CapabilityNeeds } from './capabilities';
 import { reactToSettingsChange } from './settings-reaction';
-import { clearAttempt, hasAttemptedNavTo, markAttempt, recentlyAttemptedHere } from './loop-guard';
+import {
+  clearAttempt,
+  getAttemptedUrls,
+  hasAttemptedNavTo,
+  markAttempt,
+  recentlyAttemptedHere,
+} from './loop-guard';
 import { getPauseState, isHostSnoozed, onPauseChange, onSnoozeChange } from './pause';
-import { getPickerChoice, recordPickerChoice } from './session-choice';
+import { clearPickerChoice, getPickerChoice, recordPickerChoice } from './session-choice';
 import { getSettings, onSettingsChange, setSettings } from './settings';
 import { applyStrategy } from './strategy';
 import type { StrategyContext } from './strategy';
@@ -105,7 +111,24 @@ function handlePickerClickCapture(e: MouseEvent): void {
 }
 
 function getHiddenSummary(): HiddenSummary {
-  return buildHiddenSummary(document, { pageLang: lastPageLang, userOverride });
+  return buildHiddenSummary(document, {
+    pageLang: lastPageLang,
+    userOverride,
+    switchSuppressed: isSwitchSuppressed(),
+  });
+}
+
+/** True when a session-scoped guard would currently block a language switch on
+ *  this page: the loop guard holds attempt history (a prior redirect "hiccup"),
+ *  or a live picker choice for this host matches the detected page language. The
+ *  popup shows "Try switching again" only in this state — on a site that simply
+ *  serves a blocked language with no way out, nothing is suppressed and no retry
+ *  is offered. */
+function isSwitchSuppressed(): boolean {
+  return (
+    getAttemptedUrls().length > 0 ||
+    (lastPageLang != null && getPickerChoice(location.hostname) === lastPageLang)
+  );
 }
 
 /** "Show everything on this page" — reveal every concealed card and undo all
@@ -541,6 +564,15 @@ function installMessageBridge(): void {
     'movar:getHidden': () => getHiddenSummary(),
     'movar:restoreHidden': () => {
       restoreAll();
+      return getHiddenSummary();
+    },
+    'movar:retrySwitch': () => {
+      // Drop both session guards so the next apply re-attempts the switch from a
+      // clean slate. The popup reloads the tab right after this reply, and that
+      // fresh document_start pass is what re-runs the switch ladder — here we
+      // only clear the suppressors (loop-guard history + this host's picker choice).
+      clearAttempt();
+      clearPickerChoice(location.hostname);
       return getHiddenSummary();
     },
   };

--- a/apps/extension/src/lib/hidden-summary.test.ts
+++ b/apps/extension/src/lib/hidden-summary.test.ts
@@ -7,13 +7,20 @@ afterEach(() => {
 
 describe('buildHiddenSummary', () => {
   it('reports an empty summary for a pristine page, threading pageLang + userOverride through', () => {
-    expect(buildHiddenSummary(document, { pageLang: 'uk', userOverride: false })).toEqual({
+    expect(
+      buildHiddenSummary(document, {
+        pageLang: 'uk',
+        userOverride: false,
+        switchSuppressed: false,
+      }),
+    ).toEqual({
       languages: [],
       containers: 0,
       feedCurtained: 0,
       feedHidden: 0,
       pageLang: 'uk',
       userOverride: false,
+      switchSuppressed: false,
     });
   });
 
@@ -23,16 +30,18 @@ describe('buildHiddenSummary', () => {
       <a data-movar-hidden="not-in-priority" href="/ru/y" hreflang="ru">ru again</a>
       <a data-movar-hidden="not-in-priority" href="/uk/x" hreflang="uk">uk</a>
     `;
-    expect(buildHiddenSummary(document, { pageLang: null, userOverride: false }).languages).toEqual(
-      ['ru', 'uk'],
-    );
+    expect(
+      buildHiddenSummary(document, { pageLang: null, userOverride: false, switchSuppressed: false })
+        .languages,
+    ).toEqual(['ru', 'uk']);
   });
 
   it('ignores hidden elements whose reason is not "not-in-priority"', () => {
     document.body.innerHTML = `<a data-movar-hidden="content-filter:ru" href="/ru" hreflang="ru">x</a>`;
-    expect(buildHiddenSummary(document, { pageLang: null, userOverride: false }).languages).toEqual(
-      [],
-    );
+    expect(
+      buildHiddenSummary(document, { pageLang: null, userOverride: false, switchSuppressed: false })
+        .languages,
+    ).toEqual([]);
   });
 
   it('counts collapsed picker containers (curtain hosts marked picker-container)', () => {
@@ -41,9 +50,10 @@ describe('buildHiddenSummary', () => {
       <div data-movar-curtain data-movar-kind="picker-container"></div>
       <div data-movar-curtain data-movar-kind="tooltip"></div>
     `;
-    expect(buildHiddenSummary(document, { pageLang: null, userOverride: false }).containers).toBe(
-      2,
-    );
+    expect(
+      buildHiddenSummary(document, { pageLang: null, userOverride: false, switchSuppressed: false })
+        .containers,
+    ).toBe(2);
   });
 
   it('splits feed cards into curtained (blurred) and hidden (hard-hidden) channels', () => {
@@ -52,14 +62,26 @@ describe('buildHiddenSummary', () => {
       <div data-movar-hidden="content-filter:ru"></div>
       <div data-movar-hidden="content-filter:be"></div>
     `;
-    const s = buildHiddenSummary(document, { pageLang: null, userOverride: false });
+    const s = buildHiddenSummary(document, {
+      pageLang: null,
+      userOverride: false,
+      switchSuppressed: false,
+    });
     expect(s.feedCurtained).toBe(1);
     expect(s.feedHidden).toBe(2);
   });
 
   it('passes the userOverride flag through verbatim', () => {
-    expect(buildHiddenSummary(document, { pageLang: null, userOverride: true }).userOverride).toBe(
-      true,
-    );
+    expect(
+      buildHiddenSummary(document, { pageLang: null, userOverride: true, switchSuppressed: false })
+        .userOverride,
+    ).toBe(true);
+  });
+
+  it('passes the switchSuppressed flag through verbatim', () => {
+    expect(
+      buildHiddenSummary(document, { pageLang: null, userOverride: false, switchSuppressed: true })
+        .switchSuppressed,
+    ).toBe(true);
   });
 });

--- a/apps/extension/src/lib/hidden-summary.ts
+++ b/apps/extension/src/lib/hidden-summary.ts
@@ -9,6 +9,8 @@ interface HiddenSummaryContext {
   pageLang: LanguageCode | null;
   /** True after the user pressed "Show all". */
   userOverride: boolean;
+  /** True when a session guard is currently suppressing a switch on this tab. */
+  switchSuppressed: boolean;
 }
 
 /**
@@ -47,5 +49,6 @@ export function buildHiddenSummary(doc: Document, ctx: HiddenSummaryContext): Hi
     feedHidden,
     pageLang: ctx.pageLang,
     userOverride: ctx.userOverride,
+    switchSuppressed: ctx.switchSuppressed,
   };
 }

--- a/apps/extension/src/lib/loop-guard.test.ts
+++ b/apps/extension/src/lib/loop-guard.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   clearAttempt,
   getAttemptedUrls,
@@ -6,6 +6,7 @@ import {
   markAttempt,
   recentlyAttemptedHere,
 } from './loop-guard';
+import { SUPPRESSION_TTL_MS } from './time';
 
 const URL_A = 'https://example.com/uk/foo';
 const URL_B = 'https://example.com/en/foo';
@@ -120,5 +121,32 @@ describe('loop-guard — malformed storage', () => {
   it('filters out non-string entries from an otherwise valid array', () => {
     sessionStorage.setItem(ATTEMPT_KEY, JSON.stringify([URL_A, 42, URL_B, null]));
     expect(getAttemptedUrls()).toEqual([URL_A, URL_B]);
+  });
+});
+
+describe('loop-guard — TTL expiry (never a permanent block)', () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+
+  it('keeps an attempt within the TTL window', () => {
+    markAttempt(URL_A);
+    vi.advanceTimersByTime(SUPPRESSION_TTL_MS - 1);
+    expect(recentlyAttemptedHere(URL_A)).toBe(true);
+  });
+
+  it('drops an attempt once the TTL elapses, so the switch retries', () => {
+    markAttempt(URL_A);
+    vi.advanceTimersByTime(SUPPRESSION_TTL_MS);
+    expect(recentlyAttemptedHere(URL_A)).toBe(false);
+    expect(getAttemptedUrls()).toEqual([]);
+  });
+
+  it('expires per-entry: a later attempt outlives an earlier one', () => {
+    markAttempt(URL_A);
+    vi.advanceTimersByTime(SUPPRESSION_TTL_MS / 2);
+    markAttempt(URL_B);
+    // URL_A now crosses the TTL while URL_B (marked later) is still live.
+    vi.advanceTimersByTime(SUPPRESSION_TTL_MS / 2);
+    expect(getAttemptedUrls()).toEqual([URL_B]);
   });
 });

--- a/apps/extension/src/lib/loop-guard.ts
+++ b/apps/extension/src/lib/loop-guard.ts
@@ -64,6 +64,25 @@ function isAttempt(item: unknown): item is Attempt {
   );
 }
 
+/** Coerce one raw parsed array element into a live attempt, or null to drop it:
+ *  legacy array-of-strings entries (no timestamp) are stamped fresh; new
+ *  `{url,ts}` entries are kept only while unexpired. */
+function toLiveEntry(item: unknown, now: number): Attempt | null {
+  if (typeof item === 'string') return { url: item, ts: now };
+  if (isAttempt(item) && now - item.ts < SUPPRESSION_TTL_MS) return item;
+  return null;
+}
+
+/** Parse a JSON-array blob, returning [] on malformed JSON or a non-array. */
+function parseArray(raw: string): unknown[] {
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    return Array.isArray(parsed) ? parsed : [];
+  } catch {
+    return [];
+  }
+}
+
 /** Parse the raw blob into live attempts: migrate the two legacy formats (a
  *  bare URL string, and a JSON array of URL strings) by stamping them with the
  *  current time — treated as fresh so an in-progress loop survives an upgrade —
@@ -74,20 +93,10 @@ function readEntries(): Attempt[] {
   const now = Date.now();
   // Legacy single-URL format: bare string, not JSON. Migrate inline.
   if (!raw.startsWith('[')) return [{ url: raw, ts: now }];
-  let parsed: unknown;
-  try {
-    parsed = JSON.parse(raw);
-  } catch {
-    return [];
-  }
-  if (!Array.isArray(parsed)) return [];
-  const out: Attempt[] = [];
-  for (const item of parsed) {
-    // Legacy array-of-strings: stamp as fresh. New {url,ts}: keep if unexpired.
-    if (typeof item === 'string') out.push({ url: item, ts: now });
-    else if (isAttempt(item) && now - item.ts < SUPPRESSION_TTL_MS) out.push(item);
-  }
-  return out;
+  return parseArray(raw).flatMap((item) => {
+    const entry = toLiveEntry(item, now);
+    return entry ? [entry] : [];
+  });
 }
 
 export function getAttemptedUrls(): string[] {

--- a/apps/extension/src/lib/loop-guard.ts
+++ b/apps/extension/src/lib/loop-guard.ts
@@ -13,10 +13,21 @@
  * previous URL, but we're never on it when we check.
  *
  * State lives in `sessionStorage` so it scopes to the tab and clears on
- * tab close. The legacy single-URL format (`movar:redirectedFrom` = bare
- * string) is migrated inline on read so users upgrading mid-loop recover
+ * tab close. Each entry also carries a timestamp and self-expires after
+ * `SUPPRESSION_TTL_MS`, so a long-lived or repeatedly-reloaded tab retries
+ * after the window instead of staying blocked forever. Two legacy on-disk
+ * formats — a bare URL string and a JSON array of URL strings — are migrated
+ * inline on read (stamped as fresh) so users upgrading mid-loop recover
  * without manual storage clearing.
  */
+
+import { SUPPRESSION_TTL_MS } from './time';
+
+/** One recorded redirect attempt: the URL we redirected FROM and when. */
+interface Attempt {
+  url: string;
+  ts: number;
+}
 
 const ATTEMPT_KEY = 'movar:redirectedFrom';
 /** Older builds wrote a binary flag at this key — sweep it on clear. */
@@ -43,18 +54,44 @@ function writeStorage(value: string): void {
   }
 }
 
-export function getAttemptedUrls(): string[] {
+/** Narrow an untrusted parsed array element to a timestamped attempt. */
+function isAttempt(item: unknown): item is Attempt {
+  return (
+    typeof item === 'object' &&
+    item !== null &&
+    typeof (item as Attempt).url === 'string' &&
+    typeof (item as Attempt).ts === 'number'
+  );
+}
+
+/** Parse the raw blob into live attempts: migrate the two legacy formats (a
+ *  bare URL string, and a JSON array of URL strings) by stamping them with the
+ *  current time — treated as fresh so an in-progress loop survives an upgrade —
+ *  and drop any entry past the TTL. */
+function readEntries(): Attempt[] {
   const raw = readStorage();
   if (raw == null || raw === '') return [];
+  const now = Date.now();
   // Legacy single-URL format: bare string, not JSON. Migrate inline.
-  if (!raw.startsWith('[')) return [raw];
+  if (!raw.startsWith('[')) return [{ url: raw, ts: now }];
+  let parsed: unknown;
   try {
-    const parsed: unknown = JSON.parse(raw);
-    if (!Array.isArray(parsed)) return [];
-    return parsed.filter((x): x is string => typeof x === 'string');
+    parsed = JSON.parse(raw);
   } catch {
     return [];
   }
+  if (!Array.isArray(parsed)) return [];
+  const out: Attempt[] = [];
+  for (const item of parsed) {
+    // Legacy array-of-strings: stamp as fresh. New {url,ts}: keep if unexpired.
+    if (typeof item === 'string') out.push({ url: item, ts: now });
+    else if (isAttempt(item) && now - item.ts < SUPPRESSION_TTL_MS) out.push(item);
+  }
+  return out;
+}
+
+export function getAttemptedUrls(): string[] {
+  return readEntries().map((e) => e.url);
 }
 
 /** True if the current URL is one we previously redirected FROM. The
@@ -69,11 +106,14 @@ export function hasAttemptedNavTo(href: string): boolean {
   return getAttemptedUrls().includes(href);
 }
 
-/** Record the current URL as one we just initiated a redirect from. */
+/** Record the current URL as one we just initiated a redirect from, stamped
+ *  with the current time for TTL expiry. Re-marking an already-tracked URL is a
+ *  no-op (its original timestamp stands, so the backoff counts from the first
+ *  attempt). Writing here also persists the migrated/pruned entries. */
 export function markAttempt(href: string = location.href): void {
-  const urls = getAttemptedUrls();
-  if (urls.includes(href)) return;
-  const next = [...urls, href];
+  const entries = readEntries();
+  if (entries.some((e) => e.url === href)) return;
+  const next = [...entries, { url: href, ts: Date.now() }];
   while (next.length > MAX_TRACKED_URLS) next.shift();
   writeStorage(JSON.stringify(next));
 }

--- a/apps/extension/src/lib/messaging.ts
+++ b/apps/extension/src/lib/messaging.ts
@@ -24,6 +24,12 @@ export interface HiddenSummary {
   pageLang: LanguageCode | null;
   /** True after the user pressed "Show all" — we stop re-hiding until reload. */
   userOverride: boolean;
+  /** True when a session-scoped guard is currently suppressing a language switch
+   *  on this tab — either the loop guard holds attempt history (a prior redirect
+   *  "hiccup") or a live picker choice for this host matches the page language.
+   *  Lets the popup offer "Try switching again" only when a retry can actually do
+   *  something, vs a site that genuinely serves only a blocked language. */
+  switchSuppressed: boolean;
 }
 
 /** True when the content script has concealed anything on the tab — blocked
@@ -77,12 +83,13 @@ export interface ContentStringsMessage {
 }
 
 /** Message protocol across the content script, popup/options, and background.
- *  getHidden/restoreHidden are popup→content (tabs.sendMessage); detectText/
- *  classifySnippets/warmFranc/contentStrings are content→background
+ *  getHidden/restoreHidden/retrySwitch are popup→content (tabs.sendMessage);
+ *  detectText/classifySnippets/warmFranc/contentStrings are content→background
  *  (runtime.sendMessage). Each listener ignores the types it doesn't own. */
 export type MovarMessage =
   | { type: 'movar:getHidden' }
   | { type: 'movar:restoreHidden' }
+  | { type: 'movar:retrySwitch' }
   | DetectTextMessage
   | ClassifySnippetsMessage
   | WarmFrancMessage

--- a/apps/extension/src/lib/session-choice.test.ts
+++ b/apps/extension/src/lib/session-choice.test.ts
@@ -1,5 +1,6 @@
-import { beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { clearPickerChoice, getPickerChoice, recordPickerChoice } from './session-choice';
+import { SUPPRESSION_TTL_MS } from './time';
 
 const STORAGE_KEY = 'movar:pickerChoice';
 
@@ -70,5 +71,30 @@ describe('session-choice — malformed storage', () => {
     );
     expect(getPickerChoice('a.example.com')).toBeNull();
     expect(getPickerChoice('b.example.com')).toBe('ru');
+  });
+});
+
+describe('session-choice — TTL expiry (never a permanent block)', () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+
+  it('keeps a choice within the TTL window', () => {
+    recordPickerChoice('example.com', 'ru');
+    vi.advanceTimersByTime(SUPPRESSION_TTL_MS - 1);
+    expect(getPickerChoice('example.com')).toBe('ru');
+  });
+
+  it('drops a choice once the TTL elapses, so Movar re-asserts', () => {
+    recordPickerChoice('example.com', 'ru');
+    vi.advanceTimersByTime(SUPPRESSION_TTL_MS);
+    expect(getPickerChoice('example.com')).toBeNull();
+  });
+
+  it('a fresh click within the window resets the clock', () => {
+    recordPickerChoice('example.com', 'ru');
+    vi.advanceTimersByTime(SUPPRESSION_TTL_MS - 1);
+    recordPickerChoice('example.com', 'ru');
+    vi.advanceTimersByTime(SUPPRESSION_TTL_MS - 1);
+    expect(getPickerChoice('example.com')).toBe('ru');
   });
 });

--- a/apps/extension/src/lib/session-choice.ts
+++ b/apps/extension/src/lib/session-choice.ts
@@ -15,16 +15,36 @@
  * Storage: sessionStorage — same lifecycle as `loop-guard`. Tab-scoped, clears
  * on tab close. Choices survive in-tab navigation but don't leak to other
  * tabs or future browser sessions, matching the "for current session" wording.
+ * Each choice also self-expires after `SUPPRESSION_TTL_MS` so a stale pick can't
+ * pin a long-open tab to a blocked language forever.
  */
 import { normalizeLanguageCode } from '@movar/lang-detect';
 import type { LanguageCode } from '@movar/lang-detect';
+import { SUPPRESSION_TTL_MS } from './time';
 
 const STORAGE_KEY = 'movar:pickerChoice';
 
+/** One recorded picker choice: the language the user switched to, and when. */
+interface Choice {
+  lang: string;
+  ts: number;
+}
+
+/** Narrow an untrusted parsed value to a timestamped choice. */
+function isChoice(value: unknown): value is Choice {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    typeof (value as Choice).lang === 'string' &&
+    typeof (value as Choice).ts === 'number'
+  );
+}
+
 // Flat parse-and-validate of an untrusted sessionStorage blob; the guards are
-// independent preconditions, not nested logic.
+// independent preconditions, not nested logic. Legacy bare-string values (no
+// timestamp) are stamped fresh; timestamped entries past the TTL are dropped.
 // fallow-ignore-next-line complexity
-function readMap(): Record<string, string> {
+function readMap(): Record<string, Choice> {
   let raw: string | null;
   try {
     raw = sessionStorage.getItem(STORAGE_KEY);
@@ -32,20 +52,24 @@ function readMap(): Record<string, string> {
     return {};
   }
   if (raw == null || raw === '') return {};
+  let parsed: unknown;
   try {
-    const parsed: unknown = JSON.parse(raw);
-    if (parsed == null || typeof parsed !== 'object' || Array.isArray(parsed)) return {};
-    const out: Record<string, string> = {};
-    for (const [host, value] of Object.entries(parsed as Record<string, unknown>)) {
-      if (typeof value === 'string') out[host] = value;
-    }
-    return out;
+    parsed = JSON.parse(raw);
   } catch {
     return {};
   }
+  if (parsed == null || typeof parsed !== 'object' || Array.isArray(parsed)) return {};
+  const now = Date.now();
+  const out: Record<string, Choice> = {};
+  for (const [host, value] of Object.entries(parsed as Record<string, unknown>)) {
+    // Legacy: bare language string (no timestamp) → stamp fresh.
+    if (typeof value === 'string') out[host] = { lang: value, ts: now };
+    else if (isChoice(value) && now - value.ts < SUPPRESSION_TTL_MS) out[host] = value;
+  }
+  return out;
 }
 
-function writeMap(map: Record<string, string>): void {
+function writeMap(map: Record<string, Choice>): void {
   try {
     sessionStorage.setItem(STORAGE_KEY, JSON.stringify(map));
   } catch {
@@ -59,8 +83,8 @@ function writeMap(map: Record<string, string>): void {
  *  corrupt or unknown code falls back to "no choice" rather than feeding a
  *  bogus language through the rest of the pipeline. */
 export function getPickerChoice(host: string): LanguageCode | null {
-  const value = readMap()[host];
-  return value != null && value !== '' ? normalizeLanguageCode(value) : null;
+  const choice = readMap()[host];
+  return choice != null && choice.lang !== '' ? normalizeLanguageCode(choice.lang) : null;
 }
 
 /** Persist that the user clicked the site's own language picker on `host`
@@ -68,7 +92,7 @@ export function getPickerChoice(host: string): LanguageCode | null {
  *  wins; we don't try to interpret "user clicked twice, what did they mean". */
 export function recordPickerChoice(host: string, language: LanguageCode): void {
   const map = readMap();
-  map[host] = language;
+  map[host] = { lang: language, ts: Date.now() };
   writeMap(map);
 }
 

--- a/apps/extension/src/lib/time.ts
+++ b/apps/extension/src/lib/time.ts
@@ -7,3 +7,9 @@
 export const HOUR_MS = 3_600_000; // 60 min × 60 s × 1000 ms
 export const DAY_MS = 86_400_000; // 24 h × 60 min × 60 s × 1000 ms
 export const DAY_SECONDS = 86_400; // 24 h × 60 min × 60 s
+
+/** How long a session-scoped switch guard stays armed before it self-expires.
+ *  Both the loop guard (a redirect "hiccup") and a manual picker choice back off
+ *  for this window, then a later apply tick / reload / reopen retries — so Movar
+ *  never sits in a permanent blocked state. Single knob for both guards. */
+export const SUPPRESSION_TTL_MS = DAY_MS;

--- a/apps/extension/src/test/browser-mock.ts
+++ b/apps/extension/src/test/browser-mock.ts
@@ -228,6 +228,7 @@ const shim = {
           feedHidden: 0,
           pageLang: tab.hidden?.pageLang ?? null,
           userOverride: true,
+          switchSuppressed: false,
         } satisfies HiddenSummary;
       }
       // No seeded tab (or unknown message) → mimic "no content script", which

--- a/apps/extension/store-assets/storyboards/components/StatusHeader.stories.tsx
+++ b/apps/extension/store-assets/storyboards/components/StatusHeader.stories.tsx
@@ -53,6 +53,7 @@ function snap(over: Partial<HiddenSummary> = {}): HiddenSummary {
     feedHidden: 0,
     pageLang: null,
     userOverride: false,
+    switchSuppressed: false,
     ...over,
   };
 }

--- a/apps/extension/store-assets/storyboards/marketing/popup.stories.tsx
+++ b/apps/extension/store-assets/storyboards/marketing/popup.stories.tsx
@@ -54,6 +54,7 @@ const SERVED_UK: HiddenSummary = {
   feedHidden: 0,
   pageLang: 'uk',
   userOverride: false,
+  switchSuppressed: false,
 };
 
 /** Natural popup width (`App` renders a fixed `w-[360px]` card). */

--- a/apps/extension/store-assets/storyboards/scenes/popup-on-news-scene.tsx
+++ b/apps/extension/store-assets/storyboards/scenes/popup-on-news-scene.tsx
@@ -26,6 +26,7 @@ function servedPage(pageLang: HiddenSummary['pageLang']): HiddenSummary {
     feedHidden: 0,
     pageLang,
     userOverride: false,
+    switchSuppressed: false,
   };
 }
 

--- a/apps/extension/store-assets/storyboards/stories/popup-on-news.stories.tsx
+++ b/apps/extension/store-assets/storyboards/stories/popup-on-news.stories.tsx
@@ -46,6 +46,7 @@ function servedPage(pageLang: HiddenSummary['pageLang']): HiddenSummary {
     feedHidden: 0,
     pageLang,
     userOverride: false,
+    switchSuppressed: false,
   };
 }
 

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -37,6 +37,23 @@ layers** that run in order on every page; the first that succeeds stops the seco
   produces an aggregate "the page is Russian" verdict that feeds back into the redirect
   layer. Mixing them causes redirect/bounce "hiccups". See
   [page-content-and-lang-pickers-refactor.md](page-content-and-lang-pickers-refactor.md).
+- <a id="loop-guard"></a>**Loop guard** — The redirect layer's per-tab backoff against the
+  "hiccups" above. Each switch attempt records the URL it redirected FROM in
+  `sessionStorage`; a page already in that set won't trigger another switch, so the bounce
+  on a misconfigured site (every locale path serving `<html lang="ru">`) dies out. Entries
+  self-expire after a 24-hour TTL (`SUPPRESSION_TTL_MS`) so the backoff is never permanent.
+  Code: `apps/extension/src/lib/loop-guard.ts`.
+- <a id="picker-choice"></a>**Picker choice** (a.k.a. **session choice**) — A per-host
+  record that the user clicked the site's own [picker](#language-picker) to a blocked
+  language this session. While it stands, Movar treats that page as "what the user asked
+  for" and neither switches nor filters it — so a deliberate "show me Russian here" isn't
+  immediately undone. Same `sessionStorage` + 24-hour-TTL lifecycle as the loop guard
+  (`apps/extension/src/lib/session-choice.ts`).
+- <a id="switch-retry"></a>**Switch retry** — The popup's "Try switching again" action,
+  offered on a [blocked](#block-list) page only while a loop guard or picker choice is
+  actively suppressing the switch. It clears both guards for the tab and reloads, so Movar
+  re-attempts from a clean slate. With per-tab scoping (a new tab starts fresh) and the
+  24-hour TTL, these three paths guarantee Movar never sits in a permanent blocked state.
 - <a id="never-translate"></a>**Block-only / never translate** — A product rule: Movar
   hides or switches away from blocked-language content but never machine-translates it.
   Translating Russian would launder it into trusted Ukrainian and remove its

--- a/packages/i18n/src/messages-en.ts
+++ b/packages/i18n/src/messages-en.ts
@@ -38,6 +38,9 @@ export interface Messages {
     /** Page is still in a blocked language Movar found no lever to switch. */
     blockedTitle: (name: string) => string;
     blockedDetail: string;
+    /** Button on the blocked band, shown when a session guard is suppressing the
+     *  switch — clears the guard and reloads so Movar re-attempts. */
+    retrySwitch: string;
     /** Movar concealed picker entries and/or feed cards here. Takes the
      *  hidden picker languages (already localised); empty list → a generic
      *  line for the feed-card-only case (e.g. YouTube) where no picker
@@ -290,6 +293,7 @@ export const messagesEn: Messages = {
     servedIn: (name) => `This page is in ${name}`,
     blockedTitle: (name) => `This page is in ${name}`,
     blockedDetail: 'Movar found no way to switch it here',
+    retrySwitch: 'Try switching again',
     hiding: (names) =>
       names.length > 0
         ? `${names.join(', ')} hidden on this page`

--- a/packages/i18n/src/messages-uk.ts
+++ b/packages/i18n/src/messages-uk.ts
@@ -42,6 +42,7 @@ export const messagesUk: Messages = {
     servedIn: (name) => `Мова сторінки — ${name}`,
     blockedTitle: (name) => `Мова сторінки — ${name}`,
     blockedDetail: 'Movar не знайшов способу перемкнути її тут',
+    retrySwitch: 'Спробувати перемкнути знову',
     hiding: (names) =>
       names.length > 0
         ? `Приховано на цій сторінці: ${names.join(', ')}`

--- a/scripts/readme-metrics.snapshot.json
+++ b/scripts/readme-metrics.snapshot.json
@@ -4,16 +4,16 @@
     "score": 82,
     "grade": "B"
   },
-  "loc": 35683,
+  "loc": 35729,
   "suppressions": {
     "eslint": 40,
     "fallow": 25
   },
   "coverage": {
-    "lines": 93.6,
+    "lines": 93.7,
     "branches": 85.9
   },
   "bundle": {
-    "contentKb": 35
+    "contentKb": 36
   }
 }


### PR DESCRIPTION
## Why

During testing a tab got permanently stuck: the page served a blocked language, Movar stopped switching it, and the popup kept warning *"This page is in Russian / Movar found no way to switch it here"* — even after the language was switched back manually. The only escape was closing the tab.

Two session-scoped guards cause this, and both **survive page reloads**:

- **Loop guard** (`movar:redirectedFrom`) — the redirect layer's backoff after a bounce/"hiccup" between sibling locale URLs.
- **Picker choice** (`movar:pickerChoice`) — set when the user clicks a site's *own* picker to a blocked language; Movar then stands down for that host.

The popup's blocked-state warning fires purely on the detected page language, so once a guard armed there was no way to act on it.

## What changed — three recovery paths, so the blocked state is never permanent

1. **New tab / tab close** — already resets (both guards are tab-scoped `sessionStorage`). No code change; behaviour is now documented and covered.
2. **Time** — both guards carry a timestamp and self-expire after a **24h TTL** (`SUPPRESSION_TTL_MS`). After the window, the next apply tick / reload / reopen retries. Legacy storage formats are migrated inline on read.
3. **Button** — a **"Try switching again"** action in the popup's blocked band, shown *only* when a guard is actively suppressing the switch (`HiddenSummary.switchSuppressed`). It clears both guards for the tab and reloads so the switch ladder re-runs from `document_start`. On a site that genuinely only serves Russian, nothing is suppressed → no button.

### Key files

- `apps/extension/src/lib/loop-guard.ts`, `session-choice.ts`, `time.ts` — TTL + timestamped storage + legacy migration.
- `apps/extension/src/lib/messaging.ts` — `HiddenSummary.switchSuppressed` + the `movar:retrySwitch` message.
- `apps/extension/src/lib/content-runtime.ts` — computes `switchSuppressed`; `movar:retrySwitch` handler clears both guards.
- `apps/extension/src/entrypoints/popup/{use-popup-controller,App}.tsx` — `onRetrySwitch` (send + reload) and the gated button.
- `packages/i18n/src/messages-{en,uk}.ts` — `pageStatus.retrySwitch` copy.
- `docs/glossary.md` — new **Loop guard**, **Picker choice**, **Switch retry** entries.

## Reviewer notes

- **Why not auto-clear on plain reload?** That would reopen the exact infinite redirect loops the guard exists to prevent (see `spizhenko-regression.test.ts`). Recovery is deliberately either time-bounded or an explicit user action.
- **Picker choice also expires** on the same 24h TTL (per product decision) — a deliberate "show me Russian here" is honoured for the window, then Movar re-asserts. The retry button clears it immediately.
- **No new bundle deps**: the popup button reuses `@movar/ui`'s `Button` and a lucide icon already imported by `StatusHeader`; content-runtime reuses already-imported guard modules. Content bundle stays 36 KB / 80 KB budget, franc-free.
- **No background timer**: TTL recovery rides the existing `applyOnce` triggers (mutation / nav / reload / reopen), which is enough to guarantee "not permanent".

## Testing

- `pnpm --filter @movar/extension test` — **1025 passed** (incl. fake-timer TTL expiry for both guards, `switchSuppressed`, `movar:retrySwitch` clearing, controller send+reload, and App-level button gating).
- i18n: **121 passed**. Typecheck + lint clean. `build:chrome` + `check:content-bundle` pass.
- Not run locally: **e2e-fast** (headed Chromium — needs a display). CI runs it on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
