### PR TITLE
chore(release): extension v1.5.0

### DIFF
--- a/.changeset/exempt-dotless-host-guard.md
+++ b/.changeset/exempt-dotless-host-guard.md
@@ -1,5 +1,0 @@
----
-'@movar/extension': patch
----
-
-Hide the popup's "Always skip this site" action on hosts that can't be stored as an exempt domain. A dotless host such as `localhost` or an intranet name is dropped by the allowlist's canonicaliser at the storage boundary, so offering the action there previously reloaded the tab without exempting anything. The popup now gates the affordance on `isStorableDomain`, matching the rule the settings boundary applies.

--- a/.changeset/exempt-site-settings.md
+++ b/.changeset/exempt-site-settings.md
@@ -1,5 +1,0 @@
----
-'@movar/extension': minor
----
-
-Manage exempt sites (the allowlist) directly from the extension. The options page now shows an "Exempt sites" editor to add, review, and remove domains where Movar takes no action, and the popup gains an "Always skip this site" action that exempts the current site in one click. Exempt domains are normalised to one canonical form — a bare `example.com`, with `www.`/scheme/path stripped — so a site you exempt from the popup is matched consistently by both the content script and the network-level rewrite, and covers its subdomains.

--- a/.changeset/google-sorry-captcha-reswitch.md
+++ b/.changeset/google-sorry-captcha-reswitch.md
@@ -1,5 +1,0 @@
----
-'@movar/extension': patch
----
-
-Re-apply Movar's Google language switch after you solve a Google captcha (the "unusual traffic" / `/sorry` interstitial). Previously the results came back in the blocked language: the page you were returned to still counted as recently-redirected, so Movar treated the captcha detour as a redirect loop and skipped the switch. Movar now recognises the `/sorry` interstitial as an external interruption and re-applies the `hl`/`lr` switch on the search page you land back on.

--- a/.changeset/paa-empty-section-heading.md
+++ b/.changeset/paa-empty-section-heading.md
@@ -1,5 +1,0 @@
----
-'@movar/extension': patch
----
-
-Hide Google's "Схожі запитання" (People also ask) section heading when every question inside it is concealed, instead of leaving the label dangling over an empty box. The empty-container cleanup now treats a lone section heading as a passive label rather than content that keeps the section alive — while still preserving functional controls beside an emptied list, such as the AI Overview "5 сайтів" sources toggle. "Show everything" brings the whole section back together with its rows.

--- a/.changeset/yato-opencart-picker-active-detection.md
+++ b/.changeset/yato-opencart-picker-active-detection.md
@@ -1,5 +1,0 @@
----
-'@movar/extension': patch
----
-
-Fix broken on-site search on Ukrainian OpenCart shops (reported on yato.com.ua). Their language switcher renders each option as a `<li>` wrapping a dead-href (`href="#"`) JavaScript switcher anchor, and the extractor keeps the `<li>` wrappers as the picker's classified links. The active-language detector treated the first non-anchor entry as the "you are here" marker, so a Ukrainian page (`<html lang="uk">`) was read as Russian — its first option is `Русский`. The extension then tried to "correct" the page: the site's own `uk` hreflang is self-referential (a no-op), so it followed the Ukrainian switcher anchor, which — with `<base href>` plus `href="#"` — resolves to the homepage, discarding the user's search results. Active-language detection now judges a wrapper element by the lone switcher it contains instead of assuming any non-anchor entry is the active one, so these pickers correctly abstain and detection falls through to `<html lang>`.

--- a/apps/extension/CHANGELOG.md
+++ b/apps/extension/CHANGELOG.md
@@ -1,5 +1,18 @@
 # @movar/extension
 
+## 1.5.0
+
+### Minor Changes
+
+- 7a43390: Manage exempt sites (the allowlist) directly from the extension. The options page now shows an "Exempt sites" editor to add, review, and remove domains where Movar takes no action, and the popup gains an "Always skip this site" action that exempts the current site in one click. Exempt domains are normalised to one canonical form — a bare `example.com`, with `www.`/scheme/path stripped — so a site you exempt from the popup is matched consistently by both the content script and the network-level rewrite, and covers its subdomains.
+
+### Patch Changes
+
+- f342354: Hide the popup's "Always skip this site" action on hosts that can't be stored as an exempt domain. A dotless host such as `localhost` or an intranet name is dropped by the allowlist's canonicaliser at the storage boundary, so offering the action there previously reloaded the tab without exempting anything. The popup now gates the affordance on `isStorableDomain`, matching the rule the settings boundary applies.
+- 1256077: Re-apply Movar's Google language switch after you solve a Google captcha (the "unusual traffic" / `/sorry` interstitial). Previously the results came back in the blocked language: the page you were returned to still counted as recently-redirected, so Movar treated the captcha detour as a redirect loop and skipped the switch. Movar now recognises the `/sorry` interstitial as an external interruption and re-applies the `hl`/`lr` switch on the search page you land back on.
+- 1256077: Hide Google's "Схожі запитання" (People also ask) section heading when every question inside it is concealed, instead of leaving the label dangling over an empty box. The empty-container cleanup now treats a lone section heading as a passive label rather than content that keeps the section alive — while still preserving functional controls beside an emptied list, such as the AI Overview "5 сайтів" sources toggle. "Show everything" brings the whole section back together with its rows.
+- d4d4edc: Fix broken on-site search on Ukrainian OpenCart shops (reported on yato.com.ua). Their language switcher renders each option as a `<li>` wrapping a dead-href (`href="#"`) JavaScript switcher anchor, and the extractor keeps the `<li>` wrappers as the picker's classified links. The active-language detector treated the first non-anchor entry as the "you are here" marker, so a Ukrainian page (`<html lang="uk">`) was read as Russian — its first option is `Русский`. The extension then tried to "correct" the page: the site's own `uk` hreflang is self-referential (a no-op), so it followed the Ukrainian switcher anchor, which — with `<base href>` plus `href="#"` — resolves to the homepage, discarding the user's search results. Active-language detection now judges a wrapper element by the lone switcher it contains instead of assuming any non-anchor entry is the active one, so these pickers correctly abstain and detection falls through to `<html lang>`.
+
 ## 1.4.3
 
 ### Patch Changes

