### PR TITLE
docs(safari): make bilingual (uk+en) What's New an explicit always-rule

### DIFF
--- a/apps/extension/store-assets/apple/WHATS-NEW.md
+++ b/apps/extension/store-assets/apple/WHATS-NEW.md
@@ -11,8 +11,9 @@ release — distil the user-facing highlights from
 [`apps/extension/CHANGELOG.md`](../../CHANGELOG.md); keep it short and in the
 user's voice (what changed for them), not the developer changelog.
 
-> Movar's audience is Ukrainian, so **Ukrainian (uk) is the primary text**;
-> English (en) is the fallback locale.
+> **Always prepare both locales — Ukrainian _and_ English — every release;
+> neither is optional.** Movar's audience is Ukrainian, so Ukrainian (uk) leads
+> and English (en) is the fallback locale, but both ship every time.
 
 ---
 


### PR DESCRIPTION
Follow-up to #273. States plainly that the App Store "What's New" notes are **always** prepared in both Ukrainian and English every release — neither locale is optional. Wording-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)