### PR TITLE
chore(diagnostics): drop the dev-only app from the pre-push build gate

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -55,9 +55,19 @@ pre-push:
       # bounded, and `--parallel=1` so peak = one project build, not several
       # concurrent. Under genuine RAM exhaustion this fails fast with a clear
       # error rather than grinding ~150 s to a heap-limit crash.
+      #
+      # `--exclude=diagnostics`: the diagnostics app is a maintainer-only dev
+      # extension that never ships to any store and is never built in CI, so it
+      # has nothing shippable to gate here. WXT forces MV3 on every target, so
+      # its three near-identical bundles tripled its build cost for zero
+      # coverage gain — and that ~470 MB working set, run per-target, is a prime
+      # contributor to the OOM above. Nothing depends on diagnostics, so the
+      # exclusion is clean (it isn't pulled back in as a `^build` dep). It still
+      # builds on demand (`pnpm build`, `nx build diagnostics`, `build:chrome`);
+      # it just no longer gates pushes.
       env:
         NODE_OPTIONS: '--max-old-space-size=2048'
-      run: pnpm exec nx run-many -t build --parallel=1
+      run: pnpm exec nx run-many -t build --parallel=1 --exclude=diagnostics
     metrics:
       # Mirrors the CI metrics job: fails if the branch introduces dead code,
       # complexity, or duplication regressions vs origin/main.


### PR DESCRIPTION
The diagnostics app is a maintainer-only dev extension: it never ships to any store and is never built in CI, so building it in the pre-push `nx run-many -t build` gate gates nothing shippable. WXT forces MV3 on every target, so its three near-identical bundles tripled its build cost there for zero coverage gain — and that ~470 MB working set, run per-target, is a prime contributor to the V8 heap-limit OOM that the heap cap and `--parallel=1` already guard against.

**Change:** exclude diagnostics from the pre-push build with `--exclude=diagnostics` (`lefthook.yml`, one line + rationale). Nothing depends on diagnostics, so the exclusion is clean — it isn't pulled back in as a `^build` dependency.

It still builds on demand via `pnpm build`, `nx build diagnostics`, or its per-browser `build:chrome` / `build:firefox` / `build:safari` scripts — all unchanged. CI is unaffected (its build job is extension-only); root `pnpm build` still builds every project, diagnostics included.

Supersedes the earlier chrome-only script-reshaping approach: with diagnostics out of the pre-push gate entirely, scoping its build target to chrome was moot, so those changes were dropped and the branch rebased onto current `main`.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>