--- a/apps/extension/package.json
+++ b/apps/extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@movar/extension",
-  "version": "1.4.3",
+  "version": "1.5.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/extension/safari/Movar/Movar.xcodeproj/project.pbxproj
+++ b/apps/extension/safari/Movar/Movar.xcodeproj/project.pbxproj
@@ -684,7 +684,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1784330980;
+				CURRENT_PROJECT_VERSION = 1784636665;
 				DEVELOPMENT_TEAM = RQSR4UU3VB;
 				CODE_SIGN_ENTITLEMENTS = "iOS (Extension)/Movar Extension.entitlements";
 				REGISTER_APP_GROUPS = YES;
@@ -698,7 +698,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.4.3;
+				MARKETING_VERSION = 1.5.0;
 				OTHER_LDFLAGS = (
 					"-framework",
 					SafariServices,
@@ -720,7 +720,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1784330980;
+				CURRENT_PROJECT_VERSION = 1784636665;
 				DEVELOPMENT_TEAM = RQSR4UU3VB;
 				CODE_SIGN_ENTITLEMENTS = "iOS (Extension)/Movar Extension.entitlements";
 				REGISTER_APP_GROUPS = YES;
@@ -734,7 +734,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.4.3;
+				MARKETING_VERSION = 1.5.0;
 				OTHER_LDFLAGS = (
 					"-framework",
 					SafariServices,
@@ -759,7 +759,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1784330980;
+				CURRENT_PROJECT_VERSION = 1784636665;
 				DEVELOPMENT_TEAM = RQSR4UU3VB;
 				CODE_SIGN_ENTITLEMENTS = "iOS (App)/Movar.entitlements";
 				REGISTER_APP_GROUPS = YES;
@@ -776,7 +776,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.4.3;
+				MARKETING_VERSION = 1.5.0;
 				OTHER_LDFLAGS = (
 					"-framework",
 					SafariServices,
@@ -802,7 +802,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1784330980;
+				CURRENT_PROJECT_VERSION = 1784636665;
 				DEVELOPMENT_TEAM = RQSR4UU3VB;
 				CODE_SIGN_ENTITLEMENTS = "iOS (App)/Movar.entitlements";
 				REGISTER_APP_GROUPS = YES;
@@ -819,7 +819,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.4.3;
+				MARKETING_VERSION = 1.5.0;
 				OTHER_LDFLAGS = (
 					"-framework",
 					SafariServices,
@@ -844,7 +844,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1784330980;
+				CURRENT_PROJECT_VERSION = 1784636665;
 				DEVELOPMENT_TEAM = RQSR4UU3VB;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -861,7 +861,7 @@
 					"@executable_path/../../../../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 11.0;
-				MARKETING_VERSION = 1.4.3;
+				MARKETING_VERSION = 1.5.0;
 				OTHER_LDFLAGS = (
 					"-framework",
 					SafariServices,
@@ -882,7 +882,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1784330980;
+				CURRENT_PROJECT_VERSION = 1784636665;
 				DEVELOPMENT_TEAM = RQSR4UU3VB;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -899,7 +899,7 @@
 					"@executable_path/../../../../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 11.0;
-				MARKETING_VERSION = 1.4.3;
+				MARKETING_VERSION = 1.5.0;
 				OTHER_LDFLAGS = (
 					"-framework",
 					SafariServices,
@@ -922,7 +922,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1784330980;
+				CURRENT_PROJECT_VERSION = 1784636665;
 				DEVELOPMENT_TEAM = RQSR4UU3VB;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -939,7 +939,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 11.0;
-				MARKETING_VERSION = 1.4.3;
+				MARKETING_VERSION = 1.5.0;
 				OTHER_LDFLAGS = (
 					"-framework",
 					SafariServices,
@@ -965,7 +965,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1784330980;
+				CURRENT_PROJECT_VERSION = 1784636665;
 				DEVELOPMENT_TEAM = RQSR4UU3VB;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -982,7 +982,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 11.0;
-				MARKETING_VERSION = 1.4.3;
+				MARKETING_VERSION = 1.5.0;
 				OTHER_LDFLAGS = (
 					"-framework",
 					SafariServices,

--- a/apps/extension/store-assets/apple/WHATS-NEW.md
+++ b/apps/extension/store-assets/apple/WHATS-NEW.md
@@ -17,6 +17,36 @@ user's voice (what changed for them), not the developer changelog.
 
 ---
 
+## 1.5.0
+
+### Українська (uk)
+
+```
+Що нового у версії 1.5.0
+
+• Сайти-винятки тепер можна налаштувати прямо в розширенні. На сторінці налаштувань зʼявився редактор, де можна додати, переглянути й видалити сайти, на яких Movar нічого не робить, а у спливаючому вікні — дія «Завжди пропускати цей сайт», що додає поточний сайт до винятків одним натисканням. Домен зводиться до єдиного вигляду й охоплює піддомени.
+
+• Google повертає результати вашою мовою навіть після капчі. Якщо Google показав перевірку «незвичний трафік», Movar тепер знову застосовує перемикання мови на сторінці результатів, куди вас повернуло, замість того щоб лишати її заблокованою мовою.
+
+• Акуратніше приховування в Google: заголовок блоку «Схожі запитання» ховається разом з усіма прихованими питаннями, а не висить над порожнім місцем. «Показати все» повертає блок цілком.
+
+• Виправлено пошук на українських крамницях на OpenCart (наприклад, yato.com.ua): сторінку українською більше не сприймає як російську, тож ваші результати пошуку не губляться.
+```
+
+### English (en)
+
+```
+What's New in 1.5.0
+
+• Exempt sites are now managed right in the extension. Settings has a new editor to add, review, and remove sites where Movar does nothing, and the popup gains an "Always skip this site" action that exempts the current site in one click. Each domain is reduced to one canonical form and covers its subdomains.
+
+• Google returns results in your language even after a captcha. If Google showed an "unusual traffic" check, Movar now re-applies its language switch on the results page you land back on, instead of leaving it in the blocked language.
+
+• Tidier hiding on Google: the "People also ask" heading is hidden together with its concealed questions, instead of dangling over an empty box. "Show everything" brings the section back.
+
+• Fixed on-site search on Ukrainian OpenCart shops (e.g. yato.com.ua): a Ukrainian page is no longer misread as Russian, so your search results are no longer lost.
+```
+
 ## 1.4.3
 
 ### Українська (uk)


### PR DESCRIPTION
## Release: extension v1.5.0

Cuts the release accumulated on `main` since v1.4.3 (5 changesets → **minor**). Uses the changesets flow (`pnpm version:packages`) on a `release/**` branch — matching how v1.4.3 (#271) shipped — because the changesets version-PR bot is currently broken (`pathspec 'changeset-release/main'` failure; flagged as a follow-up).

### What's in this release

**Minor**
- **Exempt sites (allowlist), end to end** (#277, closes #90) — options-page editor to add / review / remove sites Movar skips, plus a one-click popup **"Always skip this site"**. Domains are normalised to one canonical form and cover subdomains.

**Patches**
- Hide popup "Always skip this site" on un-storable hosts like `localhost` / intranet names (#278)
- Re-apply Movar's Google language switch after a `/sorry` captcha ("unusual traffic") interstitial
- Hide Google's "Схожі запитання" (People also ask) heading when every question inside is concealed
- Fix broken on-site search on Ukrainian OpenCart shops, e.g. yato.com.ua (#281)

### Also in this PR (manual surfaces the changesets bot doesn't touch)
- **Safari** `MARKETING_VERSION` 1.4.3 → 1.5.0 + build number (monotonic Unix timestamp `1784636665`) across all targets in `Movar.xcodeproj`, for the by-hand App Store submission.
- **Bilingual (uk + en) "What's New"** block in `apps/extension/store-assets/apple/WHATS-NEW.md` — App Store Connect requires it per-localization every version.

### Verification
- `pnpm verify:release` (Node 22) — all 9 checks pass: Chrome/Firefox built at 1.5.0, zips clean, addons-linter clean (only acknowledged findings), both builds byte-for-byte reproducible, permission/justification drift clean.
- Pre-push: build + e2e-fast + metrics:audit + README parity.

### After merge (release steps)
- Tag `extension-v1.5.0` on main + publish the GitHub Release → triggers `release.yml`. AMO / CWS / Edge jobs then **park on the `production` environment approval** (manual click — nothing publishes without it).
- **Safari**: separate by-hand Xcode Organizer submission (the `release-safari` CI job parks/fails on headless provisioning — expected).
- Manual smoke test per `apps/extension` `deployment-checklist.md §Pre-submission verification`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
