### PR TITLE
fix(extension): stop the MV3 service worker crashing on every page load

### DIFF
--- a/packages/lang-detect/src/engines/franc-core.ts
+++ b/packages/lang-detect/src/engines/franc-core.ts
@@ -1,11 +1,13 @@
 /**
  * franc engine core — the trigram detect body + ISO-639-3→BCP-47 map.
  *
- * Isolated from the engine wrapper (./franc.ts) so the wrapper can load this
- * lazily: `franc`'s trigram tables are large (~170 KB), and consumers that
- * never reach the franc rung — or host it elsewhere, e.g. a background worker
- * reached by message — shouldn't pay for the tables in their main bundle. This
- * module is the ONLY franc importer on the engine side.
+ * Isolated from the engine wrapper (./franc.ts) so the ~170 KB of `franc`
+ * trigram tables sit in one module that only the wrapper (and franc-hosting
+ * consumers, e.g. a background worker reached by message) import — the
+ * franc-free barrel never reaches here. The wrapper imports this STATICALLY
+ * (not lazily): a code-split lazy import drags in Vite's DOM-reading
+ * `__vitePreload` helper, which crashes the DOM-less MV3 service worker — see
+ * ./franc.ts. This module is the ONLY franc importer on the engine side.
  *
  * Pure + isomorphic: no DOM, no browser/worker APIs. `franc` runs identically
  * in Node and the browser, so this stays drop-in for either host.

--- a/packages/lang-detect/src/engines/franc.ts
+++ b/packages/lang-detect/src/engines/franc.ts
@@ -1,43 +1,57 @@
 /**
  * franc engine — trigram-based body-text detection (franc, 187 languages).
  *
- * The heavy franc tables live in ./franc-core and load lazily on the first
- * detect(), then stay cached for the process. Importing this engine (e.g. into
- * the default roster, or a background worker that hosts franc) therefore does
- * NOT statically pull franc's tables — a consumer that never calls detect()
- * never loads them. Stays DOM/worker-agnostic and isomorphic.
+ * `./franc-core` (the ~170 KB of franc trigram tables) is imported STATICALLY
+ * here, on purpose and load-bearing. A *lazy* `import('./franc-core')` gets
+ * code-split into its own chunk, and Vite then wraps the dynamic import in its
+ * `__vitePreload` helper — which reads the DOM
+ * (`document.getElementsByTagName`, the CSP-nonce `<meta>`,
+ * `document.head.appendChild`) to inject `<link rel=modulepreload>` tags. WXT
+ * bundles the MV3 background service worker in the same DOM-assuming multi-page
+ * Vite build as the extension's HTML pages, so a lazy franc load there made the
+ * worker throw `ReferenceError: document is not defined` on every wake
+ * (`warmFranc` runs at SW boot) — surfacing as the extension "crashing" in
+ * chrome://extensions. A static import keeps franc-core in the importer's own
+ * chunk: no split, no preload helper, no DOM access. See wxt.config's
+ * `assertContentFrancFree` note for the counterpart size/isolation guards.
+ *
+ * Bundle isolation is unchanged: the franc-free barrel (`@movar/lang-detect`)
+ * still never imports this module, so the content script — which reaches franc
+ * only through the background message bridge — stays franc-free (enforced by the
+ * content-bundle guards). Every consumer of this wrapper (the background worker,
+ * the diagnostics + Safari host apps) already loads franc eagerly via
+ * `classify-franc`, so eager franc-core adds no real weight to any of them.
  *
  * Always available — `isAvailable` returns a bare synchronous `true` so the
- * orchestrator can skip a promise round-trip; it must NOT touch the lazy core.
+ * orchestrator can skip a promise round-trip.
  */
+import { detectWithFranc } from './franc-core';
 import type { DetectContext, DetectedLanguage, LanguageDetectionEngine } from '../engine';
 
 const ENGINE_ID = 'franc';
-
-type FrancDetect = (text: string, ctx: DetectContext) => DetectedLanguage | null;
-
-/** Cached franc detect fn — franc's trigram tables are evaluated once per
- *  process on the first load (first detect(), or an explicit warmFranc()). */
-let cachedDetect: FrancDetect | null = null;
-
-async function loadDetect(): Promise<FrancDetect> {
-  cachedDetect ??= (await import('./franc-core')).detectWithFranc;
-  return cachedDetect;
-}
 
 export const francEngine: LanguageDetectionEngine = {
   id: ENGINE_ID,
   isAvailable(): boolean {
     return true;
   },
+  // franc itself is synchronous; the async signature satisfies the engine
+  // contract's Promise return. A franc throw surfaces to the orchestrator, which
+  // falls through to the next engine — matching the interface's documented
+  // "throwing behaves identically to null" semantics.
+  // eslint-disable-next-line @typescript-eslint/require-await -- sync in-process detector behind the async LanguageDetectionEngine.detect contract; nothing to await
   async detect(text, ctx: DetectContext): Promise<DetectedLanguage | null> {
-    const detect = await loadDetect();
-    return detect(text, ctx);
+    return detectWithFranc(text, ctx);
   },
 };
 
