### PR TITLE
fix(safari): bundle dynamic capability chunks so iOS content filtering works

### DIFF
--- a/.changeset/safari-bundle-capability-chunks.md
+++ b/.changeset/safari-bundle-capability-chunks.md
@@ -1,0 +1,7 @@
+---
+'@movar/extension': patch
+---
+
+Fix content filtering (concealment) silently not working on iOS/Safari.
+
+The dynamic capability chunks the content script imports at runtime via `runtime.getURL` — `features/conceal.js`, `features/curtain-ui.js`, and the per-site `models/*.js` — were emitted into the Safari build output and rsynced onto disk, but `features/` and `models/` were never registered as folder references in `Movar.xcodeproj`. Xcode only bundles referenced folders, so both directories were dropped from the built `.appex`: on-device, `import(runtime.getURL('features/conceal.js'))` 404'd and `capability-loader`'s `.catch(() => null)` turned it into a silent no-op, leaving concealment dead on iOS while the Accept-Language language switch (a background DNR rule, not a content-script chunk) kept working. Register `features/` and `models/` as folder references in both extension targets, and add a post-sync guard to `sync-safari-resources.mts` that fails the build if any emitted output directory lacks a folder reference, so the drift can't recur unnoticed.

--- a/apps/extension/safari/Movar/Movar.xcodeproj/project.pbxproj
+++ b/apps/extension/safari/Movar/Movar.xcodeproj/project.pbxproj
@@ -49,6 +49,10 @@
 		3B701CB92FCE1FC300E8A5FF /* _locales in Resources */ = {isa = PBXBuildFile; fileRef = 3B701CA52FCE1FC300E8A5FF /* _locales */; };
 		3B701CBA2FCE1FC300E8A5FF /* icon in Resources */ = {isa = PBXBuildFile; fileRef = 3B701CA62FCE1FC300E8A5FF /* icon */; };
 		3B701CBB2FCE1FC300E8A5FF /* assets in Resources */ = {isa = PBXBuildFile; fileRef = 3B701CA72FCE1FC300E8A5FF /* assets */; };
