### PR TITLE
chore(safari): bump Xcode app to v1.4.3 + document local App Store submission

### DIFF
--- a/apps/extension/safari/Movar/Movar.xcodeproj/project.pbxproj
+++ b/apps/extension/safari/Movar/Movar.xcodeproj/project.pbxproj
@@ -684,7 +684,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = 1784330980;
 				DEVELOPMENT_TEAM = RQSR4UU3VB;
 				CODE_SIGN_ENTITLEMENTS = "iOS (Extension)/Movar Extension.entitlements";
 				REGISTER_APP_GROUPS = YES;
@@ -698,7 +698,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.2.0;
+				MARKETING_VERSION = 1.4.3;
 				OTHER_LDFLAGS = (
 					"-framework",
 					SafariServices,
@@ -720,7 +720,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = 1784330980;
 				DEVELOPMENT_TEAM = RQSR4UU3VB;
 				CODE_SIGN_ENTITLEMENTS = "iOS (Extension)/Movar Extension.entitlements";
 				REGISTER_APP_GROUPS = YES;
@@ -734,7 +734,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.2.0;
+				MARKETING_VERSION = 1.4.3;
 				OTHER_LDFLAGS = (
 					"-framework",
 					SafariServices,
@@ -759,7 +759,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = 1784330980;
 				DEVELOPMENT_TEAM = RQSR4UU3VB;
 				CODE_SIGN_ENTITLEMENTS = "iOS (App)/Movar.entitlements";
 				REGISTER_APP_GROUPS = YES;
@@ -776,7 +776,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.2.0;
+				MARKETING_VERSION = 1.4.3;
 				OTHER_LDFLAGS = (
 					"-framework",
 					SafariServices,
@@ -802,7 +802,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = 1784330980;
 				DEVELOPMENT_TEAM = RQSR4UU3VB;
 				CODE_SIGN_ENTITLEMENTS = "iOS (App)/Movar.entitlements";
 				REGISTER_APP_GROUPS = YES;
@@ -819,7 +819,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.2.0;
+				MARKETING_VERSION = 1.4.3;
 				OTHER_LDFLAGS = (
 					"-framework",
 					SafariServices,
@@ -844,7 +844,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = 1784330980;
 				DEVELOPMENT_TEAM = RQSR4UU3VB;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -861,7 +861,7 @@
 					"@executable_path/../../../../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 11.0;
-				MARKETING_VERSION = 1.2.0;
+				MARKETING_VERSION = 1.4.3;
 				OTHER_LDFLAGS = (
 					"-framework",
 					SafariServices,
@@ -882,7 +882,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = 1784330980;
 				DEVELOPMENT_TEAM = RQSR4UU3VB;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -899,7 +899,7 @@
 					"@executable_path/../../../../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 11.0;
-				MARKETING_VERSION = 1.2.0;
+				MARKETING_VERSION = 1.4.3;
 				OTHER_LDFLAGS = (
 					"-framework",
 					SafariServices,
@@ -922,7 +922,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = 1784330980;
 				DEVELOPMENT_TEAM = RQSR4UU3VB;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -939,7 +939,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 11.0;
-				MARKETING_VERSION = 1.2.0;
+				MARKETING_VERSION = 1.4.3;
 				OTHER_LDFLAGS = (
 					"-framework",
 					SafariServices,
@@ -965,7 +965,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = 1784330980;
 				DEVELOPMENT_TEAM = RQSR4UU3VB;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -982,7 +982,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 11.0;
-				MARKETING_VERSION = 1.2.0;
+				MARKETING_VERSION = 1.4.3;
 				OTHER_LDFLAGS = (
 					"-framework",
 					SafariServices,

--- a/docs/release-credentials.md
+++ b/docs/release-credentials.md
@@ -192,6 +192,18 @@ Actions → Release → Run workflow → dry_run: true
 The `prepare` job runs (validate + build + artifact upload); the four
 store jobs are skipped via the workflow's `if` guard.
 
+### Safari is submitted locally, not from CI
+
+Publishing the Release runs `release-chrome`, `release-firefox`, and
+`release-edge` from CI (approve the `production` gate below to let them submit).
+**Safari is the exception** — its `release-safari` job fails at the archive step
+on headless provisioning (`401` / no profiles), so the iOS + macOS App Store
+submission is done from a Mac via Xcode Organizer. Full step-by-step (version +
+timestamp build-number bump, fresh build, archive, upload, notarized `.dmg`) is
+in [docs/safari-deploy.md § Local App Store submission](safari-deploy.md#local-app-store-submission-xcode-organizer).
+**Leave the parked `release-safari` CI job unapproved** so it doesn't double-submit
+the same version.
+
 ## Required-approval gate: the `production` environment
 
 Each of `release-firefox`, `release-chrome`, `release-edge`, and

--- a/docs/safari-deploy.md
+++ b/docs/safari-deploy.md
@@ -121,6 +121,130 @@ release time. All three macOS workflows pin Xcode to an **exact** version
 the `macos-15` image default, which drifts — objectVersion 77 needs Xcode 16.
 Bump that path in all three files together when you move toolchains.
 
+## Local App Store submission (Xcode Organizer)
+
+_This — not `release-safari` — is how Safari actually ships today._
+
+> **Why local, not CI.** The `release-safari` job currently **fails at the archive
+> step**: headless automatic signing gets a `401` from App Store Connect
+> (`** ARCHIVE FAILED ** … No profiles for 'fyi.movar.safari' were found`), so it
+> can't mint provisioning profiles on the runner. It has failed this way for
+> v1.2.0, v1.3.0, and v1.4.3 — so Safari has, in practice, **always** been
+> submitted from a Mac. Chrome / Firefox / Edge still ship from CI; only Safari is
+> hand-driven. (Fixing the CI ASC-key/profile path is tracked separately; until
+> then this section is the source of truth.)
+
+Xcode's Organizer signs and uploads through your **logged-in Apple ID session**,
+which is exactly what the CI runner can't do — so the archive that fails on CI
+succeeds locally.
+
+### Prerequisites (one-time)
+
+- Xcode signed into the Apple Developer account, Team `RQSR4UU3VB`
+  (**Xcode ▸ Settings ▸ Accounts**), with "Download Manual Profiles" run once.
+- Both signing identities present in the login keychain:
+
+  ```sh
+  security find-identity -v -p codesigning | grep -E 'Apple Distribution|Developer ID Application'
+  ```
+
+- The App Store Connect record exists — `fyi.movar.safari` (app id `6779282071`),
+  with **both** the iOS and macOS platforms added. First-submission metadata
+  (screenshots, privacy, review notes) comes from
+  [`apps/extension/store-assets/apple/`](../apps/extension/store-assets/apple/).
+
+### Per-release steps
+
+1. **Cut the extension release first.** Safari ships the _same_ version as
+   `apps/extension/package.json`; publish `extension-v<version>` (see
+   [Cutting a release](release-credentials.md#cutting-a-release)) so the version
+   is final. **Leave the parked `release-safari` CI job _unapproved_** — approving
+   it only burns a failing macOS run and risks a duplicate submit for the same
+   version.
+
+2. **Update `main` and bump the Xcode marketing + build version.** Safari's
+   version lives in `Movar.xcodeproj` (not `package.json`), and the build number
+   must **exceed the last macOS upload** — the Mac App Store rejects a
+   `CFBundleVersion` that isn't higher than the previous one _even across marketing
+   versions_. Use a **Unix timestamp** (`date +%s`), which is monotonic by
+   construction. History: macOS `1.2.0`→build `1`, `1.3.0`→build `1783635325`,
+   `1.4.3`→build `1784330980`.
+
+   ```sh
+   git checkout main && git pull
+   v="$(node -p "require('./apps/extension/package.json').version")"   # e.g. 1.4.3
+   b="$(date +%s)"                                                     # monotonic build number
+   sed -i '' \
+     -e "s/MARKETING_VERSION = [^;]*;/MARKETING_VERSION = $v;/g" \
+     -e "s/CURRENT_PROJECT_VERSION = [^;]*;/CURRENT_PROJECT_VERSION = $b;/g" \
+     "apps/extension/safari/Movar/Movar.xcodeproj/project.pbxproj"
+   git commit -am "chore(safari): bump Xcode app to v$v (build $b) for App Store submission"
+   ```
+
+   (iOS's `CFBundleVersion` only needs to be unique _per_ version, so the shared
+   timestamp is fine there too. Commit the bump so the shipped build number is
+   recorded.)
+
+3. **Freshly build the web extension + host-app resources — required before
+   archiving.** A fresh checkout has empty `Resources/`, so the `.appex` would
+   ship with no manifest and the app with a stale host screen:
+
+   ```sh
+   pnpm --filter @movar/extension build:safari        # web-ext + Extension Resources
+   pnpm --filter @movar/safari-host-app build          # host-app.js/.css + *.lproj/Main.html
+   ```
+
+4. **Archive both apps in Xcode** (`open apps/extension/safari/Movar/Movar.xcodeproj`).
+   `Product ▸ Archive` is only enabled with a **generic device** destination:
+   - Scheme **Movar (macOS)**, destination **Any Mac** → **Product ▸ Archive**.
+   - Scheme **Movar (iOS)**, destination **Any iOS Device (arm64)** → **Product ▸ Archive**.
+
+   Keep **"Automatically manage signing"** on — Xcode mints/downloads the App
+   Store provisioning profiles through your account session.
+
+5. **Upload to App Store Connect.** In **Window ▸ Organizer**, for _each_ archive:
+   **Distribute App ▸ App Store Connect ▸ Upload** → keep automatic signing →
+   **Upload**. (This replaces the CI job's `xcrun altool --upload-app`.)
+
+6. **Notarized `.dmg` for direct download** (optional — mirrors what the CI job
+   would have attached to the Release). From the **macOS** archive:
+   **Distribute App ▸ Direct Distribution** → Xcode notarizes → **Export** the
+   notarized `.app`, then:
+
+   ```sh
+   # one-time: store an ASC-key or Apple-ID credential for notarytool
+   # xcrun notarytool store-credentials movar-notary --key … --key-id … --issuer …
+   hdiutil create -volname Movar -srcfolder /path/to/Movar.app -ov -format UDZO "Movar-$v.dmg"
+   xcrun notarytool submit "Movar-$v.dmg" --keychain-profile movar-notary --wait
+   xcrun stapler staple "Movar-$v.dmg"
+   gh release upload "extension-v$v" "Movar-$v.dmg" --clobber
+   ```
+
+7. **Submit for review in App Store Connect.** For the new version on **each**
+   platform: attach the just-uploaded build (it appears after processing), fill
+   **What's New**, answer export-compliance, and **Submit for Review**.
+
+8. **After approval** — the marketing download links already point at the app-id
+   URL shared by iOS + macOS
+   ([apps/marketing/src/lib/downloads.ts](../apps/marketing/src/lib/downloads.ts)),
+   so nothing changes there once iOS clears review.
+
+### Verify before uploading
+
+```sh
+# version + a build number ABOVE the last macOS upload, for both schemes
+for s in "Movar (iOS)" "Movar (macOS)"; do
+  xcodebuild -project apps/extension/safari/Movar/Movar.xcodeproj -scheme "$s" \
+    -showBuildSettings 2>/dev/null | grep -E 'MARKETING_VERSION|CURRENT_PROJECT_VERSION'
+done
+```
+
+- **Archive hangs / "endlessly building"** → the `clang-stat-cache` deadlock, not a
+  project bug. See [Troubleshooting](#build-hangs-forever-endlessly-building).
+- **"No profiles for 'fyi.movar.safari'"** locally → make sure Xcode is signed in
+  and "Automatically manage signing" is on so it can create the App Store profile
+  (this is the same failure CI hits, but locally your session can fix it).
+
 ## One-time setup (done — kept for reference & credential rotation)
 
 ### 1. Enrol & register identifiers


### PR DESCRIPTION
Preps the Safari native wrapper for the 1.4.3 App Store submission and documents the manual flow it actually ships through.

### Xcode version bump
`Movar.xcodeproj` had been frozen at `MARKETING_VERSION 1.2.0` / `CURRENT_PROJECT_VERSION 1` for two releases — a latent trap, since a GUI archive without an override would ship **1.2.0**. Bumped both across all 8 build-config blocks:
- `MARKETING_VERSION` → **1.4.3** (matches `apps/extension/package.json`)
- `CURRENT_PROJECT_VERSION` → **1784330980** (a Unix timestamp; must exceed the last macOS upload `1783635325` — the Mac App Store rejects a non-increasing `CFBundleVersion` even across marketing versions)

Both are overridden at build time by `build:safari:app` and the CI jobs, so this only affects a GUI/Organizer archive — which is exactly the path Safari ships through.

### Docs — the local submission flow
`release-safari` (CI) **fails at the archive step** on headless provisioning (`401` / `No profiles for 'fyi.movar.safari'`) — it has for v1.2.0/1.3.0/1.4.3 — so Safari is submitted from a Mac via Xcode Organizer. Added the whole step-by-step (version+timestamp bump, fresh build, archive iOS+macOS, upload, notarized `.dmg`, submit) to `docs/safari-deploy.md`, referenced from the "Cutting a release" steps in `docs/release-credentials.md`.

`safari-wrapper.yml` will archive both schemes unsigned to verify the bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)