### PR TITLE
ci(changesets): stop the version-PR bot's push firing the lefthook pre-push hook

### DIFF
--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -70,3 +70,12 @@ jobs:
           title: 'chore: version packages'
         env:
           GITHUB_TOKEN: ${{ secrets.CHANGESETS_TOKEN || github.token }}
+          # `pnpm install` above ran `prepare` → `lefthook install`, which wires
+          # the local pre-push hook (build + metrics + e2e-fast). Without this,
+          # the action's automated `git push` of `changeset-release/main` fires
+          # that hook inside the runner — e2e-fast has no browser/build setup
+          # here, fails, and the push dies with "failed to push some refs", so
+          # the version PR never opens. The pre-push hook is a developer guard;
+          # main is already protected by the required ci-gate + metrics-gate
+          # checks. LEFTHOOK=0 makes the installed hook `exit 0` immediately.
+          LEFTHOOK: '0'


### PR DESCRIPTION
## Problem

The **Version** workflow (`changesets.yml`) has failed on every changeset-carrying merge since v1.4.3 (#276, #277, #278, #281), so the `chore: version packages` PR never opens and releases are cut by hand on `release/**`.

The `pathspec 'changeset-release/main' did not match any file(s) known to git` line in the failed logs is a **red herring** — that's `changesets/action` probing for an existing branch (`git checkout changeset-release/main`) before it falls back to `git checkout -b changeset-release/main`, which succeeds 40ms later. Branch creation is fine.

## Root cause

`pnpm install --frozen-lockfile` runs `prepare` → `lefthook install`, which wires the local **pre-push** hook (`build` + `metrics` + `e2e-fast`). When `changesets/action` does its automated `git push` of `changeset-release/main`, that hook fires **inside the runner**. e2e-fast has no build/browser setup in the Version job, fails, and the push dies with `failed to push some refs` → the action errors out → the version PR never opens.

(v1.4.3's run "succeeded" in 36s because it *was* the version-PR merge — no pending changesets → no-op → nothing pushed → no hook.)

## Fix

Set `LEFTHOOK=0` on the action step. The installed hook is literally `if [ "$LEFTHOOK" = "0" ]; then exit 0; fi`, so it short-circuits before running anything. The pre-push hook is a **developer** guard; `main` is already protected by the required **ci-gate + metrics-gate** checks — which still run on the opened version PR.

Verified locally: invoking the real installed `.git/hooks/pre-push` with `LEFTHOOK=0` exits `0` without running build/e2e.

## Follow-up (separate, not in this PR)

`CHANGESETS_TOKEN` is still **not set** — the workflow falls back to `github.token`. A PR opened with `github.token` won't trigger `on: pull_request` CI (GitHub anti-recursion). To make the opened version PR's checks runnable, provision `CHANGESETS_TOKEN` per `docs/release-credentials.md § Changesets version PR`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)