### PR TITLE
fix: on-site search broken on OpenCart shops (yato.com.ua) via picker mis-detection

### DIFF
--- a/.changeset/yato-opencart-picker-active-detection.md
+++ b/.changeset/yato-opencart-picker-active-detection.md
@@ -1,0 +1,5 @@
+---
+'@movar/extension': patch
+---
+
+Fix broken on-site search on Ukrainian OpenCart shops (reported on yato.com.ua). Their language switcher renders each option as a `<li>` wrapping a dead-href (`href="#"`) JavaScript switcher anchor, and the extractor keeps the `<li>` wrappers as the picker's classified links. The active-language detector treated the first non-anchor entry as the "you are here" marker, so a Ukrainian page (`<html lang="uk">`) was read as Russian — its first option is `Русский`. The extension then tried to "correct" the page: the site's own `uk` hreflang is self-referential (a no-op), so it followed the Ukrainian switcher anchor, which — with `<base href>` plus `href="#"` — resolves to the homepage, discarding the user's search results. Active-language detection now judges a wrapper element by the lone switcher it contains instead of assuming any non-anchor entry is the active one, so these pickers correctly abstain and detection falls through to `<html lang>`.

--- a/apps/extension/src/lib/yato-regression.test.ts
+++ b/apps/extension/src/lib/yato-regression.test.ts
@@ -1,0 +1,193 @@
+/**
+ * Regression: https://yato.com.ua/ (OpenCart) — Movar broke the on-site search.
+ *
+ * Symptom (user report 2026-07-20): searching on yato tossed the user back to
+ * the homepage, losing their results.
+ *
+ * Root cause is a picker mis-detection. yato's language switcher renders each
+ * option as a `<li>` wrapping a dead-href, JS-driven anchor:
+ *
+ *   <button class="dropdown-toggle"><span>Українська</span></button>   ← active
+ *   <ul>
+ *     <li class="top-menu__language-item"><a href="#" data-code="ru-ru">Русский</a></li>
+ *     <li class="top-menu__language-item"><a href="#" data-code="uk-ua">Українська</a></li>
+ *   </ul>
+ *
+ * `dedupNested` keeps the `<li>` wrappers as the classified links (they're the
+ * outer elements). Pre-fix, `activeLanguageFromPicker`'s "a non-anchor entry is
+ * the active language by construction" rule fired on the FIRST `<li>`
+ * (Русский), so the Ukrainian page (`<html lang="uk">`) was detected as
+ * Russian. The switch ladder then engaged: the page's own `uk-ua` hreflang is
+ * self-referential (a no-op), so it fell through to `tryPickerRedirect`, which
+ * followed the "Українська" switcher anchor. With `<base href="https://yato.com.ua/">`
+ * plus `href="#"`, that anchor resolves to the homepage `https://yato.com.ua/#`
+ * — throwing away the `/search/?search=…` results the user was looking at.
+ *
+ * Fix: a non-anchor element that wraps an interactive switcher (an anchor with
+ * an href, or a button) is judged BY that switcher, not assumed to be a bare
+ * "you are here" marker. yato's `<li>`s each wrap an `href="#"` anchor → no
+ * longer read as active → detection falls through to `<html lang="uk">` → no
+ * switch fires. See packages/lang-pickers/src/active.ts (`resolveSwitcher`).
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Mock } from 'vitest';
+import { defaultSettings } from '@movar/settings';
+import { detectPageLanguage } from '@movar/page-language';
+import { findLanguagePickers } from '@movar/lang-pickers/extract';
+import { buildPickerModel } from '@movar/lang-pickers/build-model';
+import { pickRedirectTarget } from '@movar/lang-pickers/redirect';
+import { attemptLanguageSwitch } from './language-switch';
+import type { LanguageSwitchDeps } from './language-switch';
+import { filterPickers } from './picker-filter';
+import { testContentPresenter } from './dom-test-helpers';
+
+const SEARCH_HREF =
+  'https://yato.com.ua/search/?search=%D0%BC%D0%BE%D0%BB%D0%BE%D1%82%D0%BE%D0%BA&description=true';
+const HOMEPAGE = 'https://yato.com.ua/';
+const LOC = { pathname: '/search/', hostname: 'yato.com.ua', href: SEARCH_HREF };
+
+/** The language `<form>` verbatim from the live search page (captured
+ *  2026-07-20). Active language lives only in the dropdown-toggle button's
+ *  text; the two options are `<li>`-wrapped `href="#"` switcher anchors. */
+const LANGUAGE_FORM = `
+  <div class="top-menu__language">
+    <form action="https://yato.com.ua/index.php?route=common/language/language" method="post" id="language">
+      <div class="btn-group">
+        <button class="top-menu__btn dropdown-toggle" aria-label="language" data-toggle="dropdown"><i class="fa fa-globe"></i><span class="top-menu__btn-text">Українська</span></button>
+        <ul class="dropdown-menu dropdown-menu-right">
+          <li class="top-menu__language-item"><a href="#" data-code="ru-ru">Русский</a></li>
+          <li class="top-menu__language-item"><a href="#" data-code="uk-ua">Українська</a></li>
+        </ul>
+      </div>
+      <input type="hidden" name="code" value="">
+      <input type="hidden" name="redirect_route" value="product/search">
+      <input type="hidden" name="redirect_query" value="&search=молоток&description=true">
+    </form>
+  </div>`;
+
+/** `<base>` + the self-referential hreflang set the live page publishes. The
+ *  base is load-bearing: it makes every `<a href="#">` resolve to the homepage. */
+const HEAD = `
+  <base href="https://yato.com.ua/">
+  <link rel="alternate" hreflang="ru-ua" href="https://yato.com.ua/ru/search/?search=%D0%BC%D0%BE%D0%BB%D0%BE%D1%82%D0%BE%D0%BA&description=true">
+  <link rel="alternate" hreflang="uk-ua" href="${SEARCH_HREF}">
+  <link rel="alternate" hreflang="x-default" href="${SEARCH_HREF}">`;
+
+/** `record` and `location.replace` are typed as `Mock` so `expect(deps.record)`
+ *  reads them as plain function values rather than tripping `unbound-method`. */
+type MockedDeps = Omit<LanguageSwitchDeps, 'record' | 'location'> & {
+  record: Mock<LanguageSwitchDeps['record']>;
+  location: {
+    readonly href: string;
+    replace: Mock<(url: string) => void>;
+    reload: Mock<() => void>;
+  };
+};
+
+/** Switch-ladder deps with a stubbed navigation surface. `applyStrategy` is a
+ *  no-op (the real hreflang strategy is exercised in strategy.test.ts); what
+ *  this file cares about is whether the PICKER-redirect branch fires and where
+ *  it points — which flows through `location.replace`, a spy here. */
+function makeDeps(href: string): MockedDeps {
+  return {
+    recentlyAttemptedHere: vi.fn(() => false),
+    hasAttemptedNavTo: vi.fn(() => false),
+    markAttempt: vi.fn(),
+    record: vi.fn(async () => {}),
+    applyStrategy: vi.fn(() => ({ navigated: false, needsReload: false, appliedSteps: 0 })),
+    loopGuardCtx: {},
+    location: { href, replace: vi.fn(), reload: vi.fn() },
+    setSimulatedClick: vi.fn(),
+  };
+}
+
+beforeEach(() => {
+  document.documentElement.setAttribute('lang', 'uk');
+  document.head.innerHTML = HEAD;
+  document.body.innerHTML = LANGUAGE_FORM;
+});
+
+afterEach(() => {
+  document.documentElement.removeAttribute('lang');
+  document.head.innerHTML = '';
+  document.body.innerHTML = '';
+});
+
+describe('yato.com.ua regression — search-breaking picker mis-detection', () => {
+  it('detects exactly one picker whose two options classify as ru + uk', () => {
+    const pickers = findLanguagePickers();
+    expect(pickers).toHaveLength(1);
+    expect(pickers[0]!.links.map((l) => l.language).toSorted()).toEqual(['ru', 'uk']);
+  });
+
+  it('does NOT vote Russian as the active language (root cause)', () => {
+    // Pre-fix this returned 'ru' — the first `<li>` was read as the active
+    // marker. The active language is genuinely ambiguous from the options
+    // alone (both are dead-href switchers), so the picker must abstain.
+    const model = buildPickerModel(findLanguagePickers(), LOC.href);
+    expect(model.activeLanguage).not.toBe('ru');
+    expect(model.activeLanguage).toBeNull();
+  });
+
+  it('detects the page as Ukrainian via <html lang>, not Russian (the fix)', () => {
+    // Pre-fix: 'ru' (picker vote overrode <html lang="uk">). Post-fix: the
+    // picker abstains and detection falls through to the honest <html lang>.
+    expect(detectPageLanguage(document, LOC)).toBe('uk');
+  });
+
+  it('does not attempt any language switch on the (correctly Ukrainian) page', async () => {
+    const pageLang = detectPageLanguage(document, LOC);
+    const deps = makeDeps(SEARCH_HREF);
+    const switched = await attemptLanguageSwitch(
+      deps,
+      defaultSettings,
+      undefined, // no site rule for yato
+      pageLang,
+      defaultSettings.priority[0],
+      findLanguagePickers(),
+    );
+    expect(switched).toBe(false);
+    expect(deps.location.replace).not.toHaveBeenCalled();
+    expect(deps.record).not.toHaveBeenCalled();
+  });
+
+  it('SYMPTOM PROOF: a mis-detected-as-Russian page would redirect search → homepage', async () => {
+    // Force the pre-fix mis-detection to demonstrate exactly why it broke
+    // search. With pageLang='ru', the switch ladder engages; hreflang no-ops
+    // (stubbed), so tryPickerRedirect follows the uk switcher anchor — which
+    // resolves, via <base> + href="#", to the homepage, discarding the query.
+    const target = pickRedirectTarget(findLanguagePickers(), ['uk']);
+    expect(target).toBeInstanceOf(HTMLAnchorElement);
+    expect((target as HTMLAnchorElement).href).toBe(HOMEPAGE + '#');
+
+    const deps = makeDeps(SEARCH_HREF);
+    const switched = await attemptLanguageSwitch(
+      deps,
+      defaultSettings,
+      undefined,
+      'ru', // the pre-fix (wrong) verdict
+      'uk',
+      findLanguagePickers(),
+    );
+    expect(switched).toBe(true);
+    // This is the bug the fix prevents: navigating away from /search to the
+    // homepage. The `.not` case above (correct 'uk' detection) is the guard.
+    expect(deps.location.replace).toHaveBeenCalledWith(HOMEPAGE + '#');
+  });
+
+  it('still hides the Russian option in the switcher (block-only behaviour retained)', () => {
+    // The fix must not stop Movar doing its actual job: on a correctly-detected
+    // uk page it filters the picker, hiding the blocked (ru) option while
+    // leaving the uk one.
+    filterPickers(
+      findLanguagePickers(),
+      [...defaultSettings.priority],
+      { blocked: [...defaultSettings.blocked] },
+      testContentPresenter,
+    );
+    const ruLi = document.querySelector<HTMLAnchorElement>('a[data-code="ru-ru"]')?.closest('li');
+    const ukLi = document.querySelector<HTMLAnchorElement>('a[data-code="uk-ua"]')?.closest('li');
+    expect(ruLi?.getAttribute('data-movar-hidden')).not.toBeNull();
+    expect(ukLi?.getAttribute('data-movar-hidden')).toBeNull();
+  });
+});

