### PR TITLE
docs(safari): bilingual App Store "What's New" notes + require them in the flow

### DIFF
--- a/apps/extension/store-assets/apple/WHATS-NEW.md
+++ b/apps/extension/store-assets/apple/WHATS-NEW.md
@@ -1,0 +1,53 @@
+# App Store Connect — "What's New in This Version"
+
+App Store Connect **requires** "What's New" text for **every localization** on every
+version after the app's first release (unlike Chrome / Firefox / Edge, where store
+release notes are optional). Both the iOS and macOS platforms share the one app
+record (`fyi.movar.safari`), so the same text is pasted for both.
+
+Paste the block for each locale into **App Store Connect → [version] →
+What's New in This Version**, under the matching language. Update this file each
+release — distil the user-facing highlights from
+[`apps/extension/CHANGELOG.md`](../../CHANGELOG.md); keep it short and in the
+user's voice (what changed for them), not the developer changelog.
+
+> Movar's audience is Ukrainian, so **Ukrainian (uk) is the primary text**;
+> English (en) is the fallback locale.
+
+---
+
+## 1.4.3
+
+### Українська (uk)
+
+```
+Що нового у версії 1.4.3
+
+• Іконка на панелі інструментів тепер показує стан Movar: активний, приховує вміст на цій сторінці (з лічильником), призупинено, вимкнено, вимкнено для цього сайту або потребує уваги. Прибрано короткочасне блимання іконки під час завантаження сторінки, і тепер вона має однакову рамку в усіх станах.
+
+• Надійніше перемикання мови в українських інтернет-магазинах. Movar відновлює власний перемикач мови на сайтах на базі UMI.CMS, де посилання «UKR» перенаправляло назад на російську версію, і більше не втрачає справжній перемикач на деяких сайтах, які позначають мову одразу для всієї сторінки.
+
+• Стабільність. Усунуто збій фонового процесу під час завантаження сторінок, зупинено зайві перезавантаження в чаті Google AI Mode та скорочено кількість повторних записів правил (менше навантаження на Safari).
+
+• Покращення застосунку-компаньйона: щойно вибрана вкладка тепер відкривається згори, а типографіку в усьому інтерфейсі уніфіковано.
+```
+
+### English (en)
+
+```
+What's New in 1.4.3
+
+• The toolbar icon now shows Movar's state: active, hiding content on this page (with a count), paused, off, off for this site, or needing attention. Fixed a brief flicker on page load, and the icon now keeps a consistent border in every state.
+
+• More reliable language switching on Ukrainian shops. Movar recovers a site's own language switcher on UMI.CMS-based shops whose "UKR" link redirected back to Russian, and no longer loses the real switcher on some sites that tag the whole page's language at once.
+
+• Stability. Fixed a background crash during page loads, stopped needless reloads in Google AI Mode chat, and cut redundant rule writes (gentler on Safari).
+
+• Companion app polish: a freshly selected tab now opens at its top, and text styling is unified across the app.
+```
+
+<!--
+Older versions (kept for reference; ASC only shows the current version's text):
+
+Prepend each new release above this comment as `## <version>` with uk + en blocks.
+-->

--- a/docs/release-credentials.md
+++ b/docs/release-credentials.md
@@ -199,7 +199,8 @@ Publishing the Release runs `release-chrome`, `release-firefox`, and
 **Safari is the exception** — its `release-safari` job fails at the archive step
 on headless provisioning (`401` / no profiles), so the iOS + macOS App Store
 submission is done from a Mac via Xcode Organizer. Full step-by-step (version +
-timestamp build-number bump, fresh build, archive, upload, notarized `.dmg`) is
+timestamp build-number bump, fresh build, the App-Store-**required** bilingual
+"What's New" notes, archive, upload, notarized `.dmg`) is
 in [docs/safari-deploy.md § Local App Store submission](safari-deploy.md#local-app-store-submission-xcode-organizer).
 **Leave the parked `release-safari` CI job unapproved** so it doesn't double-submit
 the same version.

--- a/docs/safari-deploy.md
+++ b/docs/safari-deploy.md
@@ -220,11 +220,21 @@ succeeds locally.
    gh release upload "extension-v$v" "Movar-$v.dmg" --clobber
    ```
 
-7. **Submit for review in App Store Connect.** For the new version on **each**
-   platform: attach the just-uploaded build (it appears after processing), fill
-   **What's New**, answer export-compliance, and **Submit for Review**.
+7. **Prepare the "What's New" release notes** — App Store Connect **requires**
+   "What's New in This Version" text for **every localization** on every version
+   after the first (Chrome / Firefox / Edge treat release notes as optional; the
+   App Store does not). Update
+   [`apps/extension/store-assets/apple/WHATS-NEW.md`](../apps/extension/store-assets/apple/WHATS-NEW.md)
+   with this version's user-facing highlights in **Ukrainian and English**,
+   distilled from [`apps/extension/CHANGELOG.md`](../apps/extension/CHANGELOG.md).
+   You'll paste each locale in the next step.
 
-8. **After approval** — the marketing download links already point at the app-id
+8. **Submit for review in App Store Connect.** For the new version on **each**
+   platform: attach the just-uploaded build (it appears after processing), paste
+   the **What's New** notes from step 7 into each localization, answer
+   export-compliance, and **Submit for Review**.
+
+9. **After approval** — the marketing download links already point at the app-id
    URL shared by iOS + macOS
    ([apps/marketing/src/lib/downloads.ts](../apps/marketing/src/lib/downloads.ts)),
    so nothing changes there once iOS clears review.


### PR DESCRIPTION
The App Store requires "What's New in This Version" text for **every localization** on every version after the first — unlike Chrome/Firefox/Edge, where release notes are optional. So the local Safari submission flow was missing a required step.

- **`apps/extension/store-assets/apple/WHATS-NEW.md`** (new) — the 1.4.3 notes in **Ukrainian (primary)** + English, in copy-paste blocks ready for App Store Connect.
- **`docs/safari-deploy.md`** — new dedicated step *"Prepare the 'What's New' release notes"* in the per-release steps (renumbered), sourced from `CHANGELOG.md`.
- **`docs/release-credentials.md`** — the Safari note now lists the required "What's New" notes among the local steps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)