### PR TITLE
fix(marketing): source the homepage title & OG tagline from one slogan constant

### DIFF
--- a/apps/marketing/src/i18n.ts
+++ b/apps/marketing/src/i18n.ts
@@ -316,10 +316,36 @@ export interface Strings {
   installGuide: InstallGuideStrings;
 }
 
+/**
+ * Brand tagline — the single source of truth for the two-line slogan. The
+ * marketing hero, the OG share card, and the homepage <title> all derive
+ * from this, so the wording can't drift between surfaces the way it once did
+ * (the <title> read lowercase "keep the internet…" while every other surface
+ * read "Keep the internet…").
+ *
+ * Line 2 keeps its trailing period because the hero and OG card render it as
+ * a sentence; the <title> strips it via `titleTagline`, matching this app's
+ * other page titles, which carry no sentence punctuation.
+ *
+ * The README and the extension store listings mirror this wording through
+ * their own parity checks — `scripts/check-readme-parity.mts` reads
+ * `strings.en.hero`, so this stays the canonical source for them too.
+ */
+const tagline = {
+  en: { line1: 'Keep the internet', line2: 'in your language.' },
+  uk: { line1: 'Налаштуйте інтернет', line2: 'на рідну мову.' },
+} as const satisfies Record<Locale, { line1: string; line2: string }>;
+
+/** The tagline as a single `<title>` line — joined, trailing period dropped. */
+const titleTagline = (locale: Locale): string => {
+  const line = `${tagline[locale].line1} ${tagline[locale].line2}`;
+  return line.endsWith('.') ? line.slice(0, -1) : line;
+};
+
 const en: Strings = {
   meta: {
     htmlLang: 'en',
-    defaultTitle: 'Movar — keep the internet in your language',
+    defaultTitle: `Movar — ${titleTagline('en')}`,
     defaultDescription:
       'Movar puts the right language in front of you on Google, YouTube, and bilingual sites — without translating a thing. Free, open source, stays in your browser.',
   },
@@ -335,8 +361,8 @@ const en: Strings = {
       openSource: 'Open source',
       privacy: 'Nothing leaves your browser',
     },
-    headlineLine1: 'Keep the internet',
-    headlineLine2: 'in your language.',
+    headlineLine1: tagline.en.line1,
+    headlineLine2: tagline.en.line2,
     subhead:
       "Sites keep handing you the wrong language even when you've asked clearly. Movar fixes that — quietly, without translating a thing.",
   },
@@ -524,8 +550,8 @@ const en: Strings = {
     soon: 'Soon',
   },
   og: {
-    taglineLine1: 'Keep the internet',
-    taglineLine2: 'in your language.',
+    taglineLine1: tagline.en.line1,
+    taglineLine2: tagline.en.line2,
     caption: 'Free · Open source · No tracking',
   },
   whyThisHappens: {
@@ -741,7 +767,7 @@ const en: Strings = {
 const uk: Strings = {
   meta: {
     htmlLang: 'uk',
-    defaultTitle: 'Movar — налаштуйте інтернет на рідну мову',
+    defaultTitle: `Movar — ${titleTagline('uk')}`,
     defaultDescription:
       'Movar відкриває пошук Google, YouTube і двомовні сайти вашою мовою — без перекладу. Безкоштовно, відкритий код, лише у вашому браузері.',
   },
@@ -757,8 +783,8 @@ const uk: Strings = {
       openSource: 'Відкритий код',
       privacy: 'Нічого не покидає браузер',
     },
-    headlineLine1: 'Налаштуйте інтернет',
-    headlineLine2: 'на рідну мову.',
+    headlineLine1: tagline.uk.line1,
+    headlineLine2: tagline.uk.line2,
     subhead:
       'Ви налаштували браузер на українську, а сайти все одно вперто навʼязують російську. Movar невтомно повертає вашу мову — на кожній сторінці, без жодного перекладу.',
   },
@@ -946,8 +972,8 @@ const uk: Strings = {
     soon: 'Незабаром',
   },
   og: {
-    taglineLine1: 'Налаштуйте інтернет',
-    taglineLine2: 'на рідну мову.',
+    taglineLine1: tagline.uk.line1,
+    taglineLine2: tagline.uk.line2,
     caption: 'Безкоштовно · Відкритий код · Без стеження',
   },
   whyThisHappens: {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "movar",
   "version": "0.0.0",
   "private": true,
-  "description": "Movar — keep the internet in your language. A cross-browser extension enforcing your language preferences (UA first, EN fallback).",
+  "description": "Movar — Keep the internet in your language. A cross-browser extension enforcing your language preferences (UA first, EN fallback).",
   "packageManager": "pnpm@11.3.0",
   "engines": {
     "node": ">=22",


### PR DESCRIPTION
## What & why

The homepage `<title>` — and the OG / Twitter share card's title text + `og:image:alt` — read a **lowercased, drifted** copy of the brand tagline:

> Movar — **keep** the internet in your language

while the hero, the OG image itself, the README, and the store listings all read the canonical **Keep the internet in your language.** Both symptoms trace to a single string, `meta.defaultTitle`, which feeds the tab title *and* `og:title` / `twitter:title` / `og:image:alt`.

## How

- Add a single `tagline` constant in `apps/marketing/src/i18n.ts` (en + uk). The hero headline, the OG card tagline, and the homepage `<title>` all derive from it, so the wording can't drift between surfaces again.
- The `<title>` drops the trailing period to match the app's other page titles (`Privacy — Movar`, `Install guide — Movar`, …).
- Capitalise the same slogan in the root `package.json` description.

| Surface | Before | After |
|---|---|---|
| `<title>` / `og:title` (en) | `Movar — keep the internet in your language` | `Movar — Keep the internet in your language` |
| `<title>` / `og:title` (uk) | `Movar — налаштуйте інтернет на рідну мову` | `Movar — Налаштуйте інтернет на рідну мову` |

## Notes

- The OG **image** PNG was already correct and is unchanged — no asset regeneration.
- `pnpm check:readme` stays green: its parity guard reads `strings.en.hero`, whose value is untouched.
- If an old title shows in a live Facebook / X / LinkedIn preview, that's their OG cache — re-scrape the URL in the platform's sharing debugger once this deploys.

## Verification

- **pre-commit**: eslint, prettier, typecheck (astro check 0 errors + nx 19 projects), test, check:readme, suppressions — all green
- **pre-push**: build + metrics:audit — green (e2e skipped: no matching files)
- Built `dist/index.html` + `dist/uk/index.html`: `<title>`, `og:title`, `og:image:alt` corrected in both locales

🤖 Generated with [Claude Code](https://claude.com/claude-code)
