### PR TITLE
test(content): tear down the live-region debounce timer after each test

### DIFF
--- a/apps/extension/src/entrypoints/__tests__/content.test.ts
+++ b/apps/extension/src/entrypoints/__tests__/content.test.ts
@@ -156,7 +156,13 @@ beforeEach(async () => {
   installFakeChunks();
 });
 
-afterEach(() => {
+afterEach(async () => {
+  // restoreAll / a concealing applyOnce schedule the debounced live-region
+  // announcement on a real 600ms timer; clear it so it can't fire after jsdom
+  // is torn down (`document is not defined` crashing whatever file runs next).
+  // Dynamic import on purpose: resetModules in beforeEach gives each test a
+  // fresh live-region instance, and a static import would tear down a stale one.
+  (await import('../../lib/live-region')).teardownLiveRegion();
   vi.restoreAllMocks();
 });
 


### PR DESCRIPTION
## What

Fixes the intermittent CI failure in the `verify` job's `pnpm test` step ([example run](https://github.com/rejifald/movar/actions/runs/29581417571/job/87887770437)):

```
ReferenceError: document is not defined
 ❯ ensureRegion src/lib/live-region.ts:30:14
 ❯ Timeout._onTimeout src/lib/live-region.ts:58:5
This error originated in "src/entrypoints/__tests__/content.test.ts" test file.
```

`content.test.ts`'s file-level `afterEach` now calls `teardownLiveRegion()`, clearing any pending live-region debounce timer before the jsdom environment can be torn down.

## Why

Fake timers in `content.test.ts` only cover the empty-SERP retry test; everything else runs real timers. Two tests load the conceal chunk via `applyOnce` and then call `runtime.restoreAll()` — *"reveals through the chunk once it has loaded"* and *"re-runs applyOnce on a URL change"* — which hits `announce(revealed)` in `content-runtime.ts` and schedules the debounced announcement on a real 600 ms `setTimeout` that nothing flushes. When CI timing lets the file finish inside that window, the timer fires after teardown, `document` is gone, and the crash is attributed to whichever file the worker is running — hence the flake.

The other `restoreAll()` calls in the file never load the conceal chunk (no announcement), the one test that exercises announcements waits both timers out with `vi.waitFor`, and the other content-runtime suites (observer, integration) run fully under fake timers — so this file's `afterEach` is the only gap.

## Notes for review

- The teardown is a **dynamic** import on purpose: `beforeEach` calls `vi.resetModules()` before importing content-runtime, so each test gets a fresh live-region module instance; a static import at the top of the file would tear down a stale copy and miss the pending timer. There's a comment in the code covering this.
- I deliberately did **not** add a `typeof document === 'undefined'` guard to `live-region.ts`: it would only mask test-hygiene bugs, and the module ships in `content.js` under the bundle-budget gate.
- Test-only change; no source files touched, so coverage/metrics should be unchanged. Repo-root `pnpm test` passes (2086 tests), and the pre-commit + pre-push hook chains (lint, typecheck, build, metrics audit, fast e2e) all ran green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)