### PR TITLE
fix(extension): reconcile UK manifest description with the canonical tagline

### DIFF
--- a/apps/extension/src/public/_locales/uk/messages.json
+++ b/apps/extension/src/public/_locales/uk/messages.json
@@ -1,4 +1,4 @@
 {
   "extName": { "message": "Movar" },
-  "extDescription": { "message": "Залиште інтернет вашою мовою." }
+  "extDescription": { "message": "Налаштуйте інтернет на рідну мову." }
 }


### PR DESCRIPTION
## What

One-line copy fix to the extension's UK native-locale manifest description.

**Before:** «Залиште інтернет вашою мовою.»
**After:** «Налаштуйте інтернет на рідну мову.»

`apps/extension/src/public/_locales/uk/messages.json` — surfaced in the built manifest via `__MSG_extDescription__` (`apps/extension/wxt.config.ts:351`).

## Why

Follow-up to #286. While auditing that change I found the UK product tagline was expressed three different ways across surfaces; the extension manifest description was the lone straggler.

| Surface | EN | UK |
|---|---|---|
| Marketing hero / OG (source of truth) | Keep the internet in your language. | Налаштуйте інтернет на рідну мову. |
| Store copy (REQUIREMENTS headline, summary ×3, description) | — | Налаштуйте інтернет на рідну мову. |
| Safari host app (`brandSubtitle` / `lede`) | — | Налаштуйте інтернет на рідну мову. |
| **Extension manifest description** | Keep the internet in your language. ✓ | **Залиште інтернет вашою мовою.** ✗ → fixed |

EN was already character-identical to the marketing tagline; this brings UK into the same parity. Every other UK surface already uses the canonical phrasing, so this is aligning the last holdout rather than inventing new copy.

## Notes for the reviewer

- **No behaviour change, no visual baseline shift.** The manifest description is store-facing text metadata — it isn't rendered into any store-asset screenshot or e2e visual baseline (verified: nothing under `store-assets/` or `apps/e2e/` consumes `extDescription`).
- The old string «Залиште інтернет вашою мовою.» appeared **nowhere else** in the tree — no test, snapshot, or fixture asserts on it.
- `check:readme` parity only guards the marketing↔README tagline pair, which is why this drift wasn't caught automatically.

## Verification

Pre-commit (prettier, README parity, typecheck, commitlint) and pre-push (build, e2e-fast, metrics, `fallow audit`) all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
