### PR TITLE
fix: three triaged quick wins — theme-color dark mode (#226), PAA empty-header (#218), post-captcha re-switch (#251)

### DIFF
--- a/.changeset/google-sorry-captcha-reswitch.md
+++ b/.changeset/google-sorry-captcha-reswitch.md
@@ -1,0 +1,5 @@
+---
+'@movar/extension': patch
+---
+
+Re-apply Movar's Google language switch after you solve a Google captcha (the "unusual traffic" / `/sorry` interstitial). Previously the results came back in the blocked language: the page you were returned to still counted as recently-redirected, so Movar treated the captcha detour as a redirect loop and skipped the switch. Movar now recognises the `/sorry` interstitial as an external interruption and re-applies the `hl`/`lr` switch on the search page you land back on.

--- a/.changeset/paa-empty-section-heading.md
+++ b/.changeset/paa-empty-section-heading.md
@@ -1,0 +1,5 @@
+---
+'@movar/extension': patch
+---
+
+Hide Google's "Схожі запитання" (People also ask) section heading when every question inside it is concealed, instead of leaving the label dangling over an empty box. The empty-container cleanup now treats a lone section heading as a passive label rather than content that keeps the section alive — while still preserving functional controls beside an emptied list, such as the AI Overview "5 сайтів" sources toggle. "Show everything" brings the whole section back together with its rows.

--- a/apps/extension/src/lib/content-conceal.test.ts
+++ b/apps/extension/src/lib/content-conceal.test.ts
@@ -250,6 +250,68 @@ describe('concealNode — empty-container cleanup', () => {
     expect(document.querySelector<HTMLElement>('#toggle')!.style.display).not.toBe('none');
   });
 
+  it('tears down a section whose only leftover is its heading label (PAA "Схожі запитання")', () => {
+    // Real-SERP shape (#218): a visible section HEADING sits as a sibling of the
+    // rows-list, not inside it. Once every row is hidden the list empties, and
+    // the heading is a dangling label over an empty box — the whole section must
+    // go, not stop at the heading's text the way plain content would.
+    setBody(`
+      <div id="section">
+        <div role="heading" aria-level="2" id="heading">Схожі запитання</div>
+        <div id="list">
+          <div class="related-question-pair" id="r1"><span>Для чего реле?</span></div>
+          <div class="related-question-pair" id="r2"><span>Где ставить реле?</span></div>
+        </div>
+      </div>
+    `);
+    const section = document.querySelector<HTMLElement>('#section')!;
+    const r1 = document.querySelector<HTMLElement>('#r1')!;
+    const r2 = document.querySelector<HTMLElement>('#r2')!;
+
+    concealNode(makeNode(r1, { hideMode: 'hide' }), 'ru', { concealMode: 'hide' });
+    expect(section.style.display).not.toBe('none'); // r2 still shows — don't teardown yet
+
+    concealNode(makeNode(r2, { hideMode: 'hide' }), 'ru', { concealMode: 'hide' });
+    expect(document.querySelector<HTMLElement>('#list')!.style.display).toBe('none');
+    expect(section.style.display).toBe('none');
+    expect(section.getAttribute('data-movar-hidden')).toBe('content-filter:container:empty');
+  });
+
+  it('reveals a torn-down PAA section (heading + list) together under "Show everything"', () => {
+    setBody(`
+      <div id="section">
+        <h2 id="heading">Схожі запитання</h2>
+        <div id="list"><div class="related-question-pair" id="r1"><span>Реле?</span></div></div>
+      </div>
+    `);
+    const r1 = document.querySelector<HTMLElement>('#r1')!;
+    concealNode(makeNode(r1, { hideMode: 'hide' }), 'ru', { concealMode: 'hide' });
+    const section = document.querySelector<HTMLElement>('#section')!;
+    expect(section.style.display).toBe('none');
+
+    revealAllNodes();
+    expect(section.style.display).toBe('');
+    expect(section.hasAttribute('data-movar-hidden')).toBe(false);
+  });
+
+  it('keeps a section whose leftover is a functional control even alongside a heading', () => {
+    // The heading-skip must not cascade: a section with BOTH a label AND a
+    // control (e.g. the AI Overview "Джерела" heading + "5 сайтів" toggle) still
+    // survives its list emptying, because the control is meaningful content.
+    setBody(`
+      <div id="popup">
+        <div role="heading" id="heading">Джерела</div>
+        <button id="toggle">5 сайтів</button>
+        <ul id="list"><li id="card"></li></ul>
+      </div>
+    `);
+    const el = document.querySelector<HTMLElement>('#card')!;
+    concealNode(makeNode(el, { hideMode: 'hide' }), 'ru', { concealMode: 'hide' });
+    expect(document.querySelector<HTMLElement>('#list')!.style.display).toBe('none');
+    expect(document.querySelector<HTMLElement>('#popup')!.style.display).not.toBe('none');
+    expect(document.querySelector<HTMLElement>('#toggle')!.style.display).not.toBe('none');
+  });
+
   it('never conceals body or html even when the whole page empties out', () => {
     setBody(`<div id="card"></div>`);
     const el = document.querySelector<HTMLElement>('#card')!;

--- a/apps/extension/src/lib/content-conceal.ts
+++ b/apps/extension/src/lib/content-conceal.ts
@@ -138,34 +138,50 @@ function hideCard(el: HTMLElement, node: ContentNode, language: LanguageCode): v
  *  a container that still shows a lone image/icon as empty. */
 const VISUAL_LEAF_TAGS = new Set(['img', 'svg', 'video', 'canvas', 'iframe', 'picture', 'embed']);
 
+/** A passive section label — a heading (`<h1>`–`<h6>` or an explicit
+ *  `[role=heading]`) — as opposed to a functional control (a button, link, or
+ *  toggle). Lets the empty-ancestor climb tell a dangling "Схожі запитання" /
+ *  "People also ask" label (hide it once its list is emptied) apart from the AI
+ *  Overview "5 сайтів" sources toggle (a `<button>`, which must survive). */
+function isHeadingLabel(el: Element): boolean {
+  return /^h[1-6]$/.test(el.tagName.toLowerCase()) || el.getAttribute('role') === 'heading';
+}
+
 /** True when `el` is something a user could see: not hidden outright, and
  *  either a visible media leaf, content inside an attached shadow root (a
  *  blur-mode curtain is a CHILD of its target, curtain.ts, but renders its
  *  pill inside an `open` shadow root — invisible to plain childNodes
  *  traversal, so a container whose cards are curtained rather than hidden
- *  must not be misread as empty), or a visible descendant. */
-function isVisibleElement(el: Element): boolean {
+ *  must not be misread as empty), or a visible descendant.
+ *
+ *  With `ignoreHeadings`, a bare section heading/label counts as nothing — the
+ *  empty-ancestor climb passes this so a heading left dangling over a
+ *  fully-hidden list is torn down with it, while a functional control (not a
+ *  heading) still counts and keeps its container alive. */
+function isVisibleElement(el: Element, ignoreHeadings = false): boolean {
   if (isHiddenElement(el)) return false;
+  if (ignoreHeadings && isHeadingLabel(el)) return false;
   if (VISUAL_LEAF_TAGS.has(el.tagName.toLowerCase())) return true;
-  if (el.shadowRoot !== null && hasVisibleContent(el.shadowRoot)) return true;
-  return [...el.childNodes].some(hasVisibleContent);
+  if (el.shadowRoot !== null && hasVisibleContent(el.shadowRoot, ignoreHeadings)) return true;
+  return [...el.childNodes].some((child) => hasVisibleContent(child, ignoreHeadings));
 }
 
 /** True when `node` — element, shadow root, or text — has any visible content
  *  anywhere in its subtree: non-whitespace text, a visible media leaf, or
  *  shadow-root content, recursing through non-hidden descendants only, so a
  *  display:none child (ours or the page's own) contributes nothing — same
- *  as serialize.ts's text walk. */
-function hasVisibleContent(node: Node): boolean {
+ *  as serialize.ts's text walk. `ignoreHeadings` is threaded through to
+ *  `isVisibleElement` (see there). */
+function hasVisibleContent(node: Node, ignoreHeadings = false): boolean {
   switch (node.nodeType) {
     case Node.TEXT_NODE: {
       return (node.nodeValue ?? '').trim() !== '';
     }
     case Node.ELEMENT_NODE: {
-      return isVisibleElement(node as Element);
+      return isVisibleElement(node as Element, ignoreHeadings);
     }
     case Node.DOCUMENT_FRAGMENT_NODE: {
-      return [...node.childNodes].some(hasVisibleContent);
+      return [...node.childNodes].some((child) => hasVisibleContent(child, ignoreHeadings));
     }
     default: {
       return false;
@@ -187,12 +203,18 @@ function hasVisibleContent(node: Node): boolean {
  * regular hide, so revealAllNodes/hideAllConcealed sweep these containers
  * too — "Show everything" must bring an emptied section back along with its
  * cards.
+ *
+ * A leftover section *heading* (`<h2>Схожі запитання</h2>` / "People also ask")
+ * does not count as content that keeps the section alive — otherwise the label
+ * would dangle over a now-empty list. A leftover *control* (the AI Overview
+ * "5 сайтів" sources toggle, a `<button>` sibling) still does, and survives —
+ * see `isVisibleElement`'s `ignoreHeadings`.
  */
 function concealEmptyAncestors(el: HTMLElement): void {
   let parent = el.parentElement;
   while (parent !== null && parent !== document.body && parent !== document.documentElement) {
     if (parent.hasAttribute(HIDDEN_ATTR)) return;
-    if (hasVisibleContent(parent)) return;
+    if (hasVisibleContent(parent, /* ignoreHeadings */ true)) return;
     parent.setAttribute(HIDDEN_ATTR, 'content-filter:container:empty');
     parent.style.setProperty('display', 'none', 'important');
     parent = parent.parentElement;

--- a/apps/extension/src/lib/content-runtime.ts
+++ b/apps/extension/src/lib/content-runtime.ts
@@ -608,6 +608,21 @@ async function applyOnceInner(settings: MovarSettings, generation: number): Prom
     clearAttempt();
   }
 
+  // A detour through the site's OWN captcha/bot-check interstitial (Google's
+  // /sorry) is an external interruption, not a Movar redirect loop — yet it
+  // leaves the pre-captcha URL marked as redirected-from, which would suppress
+  // the enforce-mode re-switch and strand the SERP in the blocked language
+  // (#251). Drop the guard when the interstitial is the page we're on (cleared
+  // proactively, before the user solves it) or the referrer of the page we've
+  // been returned to. YouTube's `bare → params → bare` replaceState loop has no
+  // interstitial in its chain, so its enforce-mode guard retention above holds.
+  if (
+    rule?.interstitialMatch?.(location.href) === true ||
+    rule?.interstitialMatch?.(document.referrer) === true
+  ) {
+    clearAttempt();
+  }
+
   // Only the FIRST enforce evaluation for this page/pathname lineage may treat
   // a strip-listed token's mere presence as reason enough to navigate (the
   // stale-session-bias cleanup docs/google-search-url-params.md needs); every

--- a/apps/extension/src/lib/google-captcha-return.integration.test.ts
+++ b/apps/extension/src/lib/google-captcha-return.integration.test.ts
@@ -1,0 +1,165 @@
+/**
+ * Integration test for #251 — the Google captcha (/sorry) detour.
+ *
+ * When Google interrupts a SERP with an "unusual traffic" interstitial
+ * (`/sorry/index?continue=…`) and the user solves it, they are returned to the
+ * pre-captcha `/search` URL — the exact URL the loop guard already marked as
+ * redirected-from when the switch first fired. That makes `recentlyAttemptedHere`
+ * true, so the enforce-mode switch is suppressed as a bounce and the SERP stays
+ * in the blocked language. The fix models the interstitial on the site rule
+ * (`googleRule.interstitialMatch = isGoogleSorryUrl`); the content runtime drops
+ * the guard when the interstitial is the current page or the referrer of the
+ * returned page, so the switch re-applies.
+ *
+ * This composes the REAL sessionStorage-backed loop guard, the REAL
+ * applyStrategy, and the enforce ladder (`tryStrategySwitch`) with the real
+ * google rule — only the URL surface (location) is a test double, exactly as
+ * the content script shares its real `location`. The runtime's guard-drop clause
+ * is `rule.interstitialMatch(location.href|referrer) ⇒ clearAttempt()`; the
+ * tests exercise both halves (the predicate and the resulting ladder behaviour).
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { getRuleForHost } from '../sites/registry';
+import { isGoogleSorryUrl } from '../sites/google';
+import { applyStrategy } from './strategy';
+import { tryStrategySwitch } from './language-switch';
+import type { LanguageSwitchDeps } from './language-switch';
+import { clearAttempt, hasAttemptedNavTo, markAttempt, recentlyAttemptedHere } from './loop-guard';
+
+/** Pre-rewrite SERP: Russian results, no hl/lr yet — the URL the guard marks
+ *  redirected-from, and the URL Google's `continue` returns the user to. */
+const SERP_URL = 'https://www.google.com/search?q=%D1%80%D0%B5%D0%BB%D0%B5&udm=14';
+/** The captcha interstitial that returned the user to SERP_URL. */
+const SORRY_URL = `https://www.google.com/sorry/index?continue=${encodeURIComponent(SERP_URL)}`;
+const PRIORITY = ['uk', 'en'] as const;
+
+/** Mutable stand-in for the page `location`, shared by the ladder deps exactly
+ *  like the content script shares its real `location`. */
+function makeLocation(href: string): { href: string; replace(url: string): void; reload(): void } {
+  return {
+    href,
+    replace(url: string) {
+      this.href = url;
+    },
+    reload: vi.fn(),
+  };
+}
+type TestLocation = ReturnType<typeof makeLocation>;
+
+/** Ladder deps wired to the REAL loop guard (jsdom sessionStorage) and the REAL
+ *  applyStrategy, with only the URL surface redirected at `loc`. */
+function makeSwitchDeps(loc: TestLocation): LanguageSwitchDeps {
+  return {
+    recentlyAttemptedHere: () => recentlyAttemptedHere(loc.href),
+    hasAttemptedNavTo,
+    markAttempt: () => {
+      markAttempt(loc.href);
+    },
+    record: vi.fn(async () => {}),
+    applyStrategy,
+    loopGuardCtx: {
+      getUrl: () => new URL(loc.href),
+      navigate: (url: string) => {
+        loc.replace(url);
+      },
+      isAttemptedUrl: hasAttemptedNavTo,
+    },
+    location: loc,
+    setSimulatedClick: () => {},
+  };
+}
+
+/** The content-runtime clause under test: drop the guard when the site's
+ *  interstitial is the current page or the referrer of the returned page. */
+function applyRuntimeCaptchaGuardDrop(href: string, referrer: string): void {
+  const rule = getRuleForHost(new URL(href).hostname);
+  if (rule?.interstitialMatch?.(href) === true || rule?.interstitialMatch?.(referrer) === true) {
+    clearAttempt();
+  }
+}
+
+beforeEach(() => {
+  clearAttempt();
+});
+afterEach(() => {
+  clearAttempt();
+  vi.restoreAllMocks();
+});
+
+describe('isGoogleSorryUrl', () => {
+  it('matches the /sorry interstitial across google ccTLDs', () => {
+    expect(isGoogleSorryUrl(SORRY_URL)).toBe(true);
+    expect(isGoogleSorryUrl('https://www.google.com/sorry')).toBe(true);
+    expect(isGoogleSorryUrl('https://www.google.de/sorry/index?continue=x')).toBe(true);
+    expect(isGoogleSorryUrl('https://www.google.com.ua/sorry/index')).toBe(true);
+  });
+
+  it('rejects ordinary SERP URLs, non-google hosts, and an absent referrer', () => {
+    expect(isGoogleSorryUrl(SERP_URL)).toBe(false);
+    expect(isGoogleSorryUrl('https://www.google.com/search?q=x')).toBe(false);
+    // Not a /sorry path — a query param merely containing the word must not match.
+    expect(isGoogleSorryUrl('https://www.google.com/search?q=sorry')).toBe(false);
+    expect(isGoogleSorryUrl('https://sorry.example.com/sorry')).toBe(false);
+    expect(isGoogleSorryUrl('')).toBe(false); // empty document.referrer
+    expect(isGoogleSorryUrl('not a url')).toBe(false);
+  });
+
+  it('is wired onto the enforce-mode google rule', () => {
+    const rule = getRuleForHost('www.google.com');
+    expect(rule?.enforce).toBe(true);
+    expect(rule?.interstitialMatch?.(SORRY_URL)).toBe(true);
+    expect(rule?.interstitialMatch?.(SERP_URL)).toBe(false);
+  });
+});
+
+describe('enforce switch after a /sorry captcha return (#251)', () => {
+  it('re-applies hl/lr on the returned SERP once the captcha detour drops the guard', async () => {
+    // The switch fired once before the captcha: the guard marked the SERP URL.
+    markAttempt(SERP_URL);
+    const loc = makeLocation(SERP_URL);
+    const deps = makeSwitchDeps(loc);
+    const rule = getRuleForHost('www.google.com')!;
+
+    // Precondition — the stale guard suppresses the re-switch (the #251 bug).
+    expect(await tryStrategySwitch(deps, rule, 'ru', PRIORITY)).toBe(false);
+    expect(loc.href).toBe(SERP_URL); // no navigation
+
+    // Runtime sees the /sorry referrer on the returned page → drops the guard.
+    applyRuntimeCaptchaGuardDrop(loc.href, SORRY_URL);
+
+    // Now the switch re-applies: hl (interface) + lr (results filter).
+    expect(await tryStrategySwitch(deps, rule, 'ru', PRIORITY)).toBe(true);
+    expect(loc.href).toContain('hl=uk');
+    expect(loc.href).toContain('lr=lang_uk');
+  });
+
+  it('also drops the guard while sitting ON the /sorry page (referrer-policy safe)', async () => {
+    // Belt-and-suspenders: the content script runs on /sorry (<all_urls>), so
+    // the guard is cleared proactively there even if the return referrer is
+    // later truncated to the bare origin by Google's referrer policy.
+    markAttempt(SERP_URL);
+    applyRuntimeCaptchaGuardDrop(SORRY_URL, ''); // on /sorry, no referrer needed
+    expect(recentlyAttemptedHere(SERP_URL)).toBe(false);
+
+    const loc = makeLocation(SERP_URL);
+    const deps = makeSwitchDeps(loc);
+    const rule = getRuleForHost('www.google.com')!;
+    expect(await tryStrategySwitch(deps, rule, 'ru', PRIORITY)).toBe(true);
+    expect(loc.href).toContain('hl=uk');
+  });
+
+  it('keeps the guard when the return is NOT via a captcha (YouTube-style loop stays broken)', async () => {
+    // A same-URL return whose referrer is an ordinary SERP — not /sorry — must
+    // stay suppressed, exactly as the enforce-mode retention intends. This is
+    // the regression fence for the param-strip loop the guard exists to break.
+    markAttempt(SERP_URL);
+    applyRuntimeCaptchaGuardDrop(SERP_URL, 'https://www.google.com/search?q=other&udm=14');
+    expect(recentlyAttemptedHere(SERP_URL)).toBe(true); // guard NOT dropped
+
+    const loc = makeLocation(SERP_URL);
+    const deps = makeSwitchDeps(loc);
+    const rule = getRuleForHost('www.google.com')!;
+    expect(await tryStrategySwitch(deps, rule, 'ru', PRIORITY)).toBe(false);
+    expect(loc.href).toBe(SERP_URL); // still suppressed — no navigation
+  });
+});

--- a/apps/extension/src/sites/google/index.ts
+++ b/apps/extension/src/sites/google/index.ts
@@ -106,11 +106,30 @@ export const googleSearchStrategy: Extract<LangStrategy, { type: 'searchParams' 
   scrubParams: ['aqs', 'rlz'],
 };
 
+/** True when `url` is a Google "unusual traffic" captcha interstitial
+ *  (`www.google.<tld>/sorry/…`). Solving it 302-returns the user to the
+ *  pre-captcha `/search` URL — which the loop guard already marked as
+ *  redirected-from — so without this signal the enforce switch is suppressed as
+ *  a bounce and the SERP stays in the blocked language (#251). Tolerant of a
+ *  non-URL / empty input (an absent `document.referrer`): returns false. */
+export function isGoogleSorryUrl(url: string): boolean {
+  try {
+    const { hostname, pathname } = new URL(url);
+    return isGoogleHost(hostname) && (pathname === '/sorry' || pathname.startsWith('/sorry/'));
+  } catch {
+    return false;
+  }
+}
+
 export const googleRule: SiteRule = {
   match: 'google',
   matchHost: isGoogleHost,
   enforce: true,
   strategy: googleSearchStrategy,
+  // A solved captcha returns the user to the pre-captcha SERP URL, which the
+  // loop guard still holds as redirected-from; treat the /sorry detour as an
+  // external interruption so the enforce switch re-applies (see #251).
+  interstitialMatch: isGoogleSorryUrl,
   // Residual case URL hygiene can't reach: the poisoned entry request is
   // served BEFORE any rewrite can act on a platform without the DNR
   // pre-request layer (lib/dnr.ts), and pins can be seeded by non-entry

--- a/apps/extension/src/sites/types.ts
+++ b/apps/extension/src/sites/types.ts
@@ -135,6 +135,16 @@ export interface SiteRule {
   /** Retry a zero-organic-result page once without the result-filter param.
    *  See {@link EmptyResultsRetry}; applied by `lib/empty-results-retry.ts`. */
   emptyResultsRetry?: EmptyResultsRetry;
+  /** Recognise this site's own bot-check / captcha interstitial (Google's
+   *  `/sorry/…`). A detour through it is an EXTERNAL interruption, not one of
+   *  Movar's redirects — but it leaves the pre-interstitial URL marked in the
+   *  loop guard, which would otherwise suppress the enforce-mode re-switch on
+   *  the page the user is returned to (leaving a SERP in the blocked language).
+   *  When the runtime sees the interstitial — as the current page OR as the
+   *  referrer of the page it returned to — it drops the guard so the switch
+   *  re-applies. Matched against a full URL string; must be false for the empty
+   *  string (an absent referrer). */
+  interstitialMatch?: (url: string) => boolean;
 }
 
 /** A site that ships a lazy page-content extractor chunk, plus the host

--- a/apps/marketing/src/layouts/BaseLayout.astro
+++ b/apps/marketing/src/layouts/BaseLayout.astro
@@ -1,5 +1,5 @@
 ---
-import { colorLight } from '@movar/theme';
+import { colorLight, colorDark } from '@movar/theme';
 
 import '../styles/global.css';
 import { alternateLocaleHref, strings, type Locale } from '../i18n';
@@ -80,7 +80,11 @@ const ukHref = new URL(ukPath, Astro.site).toString();
     <link rel="icon" type="image/svg+xml" href="/icon.svg" />
     <link rel="icon" type="image/png" sizes="32x32" href="/icon-32.png" />
     <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
-    <meta name="theme-color" content={colorLight['ink-strong']} />
+    {/* Tint the browser chrome to match the page background (the sticky header
+        is `bg-bg`), per theme — light was previously the only variant and used a
+        near-black that mismatched the near-white header. */}
+    <meta name="theme-color" content={colorLight.bg} media="(prefers-color-scheme: light)" />
+    <meta name="theme-color" content={colorDark.bg} media="(prefers-color-scheme: dark)" />
 
     {/* Open Graph */}
     <meta property="og:type" content="website" />


### PR DESCRIPTION
Resolves the three "quick win" issues from the triage pass. Each is an independent, self-contained fix with its own commit; review commit-by-commit.

## #226 — dark-mode `theme-color` (`fix(marketing)`)
The `<head>` emitted a single `theme-color` using `ink-strong` (`#1c1917`) — a near-black that neither adapts to dark mode nor even matches the light theme (the sticky header is `bg-bg`, near-white `#fafaf9`). Now two media-scoped tags track the page background per theme: `#fafaf9` light, `#0c0a09` dark. This was the last open item of #226 (the `og:locale=en_US` correctness fix and og/twitter image alts already shipped separately).

**Verified:** fetched the live dev-server `<head>` for `/` and `/uk/` — both variants render, alongside `og:locale=en_US`/`uk_UA` and the image `alt`s.

## #218 — tear down an emptied section's dangling heading (`fix(content-conceal)`)
When every row of Google's "Схожі запитання" (People also ask) block is concealed, the section heading was left dangling over an empty box — the empty-ancestor cleanup stopped because the heading's own text counted as visible content. The climb now ignores a bare section heading (`<h1>`–`<h6>` / `[role=heading]`), so a label left alone over a fully-hidden list is torn down with it. A leftover **control** (the AI Overview "5 сайтів" toggle, a `<button>` sibling) is not a heading, so its container still survives — the guarded design tension the issue calls out. "Show everything" restores the whole section together.

**Tests:** real-SERP shape (heading sibling of rows), "Show everything" restore, and control-preserved-alongside-heading; the existing toggle-protection test stays green.

## #251 — re-apply the Google switch after a `/sorry` captcha (`fix(lang-switch)`)
Solving a Google captcha (`/sorry` interstitial) returned the user to the pre-captcha `/search` URL — the exact URL the loop guard marked as redirected-from — so `recentlyAttemptedHere()` was true and the enforce-mode switch was suppressed as a bounce, leaving the SERP in the blocked language. Neither `clearAttempt` trigger fires on that round-trip (OK-page clear is enforce-excluded; SPA clear needs a same-document history change), so the stale marker survived the guard's 24h TTL.

Adds `SiteRule.interstitialMatch` (wired to `isGoogleSorryUrl` on the google rule); the runtime drops the guard when the interstitial is either the current page (cleared proactively on `/sorry` — robust to referrer-policy truncation, since the content script runs on `<all_urls>`) or the referrer of the page returned to. YouTube's `bare → params → bare` `replaceState` loop has no interstitial in its chain, so its enforce-mode guard retention is untouched.

**Tests:** new integration suite covering the predicate, the rule wiring, the re-switch on return, the on-`/sorry` proactive clear, and a regression fence proving the YouTube-style loop stays suppressed.

> Note: #251's hypothesis is code-grounded but was not reproduced against a live captcha (don't solve/bypass captchas to test). The fix covers both plausible `continue`-URL / referrer shapes.

---

Two `@movar/extension` patch changesets included (#218, #251); #226 is marketing-only. All three commits passed the full pre-commit gate (lint + 1231 extension tests + typecheck across all 19 projects) and the pre-push gate (build + headless e2e-fast + metrics audit).

Closes #226
Closes #218
Closes #251

🤖 Generated with [Claude Code](https://claude.com/claude-code)