### PR TITLE
fix(safari-macos): enlarge and allow resizing the host wrapper window

### DIFF
--- a/apps/extension/safari/Movar/Shared (App)/ViewController.swift
+++ b/apps/extension/safari/Movar/Shared (App)/ViewController.swift
@@ -109,6 +109,18 @@ class ViewController: PlatformViewController, WKNavigationDelegate, WKScriptMess
         self.webView.loadFileURL(Bundle.main.url(forResource: "Main", withExtension: "html")!, allowingReadAccessTo: Bundle.main.resourceURL!)
     }
 
+#if os(macOS)
+    override func viewWillAppear() {
+        super.viewWillAppear()
+        // The host screen stacks a fixed top brand bar, a scrolling settings
+        // panel, and a fixed bottom tab bar. The window is resizable (see
+        // Main.storyboard); pin a floor so a resize can't shrink it below the
+        // point where those three zones stop fitting. The default size lives in
+        // the storyboard's contentRect.
+        self.view.window?.contentMinSize = NSSize(width: 380, height: 480)
+    }
+#endif
+
     func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
 #if os(iOS)
         webView.evaluateJavaScript("show('ios')")

--- a/apps/extension/safari/Movar/macOS (App)/Base.lproj/Main.storyboard
+++ b/apps/extension/safari/Movar/macOS (App)/Base.lproj/Main.storyboard
@@ -78,9 +78,9 @@
             <objects>
                 <windowController showSeguePresentationStyle="single" id="B8D-0N-5wS" sceneMemberID="viewController">
                     <window key="window" title="Movar" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" restorable="NO" releasedWhenClosed="NO" animationBehavior="default" id="IQv-IB-iLA">
-                        <windowStyleMask key="styleMask" titled="YES" closable="YES"/>
+                        <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES" resizable="YES"/>
                         <windowCollectionBehavior key="collectionBehavior" fullScreenNone="YES"/>
-                        <rect key="contentRect" x="196" y="240" width="425" height="350"/>
+                        <rect key="contentRect" x="196" y="240" width="480" height="700"/>
                         <rect key="screenRect" x="0.0" y="0.0" width="1680" height="1027"/>
                         <connections>
                             <outlet property="delegate" destination="B8D-0N-5wS" id="98r-iN-zZc"/>
@@ -99,11 +99,11 @@
             <objects>
                 <viewController id="XfG-lQ-9wD" customClass="ViewController" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" id="m2S-Jp-Qdl">
-                        <rect key="frame" x="0.0" y="0.0" width="425" height="350"/>
+                        <rect key="frame" x="0.0" y="0.0" width="480" height="700"/>
                         <autoresizingMask key="autoresizingMask"/>
                         <subviews>
                             <wkWebView wantsLayer="YES" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="eOr-cG-IQY">
-                                <rect key="frame" x="0.0" y="0.0" width="425" height="350"/>
+                                <rect key="frame" x="0.0" y="0.0" width="480" height="700"/>
                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                 <wkWebViewConfiguration key="configuration">
                                     <audiovisualMediaTypes key="mediaTypesRequiringUserActionForPlayback" none="YES"/>


### PR DESCRIPTION
## Problem

The macOS wrapper app (`apps/extension/safari/Movar`) opened its host window at the stock Apple Safari-extension template size — **425×350** — and the window wasn't even resizable (`styleMask` was `titled + closable` only). The three-tab host UI (fixed top brand bar + scrolling Settings panel + fixed bottom tab bar) was clipped, with no way for the user to enlarge it. Flagged as the last v1.3.0 release blocker.

## Fix

`macOS (App)/Base.lproj/Main.storyboard`:
- Default `contentRect` **425×350 → 480×700** (view + WKWebView design-time frames updated to match).
- Added `resizable` + `miniaturizable` to the window `styleMask`.

`Shared (App)/ViewController.swift`:
- Pin `contentMinSize = 380×480` on macOS in `viewWillAppear()` so a resize can't shrink the window below usability. iOS is untouched (`#if os(macOS)`-guarded).

The window has `restorable="NO"` and no frame-autosave name, so it opens at 480×700 on every launch — nothing is persisted across runs.

## Verification

- Storyboard compiles cleanly with `ibtool --compile` (the real Xcode compiler).
- `swiftc -typecheck` passes for **both** the macOS and iOS targets (confirms the guarded change compiles and the iOS build is unaffected).
- Built + ran the macOS app — window opens at the new size and resizes correctly (confirmed visually).

Part of the **v1.3.0** release (#194).

🤖 Generated with [Claude Code](https://claude.com/claude-code)