-/** Force the franc core to load now (cold-start mitigation for hosts that know
- *  a detect() is imminent — e.g. a background worker warming on startup). */
+/** No-op retained for API compatibility. franc-core is now statically bundled
+ *  with this module (see the header), so it is already parsed by the time this
+ *  module evaluates — there is nothing left to pre-load. Kept so the call sites
+ *  that warm franc before a known-imminent detect() (the background worker at
+ *  boot, `movar:warmFranc`) and their tests keep working unchanged; the message
+ *  itself still usefully wakes the service worker early. */
+// eslint-disable-next-line @typescript-eslint/require-await -- retained no-op behind the Promise<void> warmFranc contract; franc-core is statically bundled, nothing left to load
 export async function warmFranc(): Promise<void> {
-  await loadDetect();
+  // Intentionally empty — see the doc comment above.
 }

--- a/packages/lang-detect/src/franc.ts
+++ b/packages/lang-detect/src/franc.ts
@@ -1,8 +1,10 @@
 /**
  * `@movar/lang-detect/franc` — the opt-in franc subpath.
  *
- * Importing anything here statically pulls `franc` (the engine wrapper is lazy,
- * but `francOracle`/`francRung3Resolver` import franc's tables eagerly). The
+ * Importing anything here statically pulls `franc`'s trigram tables — the engine
+ * wrapper (`francEngine`/`warmFranc`) imports franc-core statically to keep the
+ * MV3 service worker off Vite's DOM-reading preload helper (see ./engines/franc),
+ * and `francOracle`/`francRung3Resolver` import the tables eagerly too. The
  * main barrel (`@movar/lang-detect`) is deliberately franc-free; consumers that
  * genuinely need franc in-process — the default roster, the extension's
  * background worker, diagnostics, tests — reach it through this entry so the


### PR DESCRIPTION
## The bug

The background **service worker threw `ReferenceError: document is not defined` on every page load** — which surfaces as the extension "crashing" (Errors badge) in `chrome://extensions`. It reproduced on any site but was most visible on pages where Movar does nothing (e.g. `vercel.com`), where that console error is the only thing on screen. The content script itself was fine.

## Root cause

The franc engine wrapper lazily did `import('./franc-core')`. Vite code-splits that dynamic import into a chunk and wraps it in its `__vitePreload` helper, which reads the DOM (`document.getElementsByTagName`, the CSP-nonce `<meta>`, `document.head.appendChild`) to inject `<link rel=modulepreload>` tags.

WXT bundles the MV3 background service worker in the **same DOM-assuming multi-page Vite build as the extension's HTML pages** (popup/options/onboarding), so `insertPreload` is on. Warming franc at SW boot (`warmFranc`) therefore ran that DOM-touching helper in a worker that has no `document`.

Notes for a reviewer:
- `build.modulePreload: false` does **not** fix this — Vite 7 gates the preload helper on `consumer` / `isWorker` / `lib`, not on `modulePreload`. Verified by dumping the resolved per-entrypoint config.
- Overriding Vite's internal preload-helper virtual module would be fragile across Vite upgrades, so the fix is at the source instead.

## The fix

Import `franc-core` **statically** in the engine wrapper (`packages/lang-detect/src/engines/franc.ts`). No code-split → no `__vitePreload` helper → no DOM access in the worker.

This is effectively free and does not change bundle isolation:
- franc's ~170 KB tables are **already eager** in `background.js` (via `francRung3Resolver` → `classify-franc`); `franc-core` is tiny.
- The content script never imports this path (it reaches franc only through the background message bridge), so it **stays franc-free** — enforced by the existing `assertContentFrancFree` / content-bundle-size guards.
- Only the background bundle changes: `franc-core` folds into `background.js` instead of becoming a split chunk.

`warmFranc` is now a documented no-op kept for API compatibility (the `movar:warmFranc` message still usefully wakes the worker early). Two doc comments updated to match.

## Verification

Reproduced and fixed against the **built extension in headless Chromium**:
- Before: SW logs `SW-UNHANDLED ReferenceError: document is not defined` on `vercel.com`. After: no SW error.
- franc detection still works in the worker: `movar:detectText` → `ru`/`en`, `movar:classifySnippets` classifies correctly, `movar:warmFranc` resolves.
- **`content.js` is byte-identical** before/after (same SHA-256, 41,223 B) — proven with a before/after build diff. Background loses the `franc-core` split chunk and all 5 `document.` refs.
- Full gates green: lang-detect (231) + extension (1145) unit tests, typecheck, lint, and the pre-push build + e2e-fast (popup/options) + fallow metrics audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)