+		3B701D0200000000000000A1 /* features in Resources */ = {isa = PBXBuildFile; fileRef = 3B701D0200000000000000F1 /* features */; };
+		3B701D0200000000000000B1 /* features in Resources */ = {isa = PBXBuildFile; fileRef = 3B701D0200000000000000F1 /* features */; };
+		3B701D0200000000000000A2 /* models in Resources */ = {isa = PBXBuildFile; fileRef = 3B701D0200000000000000F2 /* models */; };
+		3B701D0200000000000000B2 /* models in Resources */ = {isa = PBXBuildFile; fileRef = 3B701D0200000000000000F2 /* models */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -126,6 +130,8 @@
 		3B701CA52FCE1FC300E8A5FF /* _locales */ = {isa = PBXFileReference; lastKnownFileType = folder; name = _locales; path = Resources/_locales; sourceTree = "<group>"; };
 		3B701CA62FCE1FC300E8A5FF /* icon */ = {isa = PBXFileReference; lastKnownFileType = folder; name = icon; path = Resources/icon; sourceTree = "<group>"; };
 		3B701CA72FCE1FC300E8A5FF /* assets */ = {isa = PBXFileReference; lastKnownFileType = folder; name = assets; path = Resources/assets; sourceTree = "<group>"; };
+		3B701D0200000000000000F1 /* features */ = {isa = PBXFileReference; lastKnownFileType = folder; name = features; path = Resources/features; sourceTree = "<group>"; };
+		3B701D0200000000000000F2 /* models */ = {isa = PBXFileReference; lastKnownFileType = folder; name = models; path = Resources/models; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -265,6 +271,8 @@
 				3B701CA52FCE1FC300E8A5FF /* _locales */,
 				3B701CA62FCE1FC300E8A5FF /* icon */,
 				3B701CA72FCE1FC300E8A5FF /* assets */,
+				3B701D0200000000000000F1 /* features */,
+				3B701D0200000000000000F2 /* models */,
 			);
 			name = Resources;
 			path = "Shared (Extension)";
@@ -438,6 +446,8 @@
 				3B701CB42FCE1FC300E8A5FF /* icon.svg in Resources */,
 				3B701CB52FCE1FC300E8A5FF /* chunks in Resources */,
 				3B701CBB2FCE1FC300E8A5FF /* assets in Resources */,
+				3B701D0200000000000000B1 /* features in Resources */,
+				3B701D0200000000000000B2 /* models in Resources */,
 				3B701CB32FCE1FC300E8A5FF /* popup.html in Resources */,
 				3B701CB72FCE1FC300E8A5FF /* manifest.json in Resources */,
 				3B701CBA2FCE1FC300E8A5FF /* icon in Resources */,
@@ -455,6 +465,8 @@
 				3B701CAA2FCE1FC300E8A5FF /* icon.svg in Resources */,
 				3B701CAB2FCE1FC300E8A5FF /* chunks in Resources */,
 				3B701CB12FCE1FC300E8A5FF /* assets in Resources */,
+				3B701D0200000000000000A1 /* features in Resources */,
+				3B701D0200000000000000A2 /* models in Resources */,
 				3B701CA92FCE1FC300E8A5FF /* popup.html in Resources */,
 				3B701CAD2FCE1FC300E8A5FF /* manifest.json in Resources */,
 				3B701CB02FCE1FC300E8A5FF /* icon in Resources */,

--- a/apps/extension/scripts/sync-safari-resources.mts
+++ b/apps/extension/scripts/sync-safari-resources.mts
@@ -5,12 +5,19 @@
  * `apps/extension/safari/`. The shell's "Movar Extension" target bundles
  * everything under `Movar/Shared (Extension)/Resources/` — that's the
  * directory Safari actually loads at runtime. The Xcode project references
- * `chunks/`, `content-scripts/`, `_locales/`, `icon/`, and `assets/` as
- * folder references (`lastKnownFileType = folder`), so any file inside
- * gets picked up automatically on the next Xcode build. Top-level files
- * (`manifest.json`, `popup.html`, `options.html`, `background.js`,
+ * `chunks/`, `content-scripts/`, `features/`, `models/`, `_locales/`, `icon/`,
+ * and `assets/` as folder references (`lastKnownFileType = folder`), so any
+ * file inside gets picked up automatically on the next Xcode build. Top-level
+ * files (`manifest.json`, `popup.html`, `options.html`, `background.js`,
  * `icon.svg`) have stable names, so the per-file references in
  * `Movar.xcodeproj/project.pbxproj` stay valid across rebuilds.
+ *
+ * `features/` and `models/` (the dynamic capability chunks the content script
+ * imports via `runtime.getURL`) were missing from that list until it silently
+ * broke concealment on iOS — Xcode never copied them into the `.appex`, so the
+ * import 404'd on-device and capability-loader swallowed the error. The
+ * post-sync guard below now fails the build if any emitted output directory
+ * lacks a folder reference, so that class of drift can't recur unnoticed.
  *
  * Strategy: rsync with `--delete` so removed chunks vanish from the Xcode
  * tree. This is idempotent and survives Storybook/Vite hash rotations.
@@ -21,7 +28,7 @@
  * latest JS build.
  */
 import { spawnSync } from 'node:child_process';
-import { existsSync, mkdirSync } from 'node:fs';
+import { existsSync, mkdirSync, readFileSync, readdirSync } from 'node:fs';
 import path from 'node:path';
 
 const ROOT = path.resolve(import.meta.dirname, '..');
@@ -53,3 +60,48 @@ const result = spawnSync('rsync', args, { stdio: 'inherit' });
 if (result.status !== 0) {
   process.exit(result.status ?? 1);
 }
+
+// Guard: every top-level DIRECTORY the build emits must be wired into the Xcode
+// project as a folder reference, or Xcode silently omits it from the built
+// `.appex`. The file still lands in Resources/ on disk (the rsync above) but
+// never ships — which is exactly how the dynamic capability chunks regressed:
+// `features/` and `models/` were emitted + synced but unreferenced, so the
+// content script's `import(runtime.getURL('features/conceal.js'))` 404'd
+// on-device and capability-loader's `.catch(() => null)` turned it into a silent
+// no-op — concealment dead on iOS while everything statically bundled worked.
+//
+// Checked on directories, not files: the capability-chunk class is always a
+// directory, and files like `onboarding.html` are deliberately emitted-but-
+// unbundled on Safari (background.ts gates onboarding to non-Safari), which a
+// file-level check would flag as a false positive. Dot-dirs (e.g. Vite's
+// metadata) are build scratch, never bundled.
+const PBXPROJ = path.join(ROOT, 'safari', 'Movar', 'Movar.xcodeproj', 'project.pbxproj');
+const pbxproj = readFileSync(PBXPROJ, 'utf8');
+const emittedDirs = readdirSync(SOURCE, { withFileTypes: true })
+  .filter((entry) => entry.isDirectory() && !entry.name.startsWith('.'))
+  .map((entry) => entry.name);
+// Folder refs read `path = Resources/<name>;`, or quoted when the name has a
+// hyphen: `path = "Resources/content-scripts"`. Match on the trailing delimiter
+// (`;` or `"`) so `icon` doesn't spuriously satisfy the check for `icon.svg`.
+const unreferenced = emittedDirs.filter(
+  (name) => !pbxproj.includes(`Resources/${name};`) && !pbxproj.includes(`Resources/${name}"`),
+);
+if (unreferenced.length > 0) {
+  const plural = unreferenced.length === 1 ? 'y is' : 'ies are';
+  process.stderr.write(
+    `[movar:safari-sync] ${unreferenced.length} build-output director${plural} not referenced in\n` +
+      `  ${path.relative(ROOT, PBXPROJ)}:\n` +
+      unreferenced.map((name) => `    - ${name}/\n`).join('') +
+      `\nXcode only bundles referenced folders, so these would be MISSING from the built\n` +
+      `.appex and any runtime.getURL('${unreferenced[0]}/…') would 404 on-device (silently —\n` +
+      `capability-loader.ts swallows the import failure). Add each as a folder reference to\n` +
+      `both "Movar Extension" targets — mirror how 'chunks' is wired in project.pbxproj (a\n` +
+      `PBXFileReference with lastKnownFileType = folder, a Resources group child, and a\n` +
+      `PBXBuildFile per target in each Copy Bundle Resources phase).\n`,
+  );
+  process.exit(1);
+}
+
+process.stdout.write(
+  `[movar:safari-sync] OK — all ${emittedDirs.length} emitted resource dirs referenced in the Xcode project\n`,
+);


### PR DESCRIPTION
## Problem

On a real iOS device the search-language switch works but **content filtering (concealment) silently does nothing**.

Filtering is loaded by the content script at runtime via `import(runtime.getURL('features/conceal.js'))` plus a per-site `models/*.js` chunk. On Safari the extension is packaged by Xcode, which only bundles folders it **references** — and `Movar.xcodeproj` referenced `chunks/`, `content-scripts/`, `_locales/`, `icon/`, `assets/` but **never `features/` or `models/`**.

`sync-safari-resources.mts` rsynced those dirs onto disk, so they *looked* present locally, but Xcode dropped them from the built `.appex`. On-device, the import 404'd and `capability-loader`'s `.catch(() => null)` turned it into a silent no-op. The language switch was unaffected because it rides the background Accept-Language DNR rule, not a content-script chunk — which is why only filtering broke.

## Fix

- **`project.pbxproj`** — register `features/` and `models/` as folder references and add them to both "Movar Extension" targets' Copy Bundle Resources phases (mirrors how `chunks/` is wired). `plutil -lint` passes.
- **`sync-safari-resources.mts`** — add a post-sync **drift guard** that fails the build if any emitted top-level output directory lacks a folder reference, so this class of silent packaging drift can't recur. Dir-only by design, so it doesn't false-positive on intentionally-unbundled files (e.g. `onboarding.html`). Also refreshed the stale header comment.

## Verification

`pnpm --filter @movar/extension build:safari` → exit 0:
- `[movar:safari-sync] OK — all 7 emitted resource dirs referenced in the Xcode project`
- `.output/safari-mv3/features/` → `conceal.js`, `curtain-ui.js`; `models/` → `google.js`, `youtube.js` — emitted and now referenced.

Prettier / ESLint / typecheck clean on the changed files.

> Note: on-device confirmation still requires rebuilding the Xcode app shell (`build:safari:app`) and reinstalling on the device. After that, Safari Web Inspector → Network should show `features/conceal.js` load **200** instead of 404.

🤖 Generated with [Claude Code](https://claude.com/claude-code)