### PR TITLE
fix(safari-host-app): scroll a freshly-selected tab to the top

### DIFF
--- a/apps/safari-host-app/src/App.test.tsx
+++ b/apps/safari-host-app/src/App.test.tsx
@@ -1,5 +1,5 @@
 import { act, cleanup, fireEvent, render, screen, within } from '@testing-library/react';
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { App } from './App';
 import { resetBridgeForTest } from './bridge';
 import type { Platform } from './bridge';
@@ -15,14 +15,22 @@ function nativeShow(platform: Platform, enabled?: boolean, useSettings?: boolean
   });
 }
 
+/** The tab-change scroll reset (App's `useScrollTopOnTabChange`) calls
+ *  `window.scrollTo`, which jsdom leaves unimplemented (it logs to stderr on
+ *  every tab switch). Spy it so the whole suite stays quiet and the scroll-reset
+ *  tests below can assert on it. */
+let scrollToSpy: ReturnType<typeof vi.spyOn>;
+
 beforeEach(() => {
   resetBridgeForTest();
   document.body.className = '';
+  scrollToSpy = vi.spyOn(globalThis, 'scrollTo').mockImplementation(() => {});
 });
 
 afterEach(() => {
   cleanup();
   document.body.className = '';
+  scrollToSpy.mockRestore();
 });
 
 describe('App — tab structure', () => {
@@ -136,6 +144,32 @@ describe('App — arrow-key navigation (ported from Script.js initTabs)', () => 
     detector.focus();
     fireEvent.keyDown(detector, { key: 'ArrowRight' });
     expect(document.activeElement).toBe(screen.getByRole('tab', { name: 'Settings' }));
+  });
+});
+
+describe('App — scroll reset on tab change', () => {
+  it('scrolls the viewport back to the top when a click changes the active tab', () => {
+    render(<App messages={messagesEn} />);
+    // Ignore the initial-mount reset — we only care about the switch.
+    scrollToSpy.mockClear();
+    fireEvent.click(screen.getByRole('tab', { name: 'Settings' }));
+    expect(scrollToSpy).toHaveBeenCalledWith(0, 0);
+  });
+
+  it('scrolls back to the top on an arrow-key tab move too', () => {
+    render(<App messages={messagesEn} />);
+    scrollToSpy.mockClear();
+    fireEvent.keyDown(screen.getByRole('tab', { name: 'Detector' }), { key: 'ArrowRight' });
+    expect(scrollToSpy).toHaveBeenCalledWith(0, 0);
+  });
+
+  it('does not scroll when the already-active tab is re-selected (no active change)', () => {
+    render(<App messages={messagesEn} />);
+    scrollToSpy.mockClear();
+    // Detector is active by default; re-clicking it leaves `active` unchanged,
+    // so the layout effect must not re-fire.
+    fireEvent.click(screen.getByRole('tab', { name: 'Detector' }));
+    expect(scrollToSpy).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/safari-host-app/src/App.tsx
+++ b/apps/safari-host-app/src/App.tsx
@@ -1,5 +1,5 @@
 import { Info, Languages, Settings } from 'lucide-react';
-import { useEffect, useState } from 'react';
+import { useEffect, useLayoutEffect, useState } from 'react';
 import type { JSX } from 'react';
 import { hostSettingsSource, useHostState } from './bridge';
 import type { HostState } from './bridge';
@@ -83,6 +83,11 @@ export function App({ messages }: Readonly<AppProps>): JSX.Element {
   const showBrand = active === 'about' && state?.platform !== 'mac';
   useReflectAppbar(showBrand);
 
+  // Open every freshly-selected tab from its top, the way native iOS/macOS tab
+  // bars do — a tall previous tab the user scrolled down must not leave the next
+  // one landing mid-page.
+  useScrollTopOnTabChange(active);
+
   return (
     <HostLayout
       messages={messages}
@@ -104,6 +109,30 @@ export function App({ messages }: Readonly<AppProps>): JSX.Element {
       </>
     </HostLayout>
   );
+}
+
+/**
+ * Return the viewport scroller to the top on every tab change.
+ *
+ * The three panels share ONE scroll container: the `<body>` is the WebView's
+ * viewport scroller (the app-bar + tab bar are `position: fixed`; see
+ * `styles.css`), and switching tabs only flips `hidden` on the panels — it never
+ * touches the scroll offset. So without this, someone who scrolled a tall tab
+ * (a long Detector evidence report, or the Settings list on a small screen) and
+ * then picked another tab would open the next one already scrolled down. Native
+ * iOS/macOS tab bars always reveal a freshly-selected tab from its top; this
+ * restores that.
+ *
+ * `useLayoutEffect`, not `useEffect`: the reset runs after React swaps the
+ * panels but BEFORE the browser paints, so the new tab never flashes at the old
+ * scroll position first. `window.scrollTo` targets whatever the viewport
+ * scroller is, so it needn't know it's the `<body>`. Fires on the first mount
+ * too — a harmless no-op, since the WebView loads at the top.
+ */
+function useScrollTopOnTabChange(active: TabId): void {
+  useLayoutEffect(() => {
+    window.scrollTo(0, 0);
+  }, [active]);
 }
 
 /** Apply `platform-ios` / `platform-mac` to both `<html>` and `<body>` for the


### PR DESCRIPTION
## What

In the Safari wrapper's host app, switching tabs left the page **stuck at the previous tab's scroll position** — scroll a tall tab to the bottom, tap another tab, and it opened mid-page instead of at its top.

## Why

The three tabs (Detector / Settings / About) share **one scroll container**: the `<body>` is the WKWebView's viewport scroller, while the app-bar and tab bar are `position: fixed`. Switching tabs only toggles the `hidden` attribute on the panels (`HostLayout`) — nothing ever reset the scroll offset.

## The fix

A `useLayoutEffect` in `App.tsx`, keyed off the single `active` tab state, resets the viewport to the top on every tab change:

```tsx
function useScrollTopOnTabChange(active: TabId): void {
  useLayoutEffect(() => {
    window.scrollTo(0, 0);
  }, [active]);
}
```

- Keyed off `active`, so it covers **both** click and arrow-key switches with one effect.
- `useLayoutEffect` (not `useEffect`) runs after the panel swap but **before paint** — the new tab never flashes at the old offset first.
- Re-selecting the already-active tab leaves `active` unchanged → React bails → no gratuitous scroll.
- Matches native iOS/macOS tab bars, which always reveal a freshly-selected tab from its top.

## Verify

- **Browser (phone viewport):** Detector scrolled to bottom (scrollY 353) → tap About → **scrollY 0**, even though About still overflows the viewport (a genuine reset, not shorter content). Confirmed the reverse direction too. No console errors.
- **Unit tests:** 3 new tests (click switch, arrow-key switch, no-op on same-tab re-click). Full host-app suite **75 passed**, typecheck + lint clean. `window.scrollTo` stubbed in setup to silence jsdom's "Not implemented" noise.
- **e2e visual baselines:** Unaffected — the host fixture opens fresh-at-top before capturing, so the reset is a no-op there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)