### PR TITLE
fix(google): suspend the DNR redirect on empty-SERP retry (corrects #212's oq red herring)

### DIFF
--- a/apps/e2e/src/offline/google-search-dnr.spec.ts
+++ b/apps/e2e/src/offline/google-search-dnr.spec.ts
@@ -165,10 +165,9 @@ test.describe('Google /search DNR pre-request rewrite', () => {
     expect(landed.searchParams.get('lr')).toBe('lang_uk|lang_en');
     expect(landed.searchParams.get('gs_lcrp')).toBeNull();
     expect(landed.searchParams.get('aqs')).toBeNull();
-    // …user-facing `q` intact, but `oq` is stripped (a wrong-keyboard-layout
-    // `oq` poisons the SERP under `lr`, so the DNR layer sheds it pre-request)…
+    // …user-facing params intact…
     expect(landed.searchParams.get('q')).toBe('реле');
-    expect(landed.searchParams.get('oq')).toBeNull();
+    expect(landed.searchParams.get('oq')).toBe('rele');
 
     // …and — the point of the whole layer — the raw URL was never requested:
     // the network saw exactly one request, already rewritten. A content-script

--- a/apps/extension/src/entrypoints/__tests__/background.test.ts
+++ b/apps/extension/src/entrypoints/__tests__/background.test.ts
@@ -507,6 +507,36 @@ describe('franc onMessage dispatch', () => {
   });
 });
 
+describe('movar:suspendGoogleRedirect', () => {
+  it('suspends rule 2 (no addRules) and arms the self-healing restore alarm', async () => {
+    await loadBackground();
+    // Let main()'s wake-time resync land the Google redirect rule first, so the
+    // suspend call below is observably removing a real rule, not a vacuous no-op.
+    await vi.waitFor(() => {
+      expect(googleRedirectRule()).toBeDefined();
+    });
+    const update = browser.declarativeNetRequest.updateDynamicRules as ReturnType<typeof vi.fn>;
+    update.mockClear();
+    const sendResponse = vi.fn();
+
+    const keepOpen = await triggerMessage(sendResponse, { type: 'movar:suspendGoogleRedirect' });
+
+    expect(keepOpen).toBe(true);
+    await vi.waitFor(() => {
+      expect(sendResponse).toHaveBeenCalledWith(true);
+    });
+    const suspendCall = update.mock.calls[0]![0] as {
+      removeRuleIds?: number[];
+      addRules?: unknown[];
+    };
+    expect(suspendCall.removeRuleIds).toContain(GOOGLE_RULE_ID);
+    expect('addRules' in suspendCall).toBe(false);
+    expect(googleRedirectRule()).toBeUndefined();
+    // Self-healing restore: a same-named alarm is armed to reinstall the rule.
+    expect(await fakeBrowser.alarms.get('movar:restore-google-redirect')).toBeTruthy();
+  });
+});
+
 describe('change subscriptions', () => {
   it('resyncs the DNR rule when settings change', async () => {
     await loadBackground();

--- a/apps/extension/src/entrypoints/background.ts
+++ b/apps/extension/src/entrypoints/background.ts
@@ -6,7 +6,11 @@ import { contentStringsEn } from '../lib/i18n/content-strings-en';
 import { contentStringsUk } from '../lib/i18n/content-strings-uk';
 import type { ContentStrings } from '../lib/i18n/content-strings';
 import type { ResolvedLocale } from '@movar/i18n';
-import { syncAcceptLanguageRule, syncGoogleSearchRedirectRule } from '../lib/dnr';
+import {
+  suspendGoogleSearchRedirectRule,
+  syncAcceptLanguageRule,
+  syncGoogleSearchRedirectRule,
+} from '../lib/dnr';
 import {
   getPauseState,
   getSnoozedHosts,
@@ -26,6 +30,15 @@ import {
   reconcileNativeSettings,
 } from '../lib/native-settings';
 import type { MovarMessage } from '../lib/messaging';
+
+/** One-shot alarm that re-installs the Google /search redirect rule after the
+ *  empty-results retry suspended it. The retry only needs the rule down for its
+ *  single lr-less navigation; this restores it ~30s later even if the tab
+ *  closed mid-recovery or the SW slept (chrome.alarms survives suspension; a
+ *  setTimeout would not). Each new suspension pushes the restore out, so the
+ *  rule stays down through a run of failing searches and returns once they
+ *  succeed. */
+const RESTORE_GOOGLE_REDIRECT_ALARM = 'movar:restore-google-redirect';
 
 /** Reveal everything Movar concealed on the active tab — the keyboard-shortcut
  *  twin of the popup's "Show everything". Reuses the existing content handler;
@@ -126,6 +139,14 @@ const WORKER_REQUESTS: {
   'movar:warmFranc': async () => {
     await warmFranc();
   },
+  'movar:suspendGoogleRedirect': async () => {
+    await suspendGoogleSearchRedirectRule();
+    // Self-healing restore. 0.5 min is Chrome's floor for a sub-minute alarm;
+    // re-creating the same-named alarm resets the timer, so back-to-back
+    // recoveries keep the rule down until searches recover.
+    await browser.alarms.create(RESTORE_GOOGLE_REDIRECT_ALARM, { delayInMinutes: 0.5 });
+    return true;
+  },
 };
 
 /**
@@ -225,18 +246,29 @@ export default defineBackground({
     });
 
     // Timed-expiry alarms: a global pause ending (RESUME_ALARM) resumes + resyncs;
-    // the per-site snooze sweep (SNOOZE_ALARM) prunes expired hosts + resyncs.
+    // the per-site snooze sweep (SNOOZE_ALARM) prunes expired hosts + resyncs;
+    // the empty-results retry's restore (RESTORE_GOOGLE_REDIRECT_ALARM) re-installs
+    // the Google redirect rule the retry suspended.
     browser.alarms.onAlarm.addListener((alarm) => {
-      if (alarm.name === RESUME_ALARM) {
-        void (async () => {
-          await resume();
-          await resync();
-        })();
-      } else if (alarm.name === SNOOZE_ALARM) {
-        void (async () => {
-          await sweepExpiredSnoozes();
-          await resync();
-        })();
+      switch (alarm.name) {
+        case RESUME_ALARM: {
+          void (async () => {
+            await resume();
+            await resync();
+          })();
+          break;
+        }
+        case SNOOZE_ALARM: {
+          void (async () => {
+            await sweepExpiredSnoozes();
+            await resync();
+          })();
+          break;
+        }
+        case RESTORE_GOOGLE_REDIRECT_ALARM: {
+          void resync();
+          break;
+        }
       }
     });
   },

--- a/apps/extension/src/lib/content-runtime.ts
+++ b/apps/extension/src/lib/content-runtime.ts
@@ -390,6 +390,17 @@ const emptyRetryDeps: Omit<EmptyResultsRetryDeps, 'isActive'> = {
   recentlyAttemptedHere,
   markAttempt,
   record,
+  suspendRedirect: async () => {
+    try {
+      await browser.runtime.sendMessage({
+        type: 'movar:suspendGoogleRedirect',
+      } satisfies MovarMessage);
+    } catch {
+      // Background unreachable (SW mid-teardown, etc.): navigate anyway. Without
+      // the suspend the DNR rule may re-add the filter param — no worse than
+      // before this guard existed.
+    }
+  },
 };
 
 /** ms allotted to the tier-7 async engine call. Aborts the orchestrator's

--- a/apps/extension/src/lib/dnr.test.ts
+++ b/apps/extension/src/lib/dnr.test.ts
@@ -10,6 +10,7 @@ import { applyStrategy } from './strategy';
 import { googleRule } from '../sites/google';
 import {
   buildGoogleSearchRedirectRule,
+  suspendGoogleSearchRedirectRule,
   syncAcceptLanguageRule,
   syncGoogleSearchRedirectRule,
 } from './dnr';
@@ -272,15 +273,13 @@ describe('buildGoogleSearchRedirectRule', () => {
   it('removes the strip tier, the scrub tier, and the enumerated gs_* family (deduped)', () => {
     const transform = queryTransformOf(buildGoogleSearchRedirectRule(PRIORITY));
     // Order-free set compare; gs_lcrp sits in BOTH stripParams and the gs_*
-    // family enumeration and must appear once. `oq` is strip-listed (a
-    // wrong-layout `oq` poisons the SERP), so it sheds pre-request here too.
+    // family enumeration and must appear once.
     expect(transform.removeParams.toSorted()).toEqual([
       'aqs',
       'gs_l',
       'gs_lcrp',
       'gs_lp',
       'gs_ssp',
-      'oq',
       'rlz',
       'sei',
     ]);
@@ -325,10 +324,9 @@ describe('buildGoogleSearchRedirectRule', () => {
       expect(out.searchParams.get('lr')).toBe('lang_uk|lang_en');
       expect(out.searchParams.get('gs_lcrp')).toBeNull();
       expect(out.searchParams.get('aqs')).toBeNull();
-      // User-facing params survive; `oq` does not — it's strip-listed now (a
-      // wrong-keyboard-layout `oq` poisons the SERP under `lr`).
+      // User-facing params survive.
       expect(out.searchParams.get('q')).toBe('реле');
-      expect(out.searchParams.get('oq')).toBeNull();
+      expect(out.searchParams.get('oq')).toBe('rele');
       expect(out.searchParams.get('sourceid')).toBe('chrome');
     });
 
@@ -453,5 +451,23 @@ describe('syncGoogleSearchRedirectRule', () => {
     await syncGoogleSearchRedirectRule({ ...defaultSettings, priority: ['uk'] }, true);
     const rules = rulesAfter(update) as { id: number }[];
     expect(rules.map((r) => r.id).toSorted((a, b) => a - b)).toEqual([1, GOOGLE_RULE_ID]);
+  });
+});
+
+describe('suspendGoogleSearchRedirectRule', () => {
+  beforeEach(() => {
+    fakeBrowser.reset();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('removes only rule 2 (the Google /search redirect rule), no addRules', async () => {
+    const update = spyUpdate();
+    await suspendGoogleSearchRedirectRule();
+
+    expect(update).toHaveBeenCalledTimes(1);
+    expect(update.mock.calls[0]![0]).toEqual({ removeRuleIds: [2] });
   });
 });

--- a/apps/extension/src/lib/dnr.ts
+++ b/apps/extension/src/lib/dnr.ts
@@ -225,3 +225,20 @@ export async function syncGoogleSearchRedirectRule(
     }
   }
 }
+
+/**
+ * Suspend the Google /search redirect rule (remove rule 2 only; the
+ * Accept-Language rule is untouched). The empty-results retry calls this — via
+ * a background message — right before it navigates to the same query with `lr`
+ * dropped to escape a server-side session pin. Without it, this redirect rule
+ * would re-add `lr` pre-request and bounce the retry back to the pinned URL:
+ * the rule can't see the content-script loop-guard that already stops the
+ * *content* rewrite from re-adding it. The background schedules a timed alarm
+ * to re-install the rule shortly after (via {@link syncGoogleSearchRedirectRule}),
+ * so a dropped rule always comes back even if the retrying tab never reports in.
+ */
+export async function suspendGoogleSearchRedirectRule(): Promise<void> {
+  await browser.declarativeNetRequest.updateDynamicRules({
+    removeRuleIds: [GOOGLE_SEARCH_RULE_ID],
+  });
+}

--- a/apps/extension/src/lib/empty-results-retry.test.ts
+++ b/apps/extension/src/lib/empty-results-retry.test.ts
@@ -31,6 +31,7 @@ interface StubDeps extends EmptyResultsRetryDeps {
   replace: Mock<(url: string) => void>;
   record: Mock<EmptyResultsRetryDeps['record']>;
   whenSettled: Mock<EmptyResultsRetryDeps['whenSettled']>;
+  suspendRedirect: Mock<EmptyResultsRetryDeps['suspendRedirect']>;
 }
 
 function makeDeps(
@@ -66,6 +67,7 @@ function makeDeps(
     recentlyAttemptedHere: (h) => attempted.has(h),
     markAttempt: (h) => attempted.add(h),
     record: vi.fn(async () => {}),
+    suspendRedirect: vi.fn(async () => {}),
     isActive: () => active,
   };
   return deps;
@@ -112,6 +114,20 @@ describe('maybeScheduleEmptyResultsRetry', () => {
     expect(target.searchParams.get('q')).toBe('реле напруги');
   });
 
+  it('suspends the Google redirect rule before navigating to the lr-less retry URL', async () => {
+    // The DNR redirect rule (dnr.ts) would otherwise re-add `lr` at the network
+    // layer, undoing exactly the param drop this retry exists to perform — so
+    // the suspend must happen as part of every successful retry.
+    const deps = makeDeps();
+    maybeScheduleEmptyResultsRetry(RETRY, 'uk', deps);
+    await elapseSettleDelay();
+
+    expect(deps.suspendRedirect).toHaveBeenCalledTimes(1);
+    expect(deps.replace).toHaveBeenCalledTimes(1);
+    const target = new URL(deps.replace.mock.calls[0]![0]);
+    expect(target.searchParams.has('lr')).toBe(false);
+  });
+
   it('marks BOTH the empty URL and the retried URL in the loop guard', async () => {
     // The FROM mark makes this page once-only; the target mark is what stops
     // the enforce rewrite from re-adding the filter on the retried page.
@@ -154,6 +170,7 @@ describe('maybeScheduleEmptyResultsRetry', () => {
 
     expect(deps.whenSettled).not.toHaveBeenCalled();
     expect(deps.replace).not.toHaveBeenCalled();
+    expect(deps.suspendRedirect).not.toHaveBeenCalled();
   });
 
   it('does not retry when the results container never rendered', async () => {

--- a/apps/extension/src/lib/empty-results-retry.ts
+++ b/apps/extension/src/lib/empty-results-retry.ts
@@ -56,6 +56,12 @@ export interface EmptyResultsRetryDeps {
     fromLang: LanguageCode,
     toLang: LanguageCode,
   ): Promise<void>;
+  /** Ask the background to suspend the Google /search DNR redirect rule so the
+   *  upcoming lr-dropped navigation isn't re-filtered at the network layer.
+   *  Resolves before the navigation; never rejects (the content impl swallows a
+   *  background-unreachable error — the retry then proceeds unprotected, no
+   *  worse than before this guard). */
+  suspendRedirect(): Promise<void>;
   /** False once a pause/snooze/settings change supersedes the scheduling tick. */
   isActive(): boolean;
 }
@@ -114,6 +120,10 @@ async function confirmAndRetry(
   deps.markAttempt(href);
   deps.markAttempt(retryHref);
   await deps.record('search-retry', target, target);
+  // Drop the network-layer redirect rule for this navigation: it would re-add
+  // the filter param we're deliberately removing (it can't see the loop-guard
+  // marks above) and bounce us back to the pinned URL. See the dep's contract.
+  await deps.suspendRedirect();
   deps.location.replace(retryHref);
 }
 

--- a/apps/extension/src/lib/google-empty-serp-retry.integration.test.ts
+++ b/apps/extension/src/lib/google-empty-serp-retry.integration.test.ts
@@ -104,6 +104,9 @@ function makeRetryDeps(
     markAttempt,
     record: vi.fn(async () => {}),
     isActive: () => true,
+    // The DNR redirect rule is suspended (via the background) before the retry
+    // navigates, so it can't re-add the dropped filter param; a no-op here.
+    suspendRedirect: vi.fn(async () => {}),
   };
 }
 

--- a/apps/extension/src/lib/google-rule.integration.test.ts
+++ b/apps/extension/src/lib/google-rule.integration.test.ts
@@ -109,45 +109,11 @@ describe('google.com — rule + strategy integration on /search', () => {
     expect(target.searchParams.has('gs_lcrp')).toBe(false);
   });
 
-  it('strips a wrong-layout oq even when hl/lr already match (empty-SERP regression)', () => {
-    // Reported live: `реле напруги` returned zero results until `oq` was
-    // dropped. Chrome minted `oq=htkt ` — the Latin keys physically under
-    // `реле` — because the query was started in the wrong keyboard layout, and
-    // that stray Latin original-query is a pre-rewrite language signal that
-    // intersects the `lr` filter down to zero, exactly like `gs_lcrp`. The
-    // poisoned URL already carries the correct `hl`/`lr` (the rewrite set them
-    // and `oq` rode along), so only stripParams — which forces a rewrite on
-    // `oq`'s presence — recovers it; a scrub would see hl/lr on target, no-op,
-    // and leave the SERP stuck at zero across reloads.
-    const rule = getRuleForHost('www.google.com');
-    expect(rule).toBeDefined();
-    if (!rule) return;
-
-    // The exact shape the user reported: uk+en priority → lr=lang_uk|lang_en.
-    const q = 'реле напруги';
-    const initial = `https://www.google.com/search?q=${encodeURIComponent(q)}&oq=htkt+&sourceid=chrome&ie=UTF-8&hl=uk&lr=${encodeURIComponent('lang_uk|lang_en')}`;
-    const { ctx, navigate } = makeContext(initial);
-    const out = applyStrategy(rule.strategy, ['uk', 'en'], ctx);
-
-    expect(navigate).toHaveBeenCalledTimes(1);
-    expect(out.appliedSteps).toBeGreaterThan(0);
-    const target = new URL(navigate.mock.calls[0]![0] as string);
-    expect(target.searchParams.has('oq')).toBe(false);
-    // Dropping `oq` is the whole fix — the language filter the user wanted
-    // stays, so results come back constrained to uk/en rather than unfiltered.
-    expect(target.searchParams.get('hl')).toBe('uk');
-    expect(target.searchParams.get('lr')).toBe('lang_uk|lang_en');
-    // Attribution that isn't a language signal is left alone.
-    expect(target.searchParams.get('sourceid')).toBe('chrome');
-    expect(target.searchParams.get('q')).toBe(q);
-  });
-
   it('scrubs the gs_* family and legacy omnibox tokens on an entry rewrite', () => {
     // Omnibox/homepage entry URLs never carry `lr`, so the rewrite always
     // navigates — and sheds the whole `gs_*` suggest-session namespace plus
     // `aqs` (gs_lcrp's predecessor) and `rlz` (install-cohort token) on the
-    // way. `sourceid` is honest attribution and stays untouched; `oq` is
-    // stripped (a wrong-layout `oq` poisons the SERP — see its own test).
+    // way. `oq` and `sourceid` are honest attribution and stay untouched.
     const rule = getRuleForHost('www.google.com');
     expect(rule).toBeDefined();
     if (!rule) return;
@@ -159,9 +125,10 @@ describe('google.com — rule + strategy integration on /search', () => {
 
     expect(navigate).toHaveBeenCalledTimes(1);
     const target = new URL(navigate.mock.calls[0]![0] as string);
-    for (const gone of ['gs_lp', 'gs_ssp', 'aqs', 'rlz', 'oq']) {
-      expect(target.searchParams.has(gone), `${gone} should be gone`).toBe(false);
+    for (const gone of ['gs_lp', 'gs_ssp', 'aqs', 'rlz']) {
+      expect(target.searchParams.has(gone), `${gone} should be scrubbed`).toBe(false);
     }
+    expect(target.searchParams.get('oq')).toBe('rele');
     expect(target.searchParams.get('sourceid')).toBe('chrome');
     expect(target.searchParams.get('hl')).toBe('uk');
     expect(target.searchParams.get('lr')).toBe('lang_uk');
@@ -204,9 +171,7 @@ describe('google.com — rule + strategy integration on /search', () => {
     expect(second.navigate).toHaveBeenCalledTimes(1);
     const target = new URL(second.navigate.mock.calls[0]![0] as string);
     expect(target.searchParams.get('q')).toBe('druha');
-    // B's own `oq` is stripped (it's in stripParams now); the point here is
-    // that nothing from A — its scrubbed `gs_lp=TokenA` — leaks into B.
-    expect(target.searchParams.has('oq')).toBe(false);
+    expect(target.searchParams.get('oq')).toBe('b');
     expect(target.toString()).not.toContain('TokenA');
   });
 });

--- a/apps/extension/src/lib/messaging.ts
+++ b/apps/extension/src/lib/messaging.ts
@@ -82,6 +82,20 @@ export interface ContentStringsMessage {
   locale: ResolvedLocale;
 }
 
+/** Content → background: the empty-results retry is about to navigate to the
+ *  same query with the `lr` filter deliberately dropped, to escape a
+ *  server-side session pin (docs/google-search-url-params.md, finding #1). The
+ *  Google /search DNR redirect rule (lib/dnr.ts) would otherwise re-add `lr` at
+ *  the network layer — it has no view of the content-script loop-guard that
+ *  suppresses the *content* rewrite — and bounce the retry back to the pinned
+ *  zero-result URL. This asks the background to suspend that rule so the lr-less
+ *  navigation survives. Awaited (the nav waits until the rule is down) but
+ *  otherwise fire-and-forget: the background auto-restores the rule via a timed
+ *  alarm, so the suspension self-heals even if this tab never reports back. */
+export interface SuspendGoogleRedirectMessage {
+  type: 'movar:suspendGoogleRedirect';
+}
+
 /** Message protocol across the content script, popup/options, and background.
  *  getHidden/restoreHidden/retrySwitch are popup→content (tabs.sendMessage);
  *  detectText/classifySnippets/warmFranc/contentStrings are content→background
@@ -93,4 +107,5 @@ export type MovarMessage =
   | DetectTextMessage
   | ClassifySnippetsMessage
   | WarmFrancMessage
-  | ContentStringsMessage;
+  | ContentStringsMessage
+  | SuspendGoogleRedirectMessage;

--- a/apps/extension/src/sites/google/index.ts
+++ b/apps/extension/src/sites/google/index.ts
@@ -72,25 +72,9 @@ export const googleSearchStrategy: Extract<LangStrategy, { type: 'searchParams' 
   // candidate set computed under the pre-rewrite language context — down
   // to zero organic results once `lr` filters that pinned set (confirmed
   // by direct testing: removing only `gs_lcrp` took one query from 0 to
-  // ~1M results with `hl`/`lr` unchanged).
-  //
-  // `oq` (Chrome's "original query" — what was typed in the omnibox before a
-  // suggestion was accepted) is normally a harmless prefix of `q`. But when
-  // the query was started under the wrong keyboard layout it carries a
-  // layout-mismatch artifact: reaching `реле напруги` after typing `реле` on
-  // a Latin layout leaves `oq=htkt` (the physical keys under `реле`). That
-  // stray Latin original-query is a pre-rewrite language signal of exactly
-  // the `gs_lcrp` class — once `lr=lang_uk|lang_en` filters the set it
-  // intersects to zero organic results (user-reported: the SERP fills in the
-  // moment `oq` is dropped, `hl`/`lr` unchanged). It's a strip, not a scrub,
-  // because the poisoned URL is usually already at target — `hl`/`lr` set,
-  // `oq` riding along — so only forcing a rewrite on `oq`'s mere presence can
-  // recover that stuck state, exactly like the lingering-`gs_lcrp` case. (The
-  // DNR layer sheds it pre-request too — `removeParams` is derived from this
-  // strip tier, so `oq` rides along for free.)
-  //
-  // Drop all three on every rewrite so each query is judged on its own signals.
-  stripParams: ['sei', 'gs_lcrp', 'oq'],
+  // ~1M results with `hl`/`lr` unchanged). Drop both on every rewrite so
+  // each query is judged on its own signals.
+  stripParams: ['sei', 'gs_lcrp'],
   // Scrub tier — dropped only when a rewrite navigation is already
   // happening, never triggering one. `gs_*` is the omnibox/suggest-box
   // session-state namespace `gs_lcrp` belongs to (`gs_lp`, `gs_ssp`, …):

--- a/apps/extension/src/sites/registry.test.ts
+++ b/apps/extension/src/sites/registry.test.ts
@@ -124,21 +124,16 @@ describe('search-engine rules — localized Google ccTLDs', () => {
     expect(hl.joinPreferences).toBeFalsy();
   });
 
-  it.each(GOOGLE_DOMAINS)('strips the `sei`/`gs_lcrp`/`oq` session tokens for %s', (domain) => {
+  it.each(GOOGLE_DOMAINS)('strips the `sei`/`gs_lcrp` session tokens for %s', (domain) => {
     // `sei` is Google's opaque session-event token; carrying it forward
     // can override `hl`/`lr` with prior-session locale bias. `gs_lcrp` is
     // Chrome's opaque omnibox-session context blob, generated before this
     // rewrite runs — left in place it can pin serving to a candidate set
     // computed under the pre-rewrite context, zeroing out an otherwise
-    // healthy query once `lr` filters it. `oq` (Chrome's original-query
-    // attribution) is a strip too: a wrong-keyboard-layout entry leaves a
-    // Latin artifact on a Cyrillic query (`oq=htkt` for `реле`), a
-    // pre-rewrite language signal that intersects `lr` to zero. All three
-    // must force a rewrite on presence — they poison URLs that are otherwise
-    // already at target, so a scrub (non-navigating) would leave them stuck.
+    // healthy query once `lr` filters it.
     const rule = getRuleForHost(`www.${domain}`)!;
     if (rule.strategy.type !== 'searchParams') throw new Error('expected searchParams');
-    expect(rule.strategy.stripParams).toEqual(['sei', 'gs_lcrp', 'oq']);
+    expect(rule.strategy.stripParams).toEqual(['sei', 'gs_lcrp']);
   });
 
   it.each(GOOGLE_DOMAINS)(

--- a/docs/google-search-url-params.md
+++ b/docs/google-search-url-params.md
@@ -18,9 +18,8 @@ evidence instead of re-deriving all of this.
 
 ## The bug class
 
-Google attaches opaque, session-scoped tokens to search URLs, and Chrome
-adds a legible attribution param that can misfire the same way. Three of
-them are confirmed to have corrupted rewritten searches:
+Google attaches opaque, session-scoped tokens to search URLs. Two of them
+are confirmed to have corrupted rewritten searches:
 
 - **`sei`** — a session-event token that carried prior-session locale bias
   forward, overriding a freshly set `hl`/`lr`.
@@ -30,17 +29,6 @@ them are confirmed to have corrupted rewritten searches:
   context; intersecting that pinned set with the `lr` filter produced
   **zero organic results** for an otherwise healthy query. Removing only
   `gs_lcrp` took the query from 0 to ~1M results with `hl`/`lr` unchanged.
-- **`oq`** — Chrome's "original query" (what was typed in the omnibox before
-  a suggestion was accepted). Unlike the two above it is legible, not opaque,
-  and normally harmless — it mirrors a prefix of `q`. But a wrong-keyboard-
-  layout entry poisons it: starting `реле напруги` under a Latin layout
-  autocompletes the Cyrillic query while `oq` keeps the physical keys typed,
-  `htkt`. That stray Latin original-query is a pre-rewrite language signal;
-  once `lr=lang_uk|lang_en` filters results it intersects to **zero**.
-  User-reported and reproduced by hand — the SERP fills in the moment `oq` is
-  dropped, `hl`/`lr` unchanged. It is a strip rather than kept (see below)
-  because its healthy-case value is near-nil — it drives no result set or
-  correction UI — so the empty-SERP risk wins.
 
 The mechanism, generalized: _a token minted under one language context +
 a hard result filter applied afterwards = an empty or skewed intersection._
@@ -132,14 +120,11 @@ closes the bug class permanently. It fails on three counts:
 
 ## The two-tier design
 
-- **`stripParams`** (`['sei', 'gs_lcrp', 'oq']`) — confirmed-harmful tokens.
-  Their mere presence forces a rewrite, so a stuck URL is cleaned even when
+- **`stripParams`** (`['sei', 'gs_lcrp']`) — confirmed-harmful tokens. Their
+  mere presence forces a rewrite, so a stuck URL is cleaned even when
   `hl`/`lr` already match (the exact recovery path the `gs_lcrp` fix
-  needed — and the reason `oq` is a strip, not a scrub: its poisoned URL
-  arrives already at target, `oq` riding a correct `hl`/`lr`, where a
-  non-navigating scrub would see nothing to do and leave the SERP stuck at
-  zero across reloads). This trigger costs a navigation wherever the token
-  appears, so the bar for entry is _confirmed live evidence_.
+  needed). This trigger costs a navigation wherever the token appears, so
+  the bar for entry is _confirmed live evidence_.
 - **`scrubPrefixes`/`scrubParams`** (`['gs_']`; `['aqs', 'rlz']`) —
   hygiene tier. Dropped only when a navigation is already happening; never
   triggers one. Because entry URLs always rewrite, scrubs reliably cover
@@ -154,12 +139,9 @@ closes the bug class permanently. It fails on three counts:
   None of the scrubbed params is confirmed harmful — the tier is cheap
   insurance against the confirmed class.
 
-Never strip or scrub genuinely user-facing state: `q`, `start`, `udm`,
-`tbm`, `tbs`, `as_*`, `safe`, `nfpr`, `filter`, and especially `pws` —
-`pws=0` is an explicit user choice that stripping would silently undo.
-(`oq` was on this list until a wrong-layout value was convicted of the
-empty-SERP bug; it moved to `stripParams` because, unlike the params here,
-it drives nothing the user sees — see the bug-class section above.)
+Never strip or scrub user-facing state: `q`, `oq`, `start`, `udm`, `tbm`,
+`tbs`, `as_*`, `safe`, `nfpr`, `filter`, and especially `pws` — `pws=0` is
+an explicit user choice that stripping would silently undo.
 
 ## The prevention layer: pre-request DNR rewrite
 
@@ -208,8 +190,23 @@ render per search, and the poisoned request never reaches Google.
   transform (pinned by a parity test in `dnr.test.ts`) or it would
   re-navigate pages layer 0 already fixed. Layer 2 is the empty-results
   retry (finding #1) — still needed because a pin can be seeded by vectors
-  layer 0 never sees: another device on the same Google session, pre-install
-  browsing, or a non-entry surface.
+  layer 0 never sees: solving a Google **captcha** (which leaves a
+  degraded-trust session state), another device on the same Google session,
+  pre-install browsing, or a non-entry surface.
+- **Layer 2 must switch layer 0 off for its own navigation.** The retry
+  escapes a pin by navigating to the same query with `lr` dropped — but that
+  navigation is a `/search?q=` `main_frame` request, exactly what layer 0
+  matches, so layer 0 would re-add `lr` before it left the browser (it can't
+  see the content-script loop-guard that suppresses the layer-1 rewrite) and
+  bounce the retry straight back to the pinned zero-result URL. So the retry
+  first messages the background to **suspend the redirect rule**
+  (`suspendGoogleSearchRedirectRule`, via `movar:suspendGoogleRedirect`),
+  then navigates; a timed alarm re-installs the rule ~30s later (self-healing
+  across a closed tab or a slept worker, which a `setTimeout` would not
+  survive). During a run of failing searches the rule stays down and layers
+  1–2 carry Google, and it returns once searches recover. Anyone editing
+  layer 0's match condition or the retry must preserve this handshake —
+  without it the retry is a silent no-op against the network layer.
 
 Verification lives in `apps/e2e/src/offline/google-search-dnr.spec.ts`: the
 installed rule's transform, Chrome's own matcher accepting entry URLs and

--- a/docs/pitfalls.md
+++ b/docs/pitfalls.md
@@ -318,7 +318,7 @@ mechanisms are shared and rule-configurable):
    legitimately-empty one stays empty and is never retried again (per-tab loop-guard marker).
 
 Rules of the road: **never** strip or scrub user-facing state (`pws`, `tbs`, `udm`, `tbm`,
-`start`, `safe`, …) — that failure mode is _silent_, unlike this class's loud one; the
+`start`, `oq`, `safe`, …) — that failure mode is _silent_, unlike this class's loud one; the
 strategy must stay **stateless** (each rewrite derives from the current URL only — pinned by
 the cross-call tests in `strategy.searchParams.test.ts` and
 `google-rule.integration.test.ts`); and vet every new suspect with the live protocol in
@@ -332,12 +332,6 @@ extension off, baseline count alongside every batch).
 - **`gs_lcrp`** — omnibox-session blob; isolated live by removing the single param (0 → ~1M
   results, everything else unchanged). Along the way, two wrong theories — a classifier gap
   and broken `lr` pipe-join syntax — were each disproven only by one-variable live tests.
-- **`oq` (wrong keyboard layout)** — Chrome's original-query attribution, normally a harmless
-  prefix of `q`. A query started under a Latin layout leaves a Latin artifact on a Cyrillic
-  search (`oq=htkt` for `реле`); as a pre-rewrite language signal it intersects `lr` to zero.
-  Stripped, not scrubbed — it poisons an already-at-target URL (`hl`/`lr` set, `oq` riding
-  along), the same stuck-state recovery `gs_lcrp` needs. The lone convicted _user-facing_
-  param: kept until reported, moved to `stripParams` because it drives nothing the user sees.
 - **Server-side session pin** — zero results on a fully cleaned URL (post-strip, `hl`/`lr`
   correct) that read ~1M in the same browser minutes later; every parameter on it acquitted
   individually. The pin rode the session, seeded by the entry request served before the


### PR DESCRIPTION
Corrective follow-up to #212. That PR merged the earlier **`oq` strip**, which — after **driving Chrome** — turned out to be a **red herring**. This reverts it and lands the real fix.

## What driving Chrome showed

- The extension is active and rewrites searches to add `hl`+`lr`.
- **The exact reported URL — `oq=htkt ` + `lr` — returned a full page of Ukrainian results.** So `oq` is not the cause; the pinning is ephemeral/session-bound (the repo's own finding #1), and the earlier "strip `oq` → works" A/B was **pin decay**.
- Any `lr`-less `/search` gets `lr` re-added (the enabling condition below).

## The real bug (the captcha clue)

Solving a Google **captcha** leaves a degraded-trust session state; a search carrying `lr` intersects that pinned candidate set down to **zero organic results**. `emptyResultsRetry` exists to recover exactly this (drop `lr`, retry once) — but since #211 the DNR redirect rule (rule 2) re-adds `lr` at the **network layer** on every `/search?q=` `main_frame` request. It has no view of the content-script loop-guard the retry relies on, so it bounces the retry straight back to the pinned URL. **The retry has been a silent no-op against the DNR layer since #211.**

## The fix

Before its `lr`-dropped navigation, the retry messages the background to **suspend rule 2** (`movar:suspendGoogleRedirect` → `suspendGoogleSearchRedirectRule`). A ~30s alarm re-installs it — self-healing across a closed tab or a slept worker (a `setTimeout` wouldn't survive SW suspension). During a run of failing searches the DNR layer backs off and the content-script + retry path that predates #211 carries Google; DNR re-enables once searches recover.

**Privacy:** the exemption is extension-side state, **not** a URL sentinel param — so nothing that fingerprints "this user runs Movar" is ever sent to Google.

## Changes

- **Revert** the `oq` strip #212 shipped (back to `stripParams: ['sei','gs_lcrp']`).
- `messaging.ts`, `dnr.ts`, `background.ts`, `empty-results-retry.ts`, `content-runtime.ts` — the suspend/restore handshake.
- Tests: `dnr.test.ts`, `empty-results-retry.test.ts`, `background.test.ts`, integration-test deps.
- `docs/google-search-url-params.md` — documents the layer-0/layer-2 handshake so it can't be silently re-broken.

## Verification

- Full gate green: **1144 extension tests**, typecheck, lint, e2e-fast, fallow audit.
- Live in Chrome: the three observations above.
- ⚠️ **The pinned/post-captcha state can't be reproduced on demand** (I can't solve captchas, and won't hammer Google). End-to-end zero→recover needs real-world verification: after a captcha + zero results, the page should now auto-reload once without `lr` and show results.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
