### PR TITLE
docs: correct stale "no changeset version" release guidance

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -119,7 +119,8 @@ A few repo-wide rules worth knowing up front (full list in [`AGENTS.md`](AGENTS.
 - **Icons are lucide** everywhere; never hand-inline SVG paths.
 - **Don't commit observability into the published extension** — it lives in the
   separate `apps/diagnostics` dev extension.
-- **Don't run `changeset version`** — the release ritual is a hand-bump + tag
-  (see [`AGENTS.md`](AGENTS.md)).
+- **Releases go through Changesets** — add a `.changeset/*.md` per PR
+  (`pnpm changeset`); the release is cut with `pnpm version:packages` on a
+  `release/**` branch (see [`AGENTS.md`](AGENTS.md)).
 
 Thanks for contributing!

--- a/apps/extension/AGENTS.md
+++ b/apps/extension/AGENTS.md
@@ -233,13 +233,25 @@ and tears down any curtain/tooltip nodes after each test.
 
 ## Gotchas
 
-**Release ritual** — do NOT use `changeset version` (changesets target the
-workspace root, not this package). The correct ritual:
+**Release ritual** — this package is cut with **Changesets**, not a hand-bump.
+Each `.changeset/*.md` targets `'@movar/extension'` directly, so `changeset
+version` bumps `apps/extension/package.json` and writes
+`apps/extension/CHANGELOG.md` correctly. The ritual:
 
-1. Hand-bump `"version"` in `apps/extension/package.json`.
-2. `git tag extension-vX.Y.Z` — the tag must match the version exactly.
-3. Push the tag; publishing the GitHub Release auto-submits to AMO + Chrome
-   Web Store + Edge Add-ons.
+1. Per PR, add a `.changeset/*.md` describing the change (`pnpm changeset`).
+2. To cut a release, on a `release/**` branch run `pnpm version:packages`
+   (= `changeset version && pnpm format`) — this consumes the pending
+   changesets, bumps `"version"` in `apps/extension/package.json`, and updates
+   `apps/extension/CHANGELOG.md`.
+3. Safari is not on Changesets — hand-bump `MARKETING_VERSION` and the build
+   number (a Unix timestamp) in
+   `apps/extension/safari/Movar/Movar.xcodeproj/project.pbxproj`, and add the
+   bilingual (uk + en) per-version block to
+   `apps/extension/store-assets/apple/WHATS-NEW.md`.
+4. `git tag extension-vX.Y.Z` — the tag must match the version exactly.
+5. Publishing the GitHub Release triggers `.github/workflows/release.yml`,
+   whose AMO + Chrome Web Store + Edge store jobs park on the `production`
+   environment approval.
 
 **Preview vs. real browser** — `preview:*` is fast but has no real storage, no
 background SW, and no content script. Use `dev:firefox:installed` (or


### PR DESCRIPTION
## What & why

Two docs described the extension release ritual as a manual hand-bump and explicitly told contributors **not** to run `changeset version`. That guidance is stale and its reasoning is factually wrong. The live flow is Changesets: `.changeset/*.md` files target `'@movar/extension'` directly, so `changeset version` (run via `pnpm version:packages`) correctly bumps `apps/extension/package.json` and writes `apps/extension/CHANGELOG.md`. v1.4.3 and v1.5.0 were both cut this way.

## Changes

- **`apps/extension/AGENTS.md`** — *Gotchas → Release ritual*: replaced the wrong "do NOT use `changeset version`" claim + 3-step hand-bump with the real 5-step flow:
  1. add a `.changeset/*.md` per PR (`pnpm changeset`)
  2. cut on a `release/**` branch with `pnpm version:packages` (= `changeset version && pnpm format`)
  3. hand-bump only the Safari `MARKETING_VERSION` + build number in `project.pbxproj` and add the bilingual `store-assets/apple/WHATS-NEW.md` block
  4. tag `extension-vX.Y.Z`
  5. publishing the GitHub Release triggers `.github/workflows/release.yml`, whose store jobs park on the `production` environment approval
- **`CONTRIBUTING.md`** — *Conventions*: flipped the "Don't run `changeset version`" bullet to point at the Changesets flow.

## Notes for reviewers

- Docs-only; no code or product behavior changes.
- Verified against the repo before writing: a sample `.changeset/*.md` frontmatter targets `'@movar/extension'`; root `package.json` has `"version:packages": "changeset version && pnpm format"`; `changesets.yml`, `release.yml`, and `store-assets/apple/WHATS-NEW.md` all exist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
