### PR TITLE
refactor(motion): source the safari host's hover transitions from --duration-fast

### DIFF
--- a/apps/safari-host-app/src/styles.css
+++ b/apps/safari-host-app/src/styles.css
@@ -30,14 +30,15 @@
 /*
  * Design tokens — one `@import` per token set from `@movar/theme` (same tokens
  * as the popup, options, onboarding, and marketing site). This screen renders
- * through colors, type, and shadows. Its host-only overrides (the `rem` type
- * scale for Dynamic Type, the frosted bar fill, the native corner radii, and the
- * `--content-max` cap) are layered on top further down.
+ * through colors, type, shadows, and motion. Its host-only overrides (the `rem`
+ * type scale for Dynamic Type, the frosted bar fill, the native corner radii,
+ * and the `--content-max` cap) are layered on top further down.
  */
 @import '@movar/theme/color.css';
 @import '@movar/theme/typography.css';
 @import '@movar/theme/type.css';
 @import '@movar/theme/shadow.css';
+@import '@movar/theme/motion.css';
 
 /* Brand type — the same per-subset weights the extension bundles. */
 @import '@fontsource/manrope/latin-400.css';
@@ -335,7 +336,7 @@ html.platform-mac body {
   font-size: var(--text-ui-micro);
   font-weight: 500;
   letter-spacing: -0.01em;
-  transition: color 120ms ease;
+  transition: color var(--duration-fast) ease;
 }
 
 .tab-ico {
@@ -541,7 +542,7 @@ html.platform-mac body {
   color: var(--ink-soft);
   font-family: inherit;
   font-size: var(--text-ui-sm);
-  transition: color 120ms ease;
+  transition: color var(--duration-fast) ease;
 }
 
 .link:hover {
@@ -703,7 +704,7 @@ button.open-preferences {
   font-family: inherit;
   font-size: var(--text-ui-base);
   font-weight: 600;
-  transition: background-color 120ms ease;
+  transition: background-color var(--duration-fast) ease;
 }
 
 button.open-preferences .ico {
@@ -812,9 +813,9 @@ button.open-preferences:focus-visible {
   font-weight: 600;
   line-height: 1.2;
   transition:
-    background-color 120ms ease,
-    color 120ms ease,
-    border-color 120ms ease;
+    background-color var(--duration-fast) ease,
+    color var(--duration-fast) ease,
+    border-color var(--duration-fast) ease;
 }
 
 .btn .ico {


### PR DESCRIPTION
## Motion — give the dead motion set a consumer

Fourth token-consistency pass. Audited every surface against `@movar/theme`'s
motion set (`duration.{fast,base,slow}` → raw `--duration-*` vars in `motion.css`;
`easing` is typed-constant-only, deliberately **not** emitted as a var; the §7
applied-pulse keyframe → `--animate-pulse-dot`).

### Finding
`motion.css` had **zero consumers** — no surface imported it, and nothing used
`--duration-*` or `animate-pulse-dot`. Meanwhile the safari host hand-coded
`120ms ease` in **six** color/background hover transitions — which is exactly
`duration.fast` ("color / background hovers"), duplicated as a literal. The host
was also the product's only hand-written CSS with transition timings; the React
surfaces animate through Tailwind's built-in `transition`/`transition-colors`
(150 ms default = `duration.base`), which is the same "aligned to Tailwind
defaults" pattern spacing/radius use — not a bypass.

### Fix
Import `@movar/theme/motion.css` alongside the host's other theme sets and point
the six transitions at `var(--duration-fast)`. `ease` stays (it's
`easing.standard`; re-emitting `--ease-*` would clobber Tailwind's cubic-beziers).
Now the one surface that hand-writes transitions sources its timing from the
token, and `motion.css` finally has a home.

### Left as-is (legit)
- React `transition-colors` / `duration-150` — Tailwind defaults that align 1:1
  with `duration.base`.
- Marketing hero-aurora keyframes (22s/28s) — decorative, part of the sanctioned
  `--glow-*` aurora system.
- `--animate-pulse-dot` — the blessed §7 applied-moment animation, reserved for
  when that UI is built (unused ≠ bypass); now importable by the host.
- Injected curtain/tooltip inline `duration`/`easing` constants (no Movar `:root`
  on host pages).

## Verification
- **Proved it resolves**: built the host and confirmed the compiled CSS carries
  `--duration-fast: .12s` (Tailwind's minified 120 ms) with the six transitions
  referencing `var(--duration-fast)`, plus the `movar-pulse` keyframe.
- Pixel-neutral (same 120 ms; transitions don't render in static baselines) — no
  baseline moves. Pre-commit (prettier) + pre-push (build + e2e-fast + metrics) green.