### PR TITLE
chore(release): version packages — extension v1.4.3

### DIFF
--- a/.changeset/dnr-skip-redundant-writes.md
+++ b/.changeset/dnr-skip-redundant-writes.md
@@ -1,5 +1,0 @@
----
-'@movar/extension': patch
----
-
-Skip declarativeNetRequest writes whose outcome is already installed. The background resync — which re-runs on every service-worker wake, settings change, pause/snooze flip, and alarm expiry — previously rewrote both dynamic rules (Accept-Language, Google /search redirect) unconditionally. Each sync now reads the installed rules via `getDynamicRules`, deep-compares against the rule it would write, and skips the `updateDynamicRules` call when they already match (including "should be absent and is absent"). Every dynamic-rules write rewrites the browser's on-disk rules store, and on Safari ≤ 26.4 that store can crash the whole browser at launch (WebKit bug 305585) — so redundant writes were exposure, not just waste. Any doubt (failed read, platform-added keys, structural mismatch) falls back to the exact write behaviour shipped before.

--- a/.changeset/picker-html-data-lang-swallowed.md
+++ b/.changeset/picker-html-data-lang-swallowed.md
@@ -1,5 +1,0 @@
----
-'@movar/extension': patch
----
-
-Fix Movar failing to find a site's language switcher at all — automatic switching silently did nothing, with no error — on sites that stamp a `data-lang`/`data-locale` attribute on `<html>` (a common CMS pattern for page-level locale metadata; UMI.CMS shops like ds-electronics.com.ua do this as `data-lang="ru"`). Movar's picker scan seeds candidates on `data-lang`/`data-locale`, meant for individual switcher items, but `<html>` matched too — and being the ancestor of every other element on the page, it crowded out the real switcher from consideration entirely. Movar now ignores `<html>` and `<body>` as switcher candidates; they're never legitimate switcher items themselves.

--- a/apps/extension/CHANGELOG.md
+++ b/apps/extension/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @movar/extension
 
+## 1.4.3
+
+### Patch Changes
+
+- 893f392: Skip declarativeNetRequest writes whose outcome is already installed. The background resync — which re-runs on every service-worker wake, settings change, pause/snooze flip, and alarm expiry — previously rewrote both dynamic rules (Accept-Language, Google /search redirect) unconditionally. Each sync now reads the installed rules via `getDynamicRules`, deep-compares against the rule it would write, and skips the `updateDynamicRules` call when they already match (including "should be absent and is absent"). Every dynamic-rules write rewrites the browser's on-disk rules store, and on Safari ≤ 26.4 that store can crash the whole browser at launch (WebKit bug 305585) — so redundant writes were exposure, not just waste. Any doubt (failed read, platform-added keys, structural mismatch) falls back to the exact write behaviour shipped before.
+- Open a freshly-selected tab in the macOS and iOS companion app at its top. The app's tabs share one scroll position, so switching away from a tab you had scrolled down (a long Detector report, or the Settings list on a small screen) left the next tab opened mid-page. Selecting a tab now resets it to the top — whether by click or arrow key — matching how native tab bars behave.
+- Give the toolbar icon a consistent border in every state. The static fallback icon — shown on tabs Movar hasn't evaluated yet, such as a background tab, a still-loading or non-web page, or any tab after the browser suspended Movar's background worker — was the plain brand mark with no status ring, so it looked border-less next to the ringed active, paused, and off looks and could read as a state that had lost its outline. The fallback now wears a neutral resting ring matching the rest of the icon family, so an unevaluated tab always looks intentional. The brand logo used elsewhere (store artwork, the Safari app icon) is unchanged.
+- Stop the toolbar icon flashing its red "needs attention" look for a frame on page load. While a tab was still loading, a momentary gap in the hidden-content signal made the icon paint the attention posture before settling into its normal state — a visible red→green flicker on every navigation. Movar now holds the icon steady while a tab is loading and repaints it once the page finishes, so the flash is gone.
+
 ## 1.4.2
 
 ### Patch Changes

--- a/apps/extension/package.json
+++ b/apps/extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@movar/extension",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Consumes the four pending patch changesets and bumps `@movar/extension` **1.4.2 → 1.4.3**. This is the version-packages commit that precedes cutting the store release.

### What lands
- **dnr** (#256): skip redundant `declarativeNetRequest` writes — reduces exposure to the Safari ≤26.4 rules-store launch crash (WebKit 305585).
- **safari-host-app** (#268): scroll a freshly-selected companion-app tab to the top.
- **toolbar default_icon** (#270): neutral resting ring so unevaluated tabs aren't border-less.
- **toolbar-icon** (#269): stop the load-time red→green attention flash.

Also drops a stray duplicate changeset (`picker-html-data-lang`) whose prose already shipped in the 1.4.2 CHANGELOG as `7b8ee85`.

### Validation
- `pnpm verify:release` green locally under Node 22: 1222+ tests, both zips built at 1.4.3, byte-for-byte reproducible, addons-linter clean, permission-drift clean.
- Pushed as `release/**` so the release workflow runs its full `prepare` dry-run (verify:release + safari zip + `pack:amo-source`) without submitting.

The store release itself is a separate manual step: publishing `extension-v1.4.3` (which then parks on the `production` environment approval).

🤖 Generated with [Claude Code](https://claude.com/claude-code)