--- a/packages/lang-pickers/src/active.ts
+++ b/packages/lang-pickers/src/active.ts
@@ -35,27 +35,46 @@ function hasNoRealHref(el: HTMLElement): boolean {
   return rawHref == null || rawHref === '' || rawHref === '#' || rawHref.startsWith('javascript:');
 }
 
+/** Resolve a classified entry to the element whose active-ness actually decides
+ *  it. A wrapper (`<li>`, `<div>`, …) that contains exactly one interactive
+ *  switcher — an anchor WITH an href, or a button — is a switcher ITEM, so it's
+ *  judged by that switcher, not by the wrapper being non-clickable. Anchors and
+ *  buttons resolve to themselves; a wrapper with no lone switcher inside
+ *  resolves to itself (a genuine bare-text marker like
+ *  `<span class="lang-uk">UK</span>`). This is what stops OpenCart-style
+ *  `<li><a href="#">…</a></li>` option lists — yato.com.ua — from reading their
+ *  FIRST option as the active language. */
+function resolveSwitcher(el: HTMLElement): HTMLElement {
+  if (el instanceof HTMLAnchorElement || el instanceof HTMLButtonElement) return el;
+  const interactive = el.querySelectorAll<HTMLElement>('a[href], button');
+  const lone = interactive.length === 1 ? interactive.item(0) : null;
+  return lone ?? el;
+}
+
 /** True when this classified picker entry is, by construction, NOT a working
  *  switcher to ANOTHER language — so it must be the active ("you are here") one:
- *  a non-anchor marker (span/div/etc.), an anchor pointing at the current URL,
- *  or an explicitly disabled button. Deliberately EXCLUDES the bare-href anchor
- *  case (`#`, empty, javascript:) — see {@link hasNoRealHref}: a no-href anchor
- *  is frequently a JS switcher for a different language, so it isn't a reliable
- *  "current locale" marker on its own. */
+ *  a bare non-interactive marker (span/div/etc.), an anchor pointing at the
+ *  current URL, or an explicitly disabled button. A wrapper element is judged by
+ *  the lone switcher it contains (see {@link resolveSwitcher}). Deliberately
+ *  EXCLUDES the bare-href anchor case (`#`, empty, javascript:) — see
+ *  {@link hasNoRealHref}: a no-href anchor is frequently a JS switcher for a
+ *  different language, so it isn't a reliable "current locale" marker on its own. */
 function isInactiveSwitcher(el: HTMLElement, currentHref: string | undefined): boolean {
-  if (el instanceof HTMLAnchorElement) {
+  const target = resolveSwitcher(el);
+  if (target instanceof HTMLAnchorElement) {
     // A real self-link (href resolves to the current URL) IS the active marker;
     // a bare/`#` href is not — it's deferred to the corroborated/sole-candidate
     // path so it can't short-circuit a genuine class/aria signal.
-    if (hasNoRealHref(el)) return false;
-    return currentHref !== undefined && el.href === currentHref;
+    if (hasNoRealHref(target)) return false;
+    return currentHref !== undefined && target.href === currentHref;
   }
-  if (el instanceof HTMLButtonElement) {
-    return el.disabled || el.getAttribute('aria-disabled') === 'true';
+  if (target instanceof HTMLButtonElement) {
+    return target.disabled || target.getAttribute('aria-disabled') === 'true';
   }
-  // span / div / li / etc. classified as a language entry — by construction
-  // a non-clickable marker, so it's the active one.
-  return true;
+  // A non-interactive element (target === el). A leaf-ish marker with NO
+  // interactive descendant is the active one by construction; a switcher
+  // CLUSTER (several interactive descendants) is not a bare marker → abstain.
+  return el.querySelector('a[href], button') === null;
 }
 
 /** Extract every language token from a single text node by splitting on

--- a/packages/lang-pickers/src/picker.active.test.ts
+++ b/packages/lang-pickers/src/picker.active.test.ts
@@ -130,6 +130,48 @@ describe('activeLanguageFromPicker — marker signals', () => {
     expect(activeLanguageFromPicker(p, 'http://localhost/')).toBeNull();
   });
 
+  it('abstains for <li>-wrapped dead-href switchers (OpenCart / yato.com.ua)', () => {
+    // Each option is `<li class="…lang…"><a href="#" data-code>…</a></li>`, so
+    // dedupNested keeps the non-anchor `<li>` wrappers as the classified links.
+    // A `<li>` wrapping a dead-href JS switcher is NOT a "you are here" marker —
+    // pre-fix the FIRST option ('ru') was read as active, mis-detecting a
+    // Ukrainian page as Russian. The picker must abstain.
+    const p = pickerFromBody(
+      '<ul id="p">' +
+        '<li class="language-option"><a href="#" data-code="ru-ru">Русский</a></li>' +
+        '<li class="language-option"><a href="#" data-code="uk-ua">Українська</a></li>' +
+        '</ul>',
+    );
+    // Guard: the classified links really are the `<li>` wrappers, not the anchors.
+    expect(p.links.map((l) => l.el.tagName)).toEqual(['LI', 'LI']);
+    expect(activeLanguageFromPicker(p, 'https://shop.example/search?q=x')).toBeNull();
+  });
+
+  it('reads a <li> wrapping a self-link anchor as the active language', () => {
+    // The wrapper resolves to its lone switcher: when that anchor is a real
+    // self-link (href === current URL), the entry IS the active language. Guards
+    // that the OpenCart fix didn't blind the wrapped-self-link case.
+    const p = pickerFromBody(
+      '<ul id="p">' +
+        '<li class="language-option"><a href="https://shop.example/uk/x">UK</a></li>' +
+        '<li class="language-option"><a href="https://shop.example/ru/x">RU</a></li>' +
+        '</ul>',
+    );
+    expect(activeLanguageFromPicker(p, 'https://shop.example/uk/x')).toBe('uk');
+  });
+
+  it('still treats a bare <li> marker (no switcher inside) as the active language', () => {
+    // Regression guard for the fix itself: a non-anchor wrapper with NO
+    // interactive descendant is still the "you are here" marker.
+    const p = pickerFromBody(
+      '<ul id="p">' +
+        '<li class="lang-active">UK</li>' +
+        '<li class="language-option"><a href="/ru/x">RU</a></li>' +
+        '</ul>',
+    );
+    expect(activeLanguageFromPicker(p, 'https://shop.example/')).toBe('uk');
+  });
+
   it('abstains (null) when bare text names two different languages', () => {
     const container = elFromHtml<HTMLDivElement>(
       '<div>UA | DE | <a href="?lang=ru" id="ru">RU</a> | <a href="?lang=en" id="en">EN</a></div>',

--- a/scripts/readme-metrics.snapshot.json
+++ b/scripts/readme-metrics.snapshot.json
@@ -4,14 +4,14 @@
     "score": 81,
     "grade": "B"
   },
-  "loc": 42222,
+  "loc": 42241,
   "suppressions": {
     "eslint": 43,
     "fallow": 25
   },
   "coverage": {
     "lines": 94.1,
-    "branches": 86.7
+    "branches": 86.8
   },
   "bundle": {
     "contentKb": 39


### PR DESCRIPTION
## What

Fixes Movar breaking on-site search on `yato.com.ua` (reported by a user). The bug is a language-picker **mis-detection**: the Ukrainian page was read as Russian, so Movar tried to "correct" it and bounced the user to the homepage — most visibly by discarding an active search.

## Why it happened

yato (OpenCart) renders each language option as a `<li>` wrapping a dead-href JS switcher:

```html
<button class="dropdown-toggle"><span>Українська</span></button>  ← the real active marker
<ul>
  <li class="top-menu__language-item"><a href="#" data-code="ru-ru">Русский</a></li>
  <li class="top-menu__language-item"><a href="#" data-code="uk-ua">Українська</a></li>
</ul>
```

The chain:

1. `dedupNested` keeps the **`<li>` wrappers** as the picker's classified links (outer element wins over the inner `<a>`).
2. `activeLanguageFromPicker` treated any non-anchor entry as the "you are here" marker and returned the **first** `<li>` — `Русский` — so `<html lang="uk">` was overridden to `ru`.
3. `ru` is blocked → the switch ladder fired. The page's own `uk` hreflang is self-referential (no-op), so it fell through to `tryPickerRedirect`, which followed the "Українська" anchor.
4. With `<base href="https://yato.com.ua/">` + `href="#"`, that anchor resolves to `https://yato.com.ua/#` — the homepage — throwing away the `/search/?search=…` results.

This affected navigation site-wide (any non-home page bounced to home), but search is where the data loss is obvious.

## The fix

`packages/lang-pickers/src/active.ts`: active-language detection now resolves a **wrapper element to the lone interactive switcher it contains** (an anchor with an href, or a button) and judges *that*, instead of assuming any non-anchor entry is active. yato's `<li>`s each wrap an `href="#"` anchor → the picker correctly **abstains** → detection falls through to the honest `<html lang="uk">` → no switch fires. This is general: it fixes every OpenCart-style `<li><a href="#">` switcher, not just yato. Bare-text markers (`<span class="lang-uk">UK</span>`) and wrapped self-links are preserved.

## Tests

- **`apps/extension/src/lib/yato-regression.test.ts`** (new) — verbatim captured DOM: asserts detection = `uk`, no redirect fires, the Russian option is still filtered, and a *symptom-proof* that a mis-detected page would redirect search → homepage.
- **`packages/lang-pickers/src/picker.active.test.ts`** — 3 unit cases: the `<li>`-wrapper abstains; a wrapped self-link still reads as active; a bare `<li>` marker still reads as active.
- Reproduced deterministically first (detection was `ru`, redirect target `yato.com.ua/#`), then verified the fix against the **full 147 KB live page HTML**.
- Green: lang-pickers (68), page-language (47), full extension suite (1253), lint + typecheck across all workspace projects.

## Reviewer notes

- The root cause is the interaction between `dedupNested` (keeps outer `<li>`) and the active-detection heuristic; the fix targets the detection seam (lower-risk than changing extraction, which picker-filter's hide/divider logic depends on).
- Changeset included (`@movar/extension: patch`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)