### PR TITLE
fix(lang-switch): recover the switch on UMI.CMS shops with a bouncing hreflang

### DIFF
--- a/apps/extension/src/lib/language-switch.test.ts
+++ b/apps/extension/src/lib/language-switch.test.ts
@@ -167,9 +167,32 @@ describe('tryHreflangRedirect', () => {
 });
 
 describe('tryPickerRedirect', () => {
-  it('bails when recently attempted', async () => {
+  it('anchor picker fires on a recently-attempted URL when the target is untried', async () => {
+    // The page's own hreflang bounced us back to this blocked URL (so
+    // recentlyAttemptedHere is true), but the on-page switcher points at a
+    // DIFFERENT, untried URL — follow it instead of giving up.
     const deps = makeDeps({ recentlyAttemptedHere: vi.fn(() => true) });
-    expect(await tryPickerRedirect(deps, [], 'ru', ['uk'])).toBe(false);
+    const link = anchor('https://example.com/uk');
+    expect(await tryPickerRedirect(deps, [picker(link, 'uk')], 'ru', ['uk'])).toBe(true);
+    expect(deps.location.replace).toHaveBeenCalledWith('https://example.com/uk');
+  });
+
+  it('records the anchor target in the loop guard so a bounce cannot re-fire it', async () => {
+    // markAttempt(target) is the safety net that replaces the coarse guard: a
+    // genuinely-bouncing picker (target 301s back here) is caught on the next
+    // pass by hasAttemptedNavTo(target), not by recentlyAttemptedHere.
+    const deps = makeDeps({ recentlyAttemptedHere: vi.fn(() => true) });
+    const link = anchor('https://example.com/uk');
+    await tryPickerRedirect(deps, [picker(link, 'uk')], 'ru', ['uk']);
+    expect(deps.markAttempt).toHaveBeenCalledWith('https://example.com/uk');
+  });
+
+  it('button picker still bails on a recently-attempted URL (no target to guard per-target)', async () => {
+    const deps = makeDeps({ recentlyAttemptedHere: vi.fn(() => true) });
+    const button = document.createElement('button');
+    const click = vi.spyOn(button, 'click');
+    expect(await tryPickerRedirect(deps, [picker(button, 'uk')], 'ru', ['uk'])).toBe(false);
+    expect(click).not.toHaveBeenCalled();
   });
 
   it('returns false when no redirect target is found', async () => {
@@ -245,6 +268,20 @@ describe('attemptLanguageSwitch', () => {
 
   it('falls back to the picker when hreflang fails but a picker exists', async () => {
     const deps = makeDeps(); // applyStrategy never navigates → hreflang fails
+    const link = anchor('https://example.com/uk');
+    expect(
+      await attemptLanguageSwitch(deps, settings(), undefined, 'ru', 'uk', [picker(link, 'uk')]),
+    ).toBe(true);
+    expect(deps.location.replace).toHaveBeenCalledWith('https://example.com/uk');
+  });
+
+  it('rescues via the picker after the site hreflang already bounced back here', async () => {
+    // UMI.CMS two-pass shape (ds-electronics.com.ua): pass 1 followed the
+    // broken `uk-ua` hreflang to a URL that 301'd straight back to this blocked
+    // page, arming the loop guard (recentlyAttemptedHere). On this pass hreflang
+    // bails, but the on-page switcher's untried target still gets followed —
+    // previously the coarse guard suppressed the picker too and Movar gave up.
+    const deps = makeDeps({ recentlyAttemptedHere: vi.fn(() => true) });
     const link = anchor('https://example.com/uk');
     expect(
       await attemptLanguageSwitch(deps, settings(), undefined, 'ru', 'uk', [picker(link, 'uk')]),

--- a/apps/extension/src/lib/language-switch.ts
+++ b/apps/extension/src/lib/language-switch.ts
@@ -19,8 +19,10 @@ export interface LanguageSwitchDeps {
   recentlyAttemptedHere(): boolean;
   /** True if we've already tried navigating to `url` this session. */
   hasAttemptedNavTo(url: string): boolean;
-  /** Mark the current URL as redirected-from (arms the loop guard). */
-  markAttempt(): void;
+  /** Mark a URL as redirected-from (arms the loop guard). Defaults to the
+   *  current URL; pass an explicit href to also record a navigation TARGET, so a
+   *  later bounce back to it is caught by `hasAttemptedNavTo`. */
+  markAttempt(href?: string): void;
   /** Log a correction to the on-device dashboard. */
   record(
     mechanism: CorrectionEvent['mechanism'],
@@ -102,23 +104,33 @@ export async function tryPickerRedirect(
   pageLang: LanguageCode,
   priority: LanguageCode[],
 ): Promise<boolean> {
-  if (deps.recentlyAttemptedHere()) return false;
   const target = pickRedirectTarget(pickers, priority);
   if (!target) return false;
 
   if (target instanceof HTMLAnchorElement) {
     if (!target.href || target.href === deps.location.href) return false;
-    // Loop guard: refuse to click into a URL we already redirected FROM this
-    // session. Sibling-locale URLs on misconfigured sites all share the same
-    // `<html lang>`, so following the picker would bounce.
+    // Per-target loop guard (NOT the coarse recentlyAttemptedHere): refuse only
+    // a target we already navigated TO this session. Firing on a URL we merely
+    // redirected FROM is exactly what rescues a misconfigured site — its own
+    // hreflang can point at a sibling URL that 301s straight back to this
+    // blocked page, arming recentlyAttemptedHere here, while the on-page
+    // switcher still points at the CORRECT, untried URL (UMI.CMS shops:
+    // `hreflang="uk-ua"` → `/ua/ru/…` → 301 → `/ru/…`, but the switcher's
+    // "UKR" link goes to the prefix-less Ukrainian page). Recording the target
+    // below (markAttempt(target.href)) is what stops a genuinely-bouncing
+    // picker from re-firing the same target forever.
     if (deps.hasAttemptedNavTo(target.href)) return false;
     deps.markAttempt();
+    deps.markAttempt(target.href);
     await deps.record('redirect', pageLang, priority[0] ?? pageLang);
     deps.location.replace(target.href);
     return true;
   }
 
   // <button> — let the site's own form-submit / click handler do the work.
+  // No target URL to guard per-target, so keep the coarse session guard: refuse
+  // to re-fire on a URL we already redirected from.
+  if (deps.recentlyAttemptedHere()) return false;
   deps.markAttempt();
   await deps.record('redirect', pageLang, priority[0] ?? pageLang);
   // Suppress the capture-phase click listener — Movar driving this click is not

--- a/packages/lang-detect/src/lang-codes.test.ts
+++ b/packages/lang-detect/src/lang-codes.test.ts
@@ -13,6 +13,14 @@ describe('normalizeLanguageCode (strict)', () => {
     expect(normalizeLanguageCode('ua')).toBe('uk');
   });
 
+  it('maps `ukr` → `uk` (ISO 639-2/3 code langtell omits; UMI.CMS "UKR" switchers)', () => {
+    // langtell ships rus/bel/bul/eng but not the Latin `ukr` (only Cyrillic
+    // `укр`); Movar's adapter fills that one gap, case- and trim-insensitive.
+    expect(normalizeLanguageCode('ukr')).toBe('uk');
+    expect(normalizeLanguageCode('UKR')).toBe('uk');
+    expect(normalizeLanguageCode('  Ukr  ')).toBe('uk');
+  });
+
   it('case-insensitive on ASCII and Cyrillic', () => {
     expect(normalizeLanguageCode('UK')).toBe('uk');
     expect(normalizeLanguageCode('Russian')).toBe('ru');
@@ -112,6 +120,11 @@ describe('normalizeBCP47', () => {
 
   it('treats `ua-ua` as Ukrainian (some sites use `ua` even as primary tag)', () => {
     expect(normalizeBCP47('ua-UA')).toBe('uk');
+  });
+
+  it('resolves the `ukr` primary subtag (langtell gap, region-stripped)', () => {
+    expect(normalizeBCP47('ukr')).toBe('uk');
+    expect(normalizeBCP47('ukr-UA')).toBe('uk');
   });
 
   it('still works for bare ISO codes', () => {

--- a/packages/lang-detect/src/lang-codes.ts
+++ b/packages/lang-detect/src/lang-codes.ts
@@ -1,7 +1,7 @@
 // `LanguageCode` and the BCP-47 / language-code normalizers are single-sourced
 // from langtell. The alias table (uk/ru/be/bg/en endonyms, the UA exonyms and
 // "X мова" / "по-X" picker phrases, and BCP-47 codes) and the normalization
-// logic now live in langtell; this module is the thin movar-specific adapter.
+// logic live in langtell; this module is the thin movar-specific adapter.
 //
 // `normalizeBCP47` pins langtell's permissive normalizer to movar's stricter
 // contract: an unknown primary subtag → `null` (movar gates on its known alias
@@ -9,16 +9,46 @@
 // passes the raw subtag through (`pt-BR` → `pt`). We opt into its
 // `unknownHead: "null"` mode to preserve the historical movar behavior.
 //
-// `normalizeLanguageCode` (strict, exact-match) is byte-identical on both sides,
-// so it is re-exported unchanged. The only behavioral delta versus movar's former
-// hand-rolled table is additive: be/bg aliases now normalize (langtell ships
-// those detection profiles too) — verified to be the *sole* difference against
-// the union of both alias tables.
-import { normalizeBCP47 as ntNormalizeBCP47 } from 'langtell';
+// Both normalizers also fill one gap in langtell's alias table: the Latin
+// ISO 639-2/639-3 code `ukr` → `uk` (see MOVAR_ISO3_ALIASES). langtell resolves
+// `rus`/`bel`/`bul`/`eng` but not `ukr` (it only ships the Cyrillic `укр`); the
+// supplement below closes that asymmetry. Everything else is delegated
+// unchanged.
+import {
+  normalizeBCP47 as ntNormalizeBCP47,
+  normalizeLanguageCode as ntNormalizeLanguageCode,
+} from 'langtell';
 import type { LanguageCode } from 'langtell';
 
 export type { LanguageCode } from 'langtell';
-export { normalizeLanguageCode } from 'langtell';
+
+/**
+ * ISO 639-2/639-3 three-letter codes for Movar-supported languages that
+ * langtell's alias table is missing. langtell resolves `rus`→ru, `bel`→be,
+ * `bul`→bg, and `eng`→en, but NOT the Latin `ukr`→uk — it only ships the
+ * Cyrillic `укр`. That asymmetric gap bites in the wild: Ukrainian shops on
+ * UMI.CMS label their language switcher "UKR", and the Ukrainian URL carries no
+ * language prefix (Russian sits under `/ru/`), so the path segment is no help
+ * either — the switcher's Ukrainian entry then never classifies, the picker is
+ * left with a single language, and picker detection (≥2 languages) drops it
+ * entirely. Keyed lowercase; callers trim + lowercase before lookup. Fold any
+ * future upstream fix back out of here.
+ */
+const MOVAR_ISO3_ALIASES: Record<string, LanguageCode> = { ukr: 'uk' };
+
+function movarIso3Alias(subtag: string): LanguageCode | null {
+  return MOVAR_ISO3_ALIASES[subtag.trim().toLowerCase()] ?? null;
+}
+
+/**
+ * Strict, exact-match language normalization: never hyphen-splits, so free-text
+ * URL slugs (`/ru-return-warranty`) don't false-match. Delegates to langtell,
+ * then fills langtell's missing `ukr`→uk alias. Use for URL path segments and
+ * picker label text; use {@link normalizeBCP47} for documented BCP47 inputs.
+ */
+export function normalizeLanguageCode(input: string): LanguageCode | null {
+  return ntNormalizeLanguageCode(input) ?? movarIso3Alias(input);
+}
 
 /**
  * BCP47-aware normalization: tries the full string first, then strips a
@@ -32,5 +62,13 @@ export { normalizeLanguageCode } from 'langtell';
  * unsupported rather than passing the bare subtag through.
  */
 export function normalizeBCP47(input: string): LanguageCode | null {
-  return ntNormalizeBCP47(input, { unknownHead: 'null' });
+  const direct = ntNormalizeBCP47(input, { unknownHead: 'null' });
+  if (direct != null) return direct;
+  // langtell didn't resolve it — try the leading subtag against Movar's
+  // supplemental ISO 639-2/3 aliases (`ukr` / `ukr-UA` → uk), mirroring how
+  // langtell strips a BCP47 tag down to its primary subtag. `split` always
+  // yields a first element at runtime; `?? ''` only satisfies the optional
+  // index type, and `movarIso3Alias('')` is a clean miss.
+  const primary = input.split(/[-_]/, 1)[0] ?? '';
+  return movarIso3Alias(primary);
 }

--- a/packages/lang-pickers/src/picker.classify.test.ts
+++ b/packages/lang-pickers/src/picker.classify.test.ts
@@ -143,6 +143,13 @@ describe('classifyLanguageElement — by content', () => {
     expect(classifyLanguageElement(a)?.language).toBe('uk');
   });
 
+  it('classifies via three-letter text "UKR" with a prefix-less href (UMI.CMS)', () => {
+    // The href (/rele/) carries no language segment, so the ISO 639-2/3
+    // `ukr`→uk alias filling langtell's gap is the only thing that classifies it.
+    const a = elFromHtml<HTMLAnchorElement>('<a href="/rele/">UKR</a>');
+    expect(classifyLanguageElement(a)?.language).toBe('uk');
+  });
+
   it('classifies an anchor by descendant <img alt>', () => {
     const a = elFromHtml<HTMLAnchorElement>('<a href="#"><img src="/de.png" alt="Deutsch" /></a>');
     expect(classifyLanguageElement(a)?.language).toBe('de');

--- a/packages/lang-pickers/src/picker.extract.test.ts
+++ b/packages/lang-pickers/src/picker.extract.test.ts
@@ -33,4 +33,21 @@ describe('findLanguagePickers — real-world DOM shapes', () => {
     expect(pickers).toHaveLength(1);
     expect(pickers[0]!.links.map((l) => l.language).toSorted()).toEqual(['ru', 'uk']);
   });
+
+  it('detects a UMI.CMS "UKR / RU" switcher (Ukrainian entry has only its "UKR" text)', () => {
+    // ds-electronics.com.ua shape: the Ukrainian link is the prefix-less URL
+    // labelled "UKR" (three-letter ISO code, no /uk/ or /ua/ path segment), so
+    // its ONLY language signal is that text. Before the langtell `ukr`→uk gap
+    // was filled, that entry didn't classify, the container held a single
+    // language, and the ≥2-distinct guard dropped the whole switcher.
+    setBody(`
+      <div class="lang">
+        <a class="lang__link" href="/rele/">UKR</a>
+        <a class="lang__link lang__link_active" href="/ru/rele/">RU</a>
+      </div>
+    `);
+    const pickers = findLanguagePickers();
+    expect(pickers).toHaveLength(1);
+    expect(pickers[0]!.links.map((l) => l.language).toSorted()).toEqual(['ru', 'uk']);
+  });
 });

--- a/scripts/readme-metrics.snapshot.json
+++ b/scripts/readme-metrics.snapshot.json
@@ -4,14 +4,14 @@
     "score": 81,
     "grade": "B"
   },
-  "loc": 41392,
+  "loc": 41442,
   "suppressions": {
     "eslint": 43,
     "fallow": 25
   },
   "coverage": {
     "lines": 94.1,
-    "branches": 86.3
+    "branches": 86.4
   },
   "bundle": {
     "contentKb": 38


### PR DESCRIPTION
## Problem

On `https://ds-electronics.com.ua/ru/rele/`, Movar couldn't switch the page to Ukrainian. It's a real Movar bug (two compounding ones), triggered by a misconfigured site.

The site runs on UMI.CMS and models language as **Ukrainian = prefix-less URL, Russian = `/ru/` prefix**. Two things went wrong:

1. **Broken hreflang, trusted blindly.** The page publishes `<link rel="alternate" hreflang="uk-ua" href="/ua/ru/rele/">`, but `/ua/ru/rele/` **301-redirects straight back to `/ru/rele/`** (Russian — verified with `curl -I`). Movar's rule-less ladder tries hreflang *before* the picker, followed it, bounced back, and its loop guard then suppressed the on-page switcher too — so it gave up on Russian.

2. **The correct on-page switcher wasn't even detected.** Its Ukrainian link is the prefix-less `/rele/` labelled **"UKR"**, so its only language signal is that text. langtell resolves `rus`/`bel`/`bul`/`eng` but **not the Latin `ukr`** (only the Cyrillic `укр`) — an asymmetric gap. So the entry never classified, the picker held a single language, and picker detection's ≥2-distinct-languages rule dropped it entirely.

## Fix

- **`lang-detect`** — fill langtell's `ukr`→uk gap in the adapter (`MOVAR_ISO3_ALIASES`, wrapping both `normalizeLanguageCode` and `normalizeBCP47`). Fold back out if langtell fixes it upstream.
- **`language-switch`** — `tryPickerRedirect`'s anchor branch now gates on the **per-target** `hasAttemptedNavTo(target.href)` instead of the coarse `recentlyAttemptedHere()`, and records the target via `markAttempt(target)`. After the hreflang bounces back to a blocked page, the switcher's correct (untried) target still fires — while a genuinely bouncing picker is still stopped from re-firing the same target. The `<button>` branch keeps the coarse guard (no URL to per-target-check).

General, not per-site — covers the whole UMI.CMS class of Ukrainian shops, so no site rule was added.

## Verification

- **Real, unmodified page HTML** run through the actual `findLanguagePickers` + `pickRedirectTarget`: detects 2 pickers `{ru, uk}`, and `pickRedirectTarget(['uk','en'])` → **`/rele/`** (text "UKR") — the correct Ukrainian URL, not the bouncing `/ua/ru/rele/`.
- New unit/integration tests for each behavior: the ds-electronics switcher shape, the `ukr` alias (strict + BCP47), picker-fires-after-hreflang-bounce, button-still-bails, and the two-pass ladder rescue.
- Full suites pass: lang-detect (233), lang-pickers (63), extension `src/lib` (862). Typecheck + lint clean on all three packages.

## Known residual

The first visit still burns **one wasted hreflang hop** (the bounce) before the picker rescues it, because hreflang is tried before the picker by design. Correct, just not the cleanest path — eliminating it would mean preferring the picker over hreflang when the picker directly offers the target language, a larger change to the deliberate ladder ordering. Deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
