### PR TITLE
fix(content): defer SPA location-change re-eval until the navigation commits

### DIFF
--- a/.changeset/youtube-video-click-not-opening.md
+++ b/.changeset/youtube-video-click-not-opening.md
@@ -1,0 +1,5 @@
+---
+'@movar/extension': patch
+---
+
+Fix video clicks being aborted on YouTube search results. Clicking a video on `/results` is a same-document Navigation API push to `/watch`, and the browser fires the location-change event _before_ the navigation commits — while `location.href` still reads `/results`. Movar re-applied its `hl`/`gl` search-params rewrite to that stale URL and `location.replace()`d, clobbering the click, so the page blinked and the video never opened. The re-evaluation after a client-side URL change now waits for the navigation to commit before resetting guards or re-running, so the enforce-mode rewrite can no longer abort an in-flight click.

--- a/apps/extension/src/entrypoints/__tests__/content.test.ts
+++ b/apps/extension/src/entrypoints/__tests__/content.test.ts
@@ -834,6 +834,105 @@ describe('SPA / history location-change re-trigger', () => {
     expect(getAttemptedUrls()).toHaveLength(0);
   });
 
+  // Reported bug: on YouTube, clicking a video is a same-document Navigation-API
+  // push to /watch. WXT's location watcher dispatches wxt:locationchange from the
+  // `navigate` event — BEFORE the navigation commits, while location.href still
+  // reads the /results page. Acting then re-applied the enforce searchParams rule
+  // to the still-current /results URL and location.replace()d to re-add hl/gl,
+  // aborting the click: the page blinked and the video never opened. The reset +
+  // re-apply must wait for the navigation to commit (location catches up to
+  // /watch), where the /results-gated rule is a no-op.
+  it('defers the reset + re-apply until a pre-commit SPA navigation lands (YouTube video click)', async () => {
+    sessionStorage.clear();
+    document.body.innerHTML = '';
+    const settings = { ...defaultSettings, priority: ['uk' as const], contentModification: false };
+    const live = { current: settings };
+
+    const resultsUrl = 'https://www.youtube.com/results?search_query=test';
+    const watchUrl = 'https://www.youtube.com/watch?v=abc123';
+    const fakeLocation = {
+      // Still on /results: the navigate event fires before the push commits.
+      href: resultsUrl,
+      hostname: 'www.youtube.com',
+      protocol: 'https:',
+      pathname: '/results',
+      replace: vi.fn((next: string) => {
+        fakeLocation.href = next;
+      }),
+      reload: vi.fn(),
+    };
+    // Arm the loop guard for the current page (the settled post-load state).
+    // Clearing it is exactly what would let the enforce rewrite re-fire.
+    markAttempt(resultsUrl);
+    const originalLocation = globalThis.location;
+    Object.defineProperty(globalThis, 'location', { configurable: true, value: fakeLocation });
+    try {
+      // The video click: locationchange fires with the destination while
+      // location.href is still /results.
+      runtime.handleLocationChange(live, new URL(watchUrl), new URL(resultsUrl));
+
+      // Pre-commit: nothing must fire yet. Pre-fix, the pathname-change branch
+      // synchronously cleared the guard and re-ran applyOnce against /results,
+      // re-adding hl/gl and aborting the navigation.
+      expect(getAttemptedUrls()).toContain(resultsUrl);
+      expect(fakeLocation.replace).not.toHaveBeenCalled();
+
+      // The browser commits the same-document navigation to /watch.
+      fakeLocation.href = watchUrl;
+      fakeLocation.pathname = '/watch';
+      await new Promise((resolve) => setTimeout(resolve, 5));
+
+      // Now the reset + re-apply run — against /watch, where the /results-gated
+      // enforce rule is a no-op, so the video navigation is never clobbered.
+      expect(getAttemptedUrls()).not.toContain(resultsUrl);
+      expect(fakeLocation.replace).not.toHaveBeenCalled();
+      expect(fakeLocation.href).toBe(watchUrl);
+    } finally {
+      Object.defineProperty(globalThis, 'location', {
+        configurable: true,
+        value: originalLocation,
+      });
+      sessionStorage.clear();
+    }
+  });
+
+  it('skips the re-apply when a pre-commit navigation never lands (canceled nav)', async () => {
+    sessionStorage.clear();
+    const live = { current: { ...defaultSettings } };
+    markAttempt('https://example.com/ru/page');
+
+    // location stays on the old URL — a canceled/blocked navigation. The event
+    // still arrived (WXT advanced its lastUrl), but nothing actually changed, so
+    // no reset (guard kept) and no re-apply.
+    const fakeLocation = {
+      href: 'https://example.com/ru/page',
+      hostname: 'example.com',
+      protocol: 'https:',
+      pathname: '/ru/page',
+      replace: vi.fn(),
+      reload: vi.fn(),
+    };
+    const originalLocation = globalThis.location;
+    Object.defineProperty(globalThis, 'location', { configurable: true, value: fakeLocation });
+    try {
+      runtime.handleLocationChange(
+        live,
+        new URL('https://example.com/uk/other'),
+        new URL('https://example.com/ru/page'),
+      );
+      await new Promise((resolve) => setTimeout(resolve, 5));
+      // Never committed — the guard survives and no rewrite fired.
+      expect(getAttemptedUrls()).toContain('https://example.com/ru/page');
+      expect(fakeLocation.replace).not.toHaveBeenCalled();
+    } finally {
+      Object.defineProperty(globalThis, 'location', {
+        configurable: true,
+        value: originalLocation,
+      });
+      sessionStorage.clear();
+    }
+  });
+
   it('keeps a prior "Show everything" override on a query-only SPA change', () => {
     runtime.restoreAll();
     expect(runtime.getHiddenSummary().userOverride).toBe(true);

--- a/apps/extension/src/lib/content-runtime.ts
+++ b/apps/extension/src/lib/content-runtime.ts
@@ -805,11 +805,9 @@ function installMutationObserver(live: LiveSettings): void {
   observer.observe(document.body, { childList: true, subtree: true });
 }
 
-/** React to a client-side (history-API / hash / popstate) URL change within the
- *  same document. The MutationObserver only re-applies on `document.body`
- *  childList mutations, which an SPA route transition (YouTube's polymer router,
- *  Google's instant SERP) need not produce — so enforce-mode rewrites would
- *  silently stop after the first load. This re-runs applyOnce on URL change.
+/** Per-route-change resets + re-apply, run once we're actually on `newUrl`.
+ *  Split out of {@link handleLocationChange} so its pre-commit deferral can
+ *  invoke this the moment the same-document navigation commits.
  *
  *  Per-URL reset is gated on a real PATH change (a genuinely new page): both
  *  `userOverride` ("Show everything") and the loop guard are cleared only when
@@ -819,8 +817,7 @@ function installMutationObserver(live: LiveSettings): void {
  *  `bare → params → bare` loop AND silently re-conceal content the user just
  *  revealed. So a query-only change re-runs applyOnce but keeps both flags.
  *  (applyOnceInner still self-clears the guard when it lands on an OK page.) */
-function handleLocationChange(live: LiveSettings, newUrl: URL, oldUrl: URL): void {
-  if (newUrl.href === oldUrl.href) return;
+function applyRouteChange(live: LiveSettings, newUrl: URL, oldUrl: URL): void {
   // A new route invalidates any in-flight tick keyed to the old URL.
   invalidateInFlightApplies();
   if (newUrl.pathname !== oldUrl.pathname) {
@@ -833,10 +830,47 @@ function handleLocationChange(live: LiveSettings, newUrl: URL, oldUrl: URL): voi
   void applyOnce(live.current);
 }
 
-/** Wire the WXT location-change event to {@link handleLocationChange}. WXT
- *  patches `history.pushState`/`replaceState` and listens to `popstate` /
- *  `hashchange`, dispatching `wxt:locationchange` with the new/old URLs, and
- *  auto-removes the listener when the content-script context is invalidated. */
+/** React to a client-side URL change within the same document. The
+ *  MutationObserver only re-applies on `document.body` childList mutations,
+ *  which an SPA route transition (YouTube's polymer router, Google's instant
+ *  SERP) need not produce — so enforce-mode rewrites would silently stop after
+ *  the first load. This re-runs applyOnce on URL change.
+ *
+ *  Pre-commit deferral: WXT's location watcher uses the Navigation API where
+ *  available (every modern Chromium — and YouTube's router navigates through
+ *  it), firing `wxt:locationchange` from the `navigate` event BEFORE the
+ *  same-document navigation commits, while `location.href` still reads the URL
+ *  we're leaving (`oldUrl`). Re-applying now would run applyOnce against that
+ *  old page: on an enforce-mode SERP (YouTube `/results`) the searchParams rule
+ *  matches the still-current URL, re-adds `&hl=uk&gl=UA`, and `location.replace`s
+ *  — which ABORTS the user's in-flight click-through to `/watch`. The page
+ *  blinks and the video never opens (the reported bug). So when we're still
+ *  sitting on `oldUrl`, defer the reset + re-apply until the navigation commits
+ *  (location catches up to `newUrl`). A history/`popstate`/polling change already
+ *  arrives post-commit (`location` === `newUrl`) and runs synchronously as before. */
+function handleLocationChange(live: LiveSettings, newUrl: URL, oldUrl: URL): void {
+  if (newUrl.href === oldUrl.href) return;
+  if (location.href === oldUrl.href) {
+    // Pre-commit navigate event — wait for the same-document navigation to land.
+    // location.href updates synchronously once the navigate-event dispatch
+    // unwinds, so one macrotask later it reflects the destination. If it never
+    // left `oldUrl` (the navigation was canceled or blocked, or it was a
+    // cross-document nav that is unloading this page) nothing actually changed
+    // here — skip, leaving the current page untouched.
+    setTimeout(() => {
+      if (location.href !== oldUrl.href) applyRouteChange(live, newUrl, oldUrl);
+    }, 0);
+    return;
+  }
+  applyRouteChange(live, newUrl, oldUrl);
+}
+
+/** Wire the WXT location-change event to {@link handleLocationChange}. WXT's
+ *  location watcher uses the Navigation API `navigate` event where available
+ *  (falling back to a `history` patch + polling otherwise), dispatching
+ *  `wxt:locationchange` with the new/old URLs, and auto-removes the listener
+ *  when the content-script context is invalidated. The Navigation-API path
+ *  fires BEFORE the navigation commits — see {@link handleLocationChange}. */
 function installLocationChangeListener(live: LiveSettings, ctx: ContentScriptContext): void {
   // Cast to Window so WXT's typed `wxt:locationchange` overload is selected
   // (its event carries newUrl/oldUrl); the generic EventTarget overload would

--- a/docs/pitfalls.md
+++ b/docs/pitfalls.md
@@ -365,3 +365,67 @@ extension off, baseline count alongside every batch).
   same input, and is the DNR transform still idempotent (applying it to its own output must
   change nothing — that property is the loop safety)? Both are pinned in `lib/dnr.test.ts`;
   keep those tests honest.
+
+## 5. Enforce rewrite fired on a pre-commit URL ("aborted SPA click")
+
+> _Tags: site-rules, search-params, redirects, spa, youtube, wxt_
+
+**Signature.** On an `enforce`-mode SPA search surface, **clicking a result flashes the page
+and lands you right back where you were** instead of opening the result. On YouTube: every
+video click on `/results?search_query=…` blinks and the video never opens. It looks like the
+site's own router is broken, or like concealment is eating the click — both wrong. Tell-tale:
+the surface is a search page carrying an `enforce` rule (`youtube.com`), the result is a
+**same-document** navigation to another path on the same host (`/results` → `/watch`), and the
+tab ends up back on the search URL (often with the forcing params freshly re-added).
+
+**Blast radius.** Any `enforce`-mode `searchParams` rule on a host whose in-app navigation is
+**same-document** (SPA) — today only **YouTube** (`sites/youtube/index.ts`, path-gated to
+`/results`). Google/Bing/DDG result clicks are **cross-document** navigations to other origins,
+so they unload this page and never hit this window. A future SPA search rule inherits the bug
+unless this deferral holds.
+
+**Root cause.** WXT's location watcher (`wxt/dist/utils/internal/location-watcher.mjs`) uses
+the **Navigation API** where available — every modern Chromium, and YouTube's router navigates
+through it — dispatching `wxt:locationchange` from the `navigate` event, which fires **before
+the same-document navigation commits**. At that instant `location.href` still reads the URL
+you're **leaving** (`/results`), while the event's `newUrl` is the destination (`/watch`).
+`handleLocationChange` (`lib/content-runtime.ts`) then, on a path change, cleared the loop
+guard and re-ran `applyOnce` — which reads the live `location.href` (still `/results`), matches
+the `enforce` `searchParams` gate, re-adds `&hl=uk&gl=UA`, and `location.replace`s. That
+brand-new full navigation **clobbers the in-flight same-document push**, so the click is
+aborted and the search page reloads. (The docstring that claimed WXT "patches
+`history.pushState`/`replaceState` and listens to `popstate`" was stale — that's only the
+polling fallback path, which fires _post_-commit and never triggered this.)
+
+**Guard.** `handleLocationChange` **defers the reset + re-apply until the navigation actually
+commits** — i.e. until `location.href` catches up to `newUrl`. When the event arrives while
+we're still sitting on `oldUrl` (`location.href === oldUrl.href`, the pre-commit tell), it
+schedules a one-macrotask check: `location.href` updates synchronously once the navigate-event
+dispatch unwinds, so by the next macrotask it reflects the destination, and `applyOnce` then
+evaluates the page we're actually **on** (`/watch`, where the `/results`-gated rule is a
+no-op). If `location.href` never left `oldUrl` (a canceled/blocked nav, or a cross-document nav
+already unloading this page), the deferred check is a no-op — nothing changed here. A
+history/`popstate`/polling change already arrives post-commit (`location === newUrl`) and runs
+synchronously, exactly as before. Pinned by two tests in `content.test.ts` ("defers the reset +
+re-apply until a pre-commit SPA navigation lands", "skips the re-apply when a pre-commit
+navigation never lands").
+
+**Rules of the road.** Anything in `handleLocationChange`'s path-change branch (the guard/
+override/`enforceCheckedOnce` resets) and `applyOnce` itself must read the **committed** URL,
+never the event's `newUrl` while the DOM still shows the old page — the URL and the DOM have to
+agree, and they only do post-commit. Don't "optimize" by acting on `newUrl` directly: detection
+would read the old page's DOM under the new page's URL.
+
+**The general rule:** a navigation-triggering side effect (`location.replace`/`reload`, or a
+guard reset that unblocks one) is only safe once it reads the URL it's acting on **from a
+committed location**. Two safe shapes exist and a third is the trap:
+
+- _Event-driven_ (`wxt:locationchange`) — MUST defer past commit, as above, because the
+  Navigation-API event is pre-commit. This is the trap this entry exists for.
+- _Timer-driven_ (`empty-results-retry.ts`, fired on a `setTimeout` after `load`) — safe by
+  construction: a macrotask callback can never land inside a click's sub-millisecond pre-commit
+  window, so by the time it runs `location.href` is committed, and its `isSuperseded`
+  URL-equality check bails if a navigation moved us. **Do not convert it to fire from a
+  navigation event** without adding the pre-commit deferral — that would reintroduce the class.
+- _Mutation-driven_ (`applyOnce` via the debounced `MutationObserver`) — safe: SPA route DOM
+  swaps land post-commit, and the 150 ms debounce is well past the synchronous commit.


### PR DESCRIPTION
## What

On YouTube search results (`/results?search_query=…`), clicking **any** video made the page blink and the video never opened — you were bounced back to the results page. This fixes it.

## Why

Clicking a video on YouTube is a **same-document Navigation API push** to `/watch` (not a `history.pushState`). WXT 0.20.26's location watcher listens to the Navigation API `navigate` event, which fires **before the navigation commits** — at that instant `location.href` still reads `/results`.

`handleLocationChange` then, on the path change, cleared the loop guard and re-ran `applyOnce` **against that stale `/results` URL**. Because YouTube carries an `enforce`-mode `searchParams` rule, the rewrite matched, re-added `&hl=uk&gl=UA`, and called `location.replace()` — a brand-new full navigation that **clobbered the in-flight click to `/watch`**. Deterministically, every click.

I confirmed the timing live in a browser: the video-click `navigate` event reports `destination.url = /watch` while `location.href` is still `/results`, and it goes through `navigation.navigate` (no `history.pushState`, no `popstate`).

## The fix

[`content-runtime.ts`](../blob/claude/video-click-not-opening-dd8722/apps/extension/src/lib/content-runtime.ts) — when a `wxt:locationchange` arrives while we're still on `oldUrl` (the pre-commit tell), **defer the reset + `applyOnce` by one macrotask** until the navigation commits and `location.href` catches up to the destination. `applyOnce` then evaluates `/watch`, where the `/results`-gated rule is a no-op, so the click is never aborted.

- A canceled/blocked nav that never leaves `oldUrl` is skipped (no reset, no re-apply).
- History / `popstate` / polling changes already arrive post-commit (`location === newUrl`) and run synchronously, exactly as before.
- Also corrected a stale docstring that claimed WXT only patches `history` + `popstate` (that's just the fallback path).

## Scope / blast radius

YouTube is the only affected surface: it's the sole `enforce`-mode site whose result clicks are **same-document** same-origin navigations. Google/Bing/DuckDuckGo result clicks are cross-document (external), so they unload the page and never hit this pre-commit window. The one-time "blink" when *landing* on a search page (adding `hl/gl`) is separate, pre-existing enforce behavior and is untouched.

## Codebase sweep

Asked to find similar issues, I swept the whole repo:

- **`wxt:locationchange` consumers:** exactly one (this handler) — fixed.
- **movar's own navigation-event listeners** (`popstate`/`hashchange`/`navigate`/…): none — it relies entirely on WXT.
- **Direct `history.*`/`navigation.*` calls in product code:** none.
- **`empty-results-retry`** (same shape — timer → read `location` → `location.replace`): not racy (fires on a `setTimeout` macrotask, never inside a click's sub-ms pre-commit window; `isSuperseded` bails once `location` moves; Google-only + empty-SERP-gated). No change.
- Background `tabs.onUpdated` only repaints the toolbar icon (benign). `MutationObserver`-driven `applyOnce` runs post-commit (150 ms debounce).

Documented the whole class as **§5 in `docs/pitfalls.md`**, including the timer-vs-event-driven distinction so the retry isn't converted to an event trigger without adding the deferral.

## Tests

Two regression tests in `content.test.ts`, both **proven to fail against the old synchronous path** (the guard was cleared pre-commit) and pass with the fix:

- `defers the reset + re-apply until a pre-commit SPA navigation lands (YouTube video click)`
- `skips the re-apply when a pre-commit navigation never lands (canceled nav)`

## Verification

- Full extension suite: **1255 passing**; root `pnpm test`, `typecheck`, `eslint`, `prettier` all green (pre-commit).
- Pre-push: build ✓, offline e2e-fast 20/20 ✓, `fallow audit` clean.
- No metrics-snapshot refresh needed — the added lines are fully covered, so aggregate coverage shifts well under the gate's 0.05% epsilon (`readme-parity` passed in pre-commit).

## Reviewer notes

- The pre-commit discriminator is `location.href === oldUrl.href` — it defers **only** when we can prove we're still sitting on the page we're leaving; every other path (committed, or polling/history post-commit) runs synchronously as before, so no existing behavior changes.
- Not covered by live e2e on purpose: the YouTube live spec only asserts SERP blur and never clicks through; a live-e2e for a Navigation-API timing bug would be flaky. The unit test at the `handleLocationChange` seam is the right level.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
