### PR TITLE
test(e2e): de-flake the popup default-state render-settle race

### DIFF
--- a/apps/e2e/src/offline/popup.spec.ts
+++ b/apps/e2e/src/offline/popup.spec.ts
@@ -68,9 +68,33 @@ test.describe('extension popup', () => {
     const page = await movarContext.newPage();
     await page.goto(`chrome-extension://${extensionId}/popup.html`);
 
-    // Mount sanity check: `#root` exists in popup.html, but it's empty
-    // until React mounts. Wait for the first child to appear before
-    // asserting on its contents.
+    // ─── Settle gate ────────────────────────────────────────────────────
+    // Gate the structural + content assertions below on a fully-bootstrapped
+    // popup, so each asserts against a settled tree at the default 5s expect
+    // timeout instead of racing the mount. Two races made this flake under CPU
+    // contention (the pre-push `e2e:test:fast` runs this file alongside three
+    // siblings at 2 workers — ~50s loaded vs ~11s clean — and with retries:0 a
+    // single late paint is a hard fail):
+    //   1. React's first paint can lag past the default 5s timeout on a loaded
+    //      runner, so `#root`'s child (and the copy inside it) lands late.
+    //   2. The popup first renders on `defaultSettings` (priority uk-first →
+    //      the Ukrainian no-page hero) and only swaps to this test's seeded
+    //      en-first copy once usePopupController's bootstrap useEffect settles
+    //      (async getSettings + a sendToActiveTab miss + activeTabUrl). A
+    //      content assertion at the default timeout can outrun that settle.
+    // The English no-page hero is the deterministic settled signal: its
+    // presence proves the bootstrap applied the seeded priority (['en','uk'] →
+    // English) AND resolved the active tab to the no-page state — the exact
+    // end-state every step below asserts on. 10s mirrors
+    // content-script.spec.ts's `waitForMovarSettled(…10_000)` and sits well
+    // inside the 30s spec budget (one navigation + one settle, no stacking).
+    await expect(page.getByText('Open a website to see Movar at work')).toBeVisible({
+      timeout: 10_000,
+    });
+
+    // Mount sanity check, now post-settle: `#root` holds exactly one child
+    // (App mounts a single wrapper div). The settle gate already waited for
+    // the tree to render, so the default timeout is ample here.
     await expect(page.locator('#root > *')).toHaveCount(1);
 
     // ─── No brand header — the popup opens straight onto the status hero ─
@@ -85,10 +109,10 @@ test.describe('extension popup', () => {
     await test.step('activity section', async () => {
       // Opened as a tab (not over a real web page), the popup's active tab is
       // the extension page itself, so the per-page hero resolves to the
-      // "no page" state. Over a real site it would report that page's status.
-      await expect(page.getByText('Open a website to see Movar at work')).toBeVisible();
-      // The no-page hero shows neither the priority line nor any count — both
-      // were part of the old corrections-count hero.
+      // "no page" state — asserted as the settle gate above. Over a real site
+      // it would report that page's status. Here we pin the no-page hero's
+      // shape: it shows neither the priority line nor any count — both were
+      // part of the old corrections-count hero.
       await expect(page.getByText(/Priority:/i)).toHaveCount(0);
       await expect(page.getByText(/corrections? today/)).toHaveCount(0);
     });


### PR DESCRIPTION
## What

Gates the popup structural/content assertions in `popup.spec.ts` on a deterministic settled signal — the en-first no-page hero, at a 10s CI-safe timeout — instead of relying on mount timing.

## Why

Under CPU contention (the pre-push `e2e:test:fast` runs this file alongside three siblings at 2 workers — ~50s loaded vs ~11s clean — with `retries: 0`) the default 5s expect timeout can be outrun two ways:

1. **First-paint lag** — React's first paint can exceed 5s on a loaded runner, so `#root`'s child (and the copy inside it) lands late.
2. **uk→en settle swap** — the popup first renders on `defaultSettings` (`priority` uk-first → the Ukrainian no-page hero) and only swaps to this test's seeded en-first copy once `usePopupController`'s bootstrap `useEffect` settles (async `getSettings` + a `sendToActiveTab` miss + `activeTabUrl`). A content assertion at the default timeout can outrun that settle.

Either tips the mount check or the hero assertion over. It failed once in a real pre-push run, then passed in isolation — a render-settle-under-load flake, not a regression.

## Fix — test-synchronization only

Wait for the English no-page hero (the deterministic end-state every step asserts on) at a 10s timeout — mirroring `content-script.spec.ts`'s `waitForMovarSettled(…10_000)` — then the structural/content steps run against a settled tree at the default timeout. No product change, no visual baselines; `retries: 0` and the 30s spec budget preserved (one navigation + one settle, no stacked ceilings).

## Verification

- `test:fast` 5× clean: all green.
- Fixed spec repeated 5×/10×/6× (healthy and under CPU-burner load): all green.
- Head-to-head under load: the old 5s sync reached 5.5s (at the cliff) while the new 10s gate held with headroom.
- typecheck + lint clean.

Sibling to #279 (the hreflang-redirect CorrectionEvent poll de-flake) — same class of flake, kept separate to avoid scope creep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)