### PR TITLE
ci: pin the AMO linter to web-ext@10, matching the sign step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -221,7 +221,11 @@ jobs:
             echo "::error::AMO source bundle (.output/*-amo-source.zip) not found — did the prepare job run 'pnpm pack:amo-source'?"
             exit 1
           fi
-          npx --yes web-ext@8 sign \
+          # web-ext major is pinned in lockstep with the addons-linter step in
+          # scripts/verify-release.sh — one web-ext major across the whole
+          # release path, no floating `@latest`. Bump both together; Renovate
+          # opens that PR via the web-ext customManager in renovate.json.
+          npx --yes web-ext@10 sign \
             --channel=listed \
             --source-dir=.output/firefox-mv3 \
             --upload-source-code="$amo_source_zip" \

--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,19 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:recommended", "helpers:pinGitHubActionDigests"],
   "labels": ["dependencies"],
-  "schedule": ["before 6am on monday"]
+  "schedule": ["before 6am on monday"],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "description": "Bump the pinned web-ext major (npx web-ext@N) used by the release-critical lint + sign steps in lockstep; rationale in scripts/verify-release.sh.",
+      "managerFilePatterns": [
+        "/^scripts/verify-release\\.sh$/",
+        "/^\\.github/workflows/release\\.yml$/"
+      ],
+      "matchStrings": ["web-ext@(?<currentValue>\\d+)"],
+      "depNameTemplate": "web-ext",
+      "datasourceTemplate": "npm",
+      "versioningTemplate": "npm"
+    }
+  ]
 }

--- a/scripts/verify-release.sh
+++ b/scripts/verify-release.sh
@@ -75,11 +75,18 @@ inspect_zip "$firefox_zip" "firefox zip"
 
 # addons-linter is Mozilla's official linter — it's what AMO runs on
 # every upload. Catching its findings locally means zero "instant
-# rejection" surprises on submission. We track `@latest` deliberately so
-# the local check stays in sync with AMO's server-side rules; the trade-off
-# is that a future web-ext major could introduce new strict checks that
-# fail CI without a code change here. When that happens, either fix the
-# new finding or pin to the last known-good major.
+# rejection" surprises on submission. We pin `web-ext@10` — the same major
+# the release workflow's `sign` step uses (.github/workflows/release.yml) —
+# rather than tracking `@latest`, so nothing in the release-critical path
+# floats: a new web-ext major can't turn a release red without a reviewed
+# change. The pin is not set-and-forget, though — web-ext bundles
+# addons-linter, and that bundled version is what keeps this gate in step
+# with AMO's server-side rules. Let the major fall too far behind and the
+# local check goes laxer than AMO, resurfacing the rejection surprises this
+# step exists to prevent. Renovate opens a reviewable PR to bump the major
+# when web-ext ships a new one (the web-ext customManager in renovate.json);
+# bump deliberately — re-check the new major's findings against the
+# acknowledged lists below and move the `sign` step's major in lockstep.
 #
 # We fail on any finding (error/warning/notice) that isn't on the
 # allowlist below. Two reasons we don't just use the linter's exit code
@@ -148,7 +155,7 @@ lint_build() {
   linter_json=$(mktemp)
   # web-ext lint exits non-zero on errors; we want the JSON regardless of
   # exit code so we can apply our own gate.
-  npx --yes web-ext@latest lint \
+  npx --yes web-ext@10 lint \
     --source-dir="$dir" \
     --output=json --pretty > "$linter_json" 2>/dev/null || true
 


### PR DESCRIPTION
## What

Pin the AMO addons-linter in `scripts/verify-release.sh` from `web-ext@latest`
to `web-ext@10`, and bump the `web-ext sign` step in
`.github/workflows/release.yml` from `@8` to `@10`, so the whole
release-critical path runs a single, pinned web-ext major. A Renovate
`customManager` keeps that pin fresh.

## Why

`verify-release.sh` ran the linter via `npx web-ext@latest` — the only floating
dependency left in the release path. A new upstream major can turn a release red
with no code change, inconsistent with the `sign` step (already pinned to a
major) and with the repo's pin-everything posture (`check-action-pins.mts` fails
CI on any unpinned Action `uses:`).

## The obvious fix was backwards

The naive move — "pin lint to `@8` to match sign" — is the wrong direction.
`web-ext@latest` is **10.5.0** today, and what matters for the linter is the
**addons-linter** it bundles:

| Step | Was | Resolves to | Bundled addons-linter |
|------|-----|-------------|-----------------------|
| lint | `web-ext@latest` | 10.5.0 | **10.8** (≈ AMO server-side) |
| sign | `web-ext@8`      | 8.10.0 | 7.20 |

Pinning lint *down* to `@8` would roll its ruleset back three majors and make
the local gate **laxer than AMO** — reintroducing the "passes locally, rejected
on upload" surprise the gate exists to prevent. A linter that mirrors AMO must
fail *closed*, not *open*.

So both pin to **`@10`** (the current major): deterministic, still current, one
web-ext major across the entire release path — the real single source of truth.

## Compatibility (verified)

- `web-ext@10` needs Node ≥20; repo is on 22 (`.nvmrc`). ✓
- `web-ext@10 sign` keeps every flag `release.yml` uses — `--channel`,
  `--source-dir`, `--upload-source-code`, `--api-key`, `--api-secret`. ✓
- `web-ext@10 lint --output=json` keeps the exact shape the gate's `jq` consumes
  (`errors`/`warnings`/`notices` of `{code,file,message}`); acknowledged codes
  are still emitted. ✓
- The gate logic (severity-agnostic acknowledged/unacknowledged classification +
  `fail()`) is **unchanged** — this is a version string + comment.
- Since `@latest` ≡ `@10` today, this changes nothing about what runs now; it
  only freezes the major against future drift.

## Bump reminder

Added a Renovate `customManager` (Renovate already runs here for GitHub Action
SHA pins) that bumps both `web-ext@N` refs **together** when a new major ships —
the same "pin + reviewable bump PR" pattern the repo already relies on. Validated
with `renovate-config-validator`. No new tooling.

## Independent of #263

This is the follow-up flagged in the CI-relaxation PR #263; it stands alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
