### PR TITLE
refactor(radius): source the host's two raw 8px control corners from its --radius var

### DIFF
--- a/apps/safari-host-app/src/styles.css
+++ b/apps/safari-host-app/src/styles.css
@@ -328,7 +328,7 @@ html.platform-mac body {
   gap: 3px;
   padding: 3px 2px;
   border: none;
-  border-radius: 8px;
+  border-radius: var(--radius);
   background: transparent;
   color: var(--ink-faint);
   font-family: inherit;
@@ -693,7 +693,7 @@ button.open-preferences {
   appearance: none;
   cursor: pointer;
   border: none;
-  border-radius: 8px;
+  border-radius: var(--radius);
   padding: 10px 18px;
   /* Ink-strong primary, matching the detector's Detect button + gracious-bassi
    * (near-black in light, near-white in dark). */


### PR DESCRIPTION
## Radius — audited, one safe intra-host tidy

Second token-consistency pass. Audited every surface against `@movar/theme`'s
radius scale (`chip`=`rounded-md`, `control`=`rounded-lg`, `panel`=`rounded-xl`,
`card`=`rounded-card`, `pill`=`rounded-full`; only `--radius-card` is emitted, the
rest map to Tailwind built-ins).

### Result — the system is coherent
- **Web product** (popup, options, marketing, ui) uses `rounded-{md,lg,xl,card,full}`
  correctly — no arbitrary `rounded-[…]`. The one `rounded-[3px]` (ConcealModeField)
  is a **miniature mockup proportion** (a 12px avatar placeholder inside a scaled-down
  "content feed" preview illustration), not UI chrome — a legit exception.
- **Injected content scripts** (curtain/tooltip `border-radius: 6px`, `--movar-radius`)
  use the sanctioned inline-px pattern (no Movar `:root` on host pages).
- **Marketing** `border-radius: 9999px` is the universal pill idiom.

### The safari host is a documented fixed-px exception (theme-sourcing rejected)
The host declares local `--radius: 8px` / `--radius-lg: 12px` — deliberately **fixed
px** "native corner radii" (its own layout-tokens note documents this). Its type scale
is **rem** (iOS Dynamic-Type-scaling), so sourcing radii from the theme's **rem**
tokens (`control: 0.5rem`) would make corners grow with text size — a behavior change
the host avoids. Per the pushback rule, that's a reject.

### The one safe fix (this PR)
Two host controls — a tab-style button and the primary action — hardcoded
`border-radius: 8px` while five siblings use `var(--radius)`. Point them at the var so
all the host's control corners resolve from one place.

**Pixel-neutral by construction** — `var(--radius)` resolves to the same `8px` (declared
at `:root`), so no visual change and no baseline moves. CI's host visual suite compares
against the unchanged committed PNGs (the automatic backstop; the local amd64 baseline
container hit unrelated infra flakiness this run, so I lean on the CSS-semantics
guarantee + CI). No theme change.

## Verification
- Full monorepo pre-commit gate (prettier; the change is CSS-only so lint/test/typecheck
  had no matching staged files) + pre-push gate (build compiles the host, e2e-fast,
  metrics) green.