### PR TITLE
feat(marketing): bridge Edge install links to the Chrome Web Store

### DIFF
--- a/apps/marketing/src/components/InstallGuide.astro
+++ b/apps/marketing/src/components/InstallGuide.astro
@@ -84,6 +84,14 @@ const flows = [
             data-flow={key}
             class="rounded-2xl border border-border bg-surface p-6">
             <h2 class="font-display text-xl font-bold text-ink-strong">{flow.label}</h2>
+            {key === 'chromium' && (
+              <p
+                data-edge-note
+                hidden
+                class="mt-4 rounded-lg border border-border bg-accent-surface px-4 py-3 text-sm text-ink-soft">
+                {t.edgeNote}
+              </p>
+            )}
             <ol class="mt-5 flex flex-col gap-5">
               {flow.steps.map((step, index) => {
                 const illustration = ILLUSTRATIONS[key]?.[index] ?? null;
@@ -144,6 +152,14 @@ const flows = [
   if (detected) {
     const tab = tabs.find((t) => t.dataset['flowTab'] === detected);
     tab?.querySelector('[data-your-browser]')?.removeAttribute('hidden');
+  }
+
+  // Edge routes through the Chromium flow but installs from the Chrome Web Store,
+  // behind a one-time "allow extensions from other stores" prompt — reveal the
+  // heads-up that explains it. Hidden for every other browser (Chrome never sees
+  // that prompt, so the note would only confuse it).
+  if (id === 'edge') {
+    document.querySelector('[data-edge-note]')?.removeAttribute('hidden');
   }
 
   // Show the detected flow, or the broadest (Chromium) when unrecognised.

--- a/apps/marketing/src/i18n.ts
+++ b/apps/marketing/src/i18n.ts
@@ -284,6 +284,12 @@ interface InstallGuideStrings {
   intro: string;
   /** Badge marking the flow that matches the visitor's detected browser. */
   yourBrowser: string;
+  /**
+   * Edge-only heads-up shown in the Chromium flow: Edge installs Movar from the
+   * Chrome Web Store, behind a one-time "allow extensions from other stores"
+   * prompt. Revealed by the guide's script only when Edge is detected.
+   */
+  edgeNote: string;
   flows: {
     chromium: InstallGuideFlow;
     firefox: InstallGuideFlow;
@@ -676,6 +682,8 @@ const en: Strings = {
     intro:
       'Movar keeps every page in your language. Pick your browser below and follow the steps — the one that matters is letting Movar read the content of the sites you visit.',
     yourBrowser: 'Your browser',
+    edgeNote:
+      'On Edge, Movar installs from the Chrome Web Store. The first time, Edge asks you to “allow extensions from other stores” — that’s expected. Allow it once, then add Movar; it installs into Edge like any other extension.',
     flows: {
       chromium: {
         label: 'Chrome, Edge, Brave & Opera',
@@ -1098,6 +1106,8 @@ const uk: Strings = {
     intro:
       'Movar тримає кожну сторінку вашою мовою. Оберіть свій браузер нижче й виконайте кроки — головний з них: дозволити Movar читати вміст сайтів, які ви відвідуєте.',
     yourBrowser: 'Ваш браузер',
+    edgeNote:
+      'У Edge розширення Movar встановлюється з Chrome Web Store. Першого разу Edge попросить «дозволити розширення з інших магазинів» — це нормально. Дозвольте один раз і додайте Movar; він встановиться в Edge, як і будь-яке інше розширення.',
     flows: {
       chromium: {
         label: 'Chrome, Edge, Brave і Opera',

--- a/apps/marketing/src/lib/downloads.ts
+++ b/apps/marketing/src/lib/downloads.ts
@@ -6,7 +6,7 @@
  * drifting between components.
  */
 
-type StoreId = 'chrome' | 'edge' | 'firefox' | 'safari' | 'safari-ios';
+type StoreId = 'chrome' | 'firefox' | 'safari' | 'safari-ios';
 export type BrowserId = 'chrome' | 'edge' | 'firefox' | 'opera' | 'brave' | 'safari' | 'safari-ios';
 
 export interface Store {
@@ -25,7 +25,6 @@ const stores: Record<StoreId, Store> = {
     href: 'https://chromewebstore.google.com/detail/movar/bagafijhbhalglmeecicebmgaebipdgi',
     liveAt: '2026-06-03',
   },
-  edge: { href: '#', liveAt: null }, // TODO: paste Edge Add-ons URL on first publish
   // AMO redirects no-locale URLs to the visitor's preferred locale, so
   // both the en and uk pages share one link.
   firefox: { href: 'https://addons.mozilla.org/firefox/addon/movar/', liveAt: '2026-06-01' },
@@ -40,12 +39,18 @@ const stores: Record<StoreId, Store> = {
   'safari-ios': { href: 'https://apps.apple.com/app/id6779282071', liveAt: '2026-07-12' },
 };
 
-// Opera and Brave install Chromium extensions from the Chrome Web Store —
-// reusing the chrome listing as the marketplace truth, while each browser
-// keeps its own user-facing label.
+// Edge, Opera and Brave install Chromium extensions from the Chrome Web Store,
+// so they reuse the chrome listing as the marketplace truth while each keeps
+// its own user-facing label. Edge is an INTERIM bridge: its native Edge Add-ons
+// listing is still pending (the release pipeline already submits there), so
+// until that goes live we route Edge users to the CWS listing — Edge installs
+// it behind a one-time "Allow extensions from other stores" prompt, which the
+// /install guide's Edge note explains. When the native listing is live, add an
+// `edge` entry back to `stores` (liveAt: null until it clears review, which
+// re-lights the "Soon" chip) and point this back at 'edge'.
 const browserStore: Record<BrowserId, StoreId> = {
   chrome: 'chrome',
-  edge: 'edge',
+  edge: 'chrome',
   firefox: 'firefox',
   opera: 'chrome',
   brave: 'chrome',


### PR DESCRIPTION
## Why

Edge is Chromium and installs Chrome Web Store extensions (behind a one-time "allow extensions from other stores" prompt). But the site's native Edge Add-ons listing isn't live yet — the Partner Center first submission is still pending — so Edge visitors got an **inert "Add to Edge — Soon" button** and couldn't install at all.

This wires up an **interim bridge**: send Edge users to the live Chrome Web Store listing until the native Edge listing ships.

## What changed (marketing site only)

- **`downloads.ts`** — `browserStore.edge` now maps to the `chrome` store, exactly the way Opera and Brave already do. So `perBrowser.edge` resolves to the live CWS listing (`liveAt` set), turning the hero CTA and header "Download" link into an active **"Add to Edge"** → Chrome Web Store. Removed the dead `stores.edge` `'#'`/`null` stub and dropped the now-unused `'edge'` from the (non-exported) `StoreId`.
- **`i18n.ts`** — new `installGuide.edgeNote` copy in **uk + en**, honest about the friction: *"…Edge asks you to 'allow extensions from other stores' — that's expected. Allow it once, then add Movar…"*
- **`InstallGuide.astro`** — renders that note as a callout in the Chromium flow, **hidden by default and revealed only when Edge is detected** (Chrome never sees that prompt, so the note would only confuse it — mirrors the existing `data-your-browser` badge pattern).

Chrome / Firefox / Safari paths are untouched.

## Interim, not the destination

CWS-on-Edge carries a security-flavored "allow extensions from other stores" prompt — acceptable as a stopgap, worse than a native listing. When the Edge Add-ons first submission clears review, flip `browserStore.edge` back to `'edge'` and add the native URL (with `liveAt: null` until it's approved, which re-lights the "Soon" chip). The `downloads.ts` comment documents this exact path.

## Verification

- `typecheck` 0 errors · `lint` clean · `build` 12 pages OK
- Pre-push: build ✓, fallow metrics ✓ (no issues in the 3 changed files)
- Built HTML: `perBrowser.edge` → CWS href with `liveAt` (`edge.href === chrome.href`); `edgeNote` ships hidden in both locales
- Live preview (`astro preview`): no console errors; Chrome path unchanged (note hidden, button "Add to Chrome"); forcing the Edge branch reveals the note correctly
- **No visual-baseline impact** — the 24 `marketing.visual.spec.ts` snapshots pin only `navigator.language`, so the test browser always detects as `chrome`; the Edge-only bridge + hidden note never surface there. No changeset needed (`@movar/marketing` is `private`).

> ⚠️ One caveat: the preview browser can't spoof a real Edge user-agent, so the Edge path was verified via the server-rendered store data + executing the exact reveal line the script runs — not a genuine Edge session. Worth a quick real-Edge smoke test before/after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
