### PR TITLE
chore(release): extension v1.5.1

### DIFF
--- a/.changeset/youtube-video-click-not-opening.md
+++ b/.changeset/youtube-video-click-not-opening.md
@@ -1,5 +1,0 @@
----
-'@movar/extension': patch
----
-
-Fix video clicks being aborted on YouTube search results. Clicking a video on `/results` is a same-document Navigation API push to `/watch`, and the browser fires the location-change event _before_ the navigation commits — while `location.href` still reads `/results`. Movar re-applied its `hl`/`gl` search-params rewrite to that stale URL and `location.replace()`d, clobbering the click, so the page blinked and the video never opened. The re-evaluation after a client-side URL change now waits for the navigation to commit before resetting guards or re-running, so the enforce-mode rewrite can no longer abort an in-flight click.

--- a/apps/extension/CHANGELOG.md
+++ b/apps/extension/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @movar/extension
 
+## 1.5.1
+
+### Patch Changes
+
+- ffb6b07: Fix video clicks being aborted on YouTube search results. Clicking a video on `/results` is a same-document Navigation API push to `/watch`, and the browser fires the location-change event _before_ the navigation commits — while `location.href` still reads `/results`. Movar re-applied its `hl`/`gl` search-params rewrite to that stale URL and `location.replace()`d, clobbering the click, so the page blinked and the video never opened. The re-evaluation after a client-side URL change now waits for the navigation to commit before resetting guards or re-running, so the enforce-mode rewrite can no longer abort an in-flight click.
+
 ## 1.5.0
 
 ### Minor Changes

--- a/apps/extension/package.json
+++ b/apps/extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@movar/extension",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/extension/safari/Movar/Movar.xcodeproj/project.pbxproj
+++ b/apps/extension/safari/Movar/Movar.xcodeproj/project.pbxproj
@@ -684,7 +684,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1784636665;
+				CURRENT_PROJECT_VERSION = 1784961373;
 				DEVELOPMENT_TEAM = RQSR4UU3VB;
 				CODE_SIGN_ENTITLEMENTS = "iOS (Extension)/Movar Extension.entitlements";
 				REGISTER_APP_GROUPS = YES;
@@ -698,7 +698,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.5.0;
+				MARKETING_VERSION = 1.5.1;
 				OTHER_LDFLAGS = (
 					"-framework",
 					SafariServices,
@@ -720,7 +720,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1784636665;
+				CURRENT_PROJECT_VERSION = 1784961373;
 				DEVELOPMENT_TEAM = RQSR4UU3VB;
 				CODE_SIGN_ENTITLEMENTS = "iOS (Extension)/Movar Extension.entitlements";
 				REGISTER_APP_GROUPS = YES;
@@ -734,7 +734,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.5.0;
+				MARKETING_VERSION = 1.5.1;
 				OTHER_LDFLAGS = (
 					"-framework",
 					SafariServices,
@@ -759,7 +759,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1784636665;
+				CURRENT_PROJECT_VERSION = 1784961373;
 				DEVELOPMENT_TEAM = RQSR4UU3VB;
 				CODE_SIGN_ENTITLEMENTS = "iOS (App)/Movar.entitlements";
 				REGISTER_APP_GROUPS = YES;
@@ -776,7 +776,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.5.0;
+				MARKETING_VERSION = 1.5.1;
 				OTHER_LDFLAGS = (
 					"-framework",
 					SafariServices,
@@ -802,7 +802,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1784636665;
+				CURRENT_PROJECT_VERSION = 1784961373;
 				DEVELOPMENT_TEAM = RQSR4UU3VB;
 				CODE_SIGN_ENTITLEMENTS = "iOS (App)/Movar.entitlements";
 				REGISTER_APP_GROUPS = YES;
@@ -819,7 +819,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.5.0;
+				MARKETING_VERSION = 1.5.1;
 				OTHER_LDFLAGS = (
 					"-framework",
 					SafariServices,
@@ -844,7 +844,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1784636665;
+				CURRENT_PROJECT_VERSION = 1784961373;
 				DEVELOPMENT_TEAM = RQSR4UU3VB;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -861,7 +861,7 @@
 					"@executable_path/../../../../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 11.0;
-				MARKETING_VERSION = 1.5.0;
+				MARKETING_VERSION = 1.5.1;
 				OTHER_LDFLAGS = (
 					"-framework",
 					SafariServices,
@@ -882,7 +882,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1784636665;
+				CURRENT_PROJECT_VERSION = 1784961373;
 				DEVELOPMENT_TEAM = RQSR4UU3VB;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -899,7 +899,7 @@
 					"@executable_path/../../../../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 11.0;
-				MARKETING_VERSION = 1.5.0;
+				MARKETING_VERSION = 1.5.1;
 				OTHER_LDFLAGS = (
 					"-framework",
 					SafariServices,
@@ -922,7 +922,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1784636665;
+				CURRENT_PROJECT_VERSION = 1784961373;
 				DEVELOPMENT_TEAM = RQSR4UU3VB;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -939,7 +939,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 11.0;
-				MARKETING_VERSION = 1.5.0;
+				MARKETING_VERSION = 1.5.1;
 				OTHER_LDFLAGS = (
 					"-framework",
 					SafariServices,
@@ -965,7 +965,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1784636665;
+				CURRENT_PROJECT_VERSION = 1784961373;
 				DEVELOPMENT_TEAM = RQSR4UU3VB;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -982,7 +982,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 11.0;
-				MARKETING_VERSION = 1.5.0;
+				MARKETING_VERSION = 1.5.1;
 				OTHER_LDFLAGS = (
 					"-framework",
 					SafariServices,

--- a/apps/extension/store-assets/apple/WHATS-NEW.md
+++ b/apps/extension/store-assets/apple/WHATS-NEW.md
@@ -17,6 +17,24 @@ user's voice (what changed for them), not the developer changelog.
 
 ---
 
+## 1.5.1
+
+### Українська (uk)
+
+```
+Що нового у версії 1.5.1
+
+• Виправлено відкриття відео з результатів пошуку на YouTube. Раніше клік по відео у списку результатів міг обірватися — сторінка блимала, і відео не відкривалося; тепер воно відкривається як слід.
+```
+
+### English (en)
+
+```
+What's New in 1.5.1
+
+• Fixed opening videos from YouTube search results. Clicking a video in the results list could be interrupted — the page blinked and the video wouldn't open; now it opens as expected.
+```
+
 ## 1.5.0
 
 ### Українська (uk)


### PR DESCRIPTION
Patch release cutting **extension v1.5.1** from the single pending changeset.

## What ships

- **Fix video clicks being aborted on YouTube search results** (#285). Clicking a video on `/results` is a same-document Navigation-API push to `/watch`; the location-change event fires *before* the navigation commits, so Movar re-applied its `hl`/`gl` rewrite to the stale `/results` URL and `location.replace()`d — clobbering the click. Re-evaluation now waits for the navigation to commit.

## Release mechanics

- `@movar/extension` 1.5.0 → **1.5.1** (`changeset version`; CHANGELOG updated, changeset consumed)
- Safari `MARKETING_VERSION` → **1.5.1**, `CURRENT_PROJECT_VERSION` → **1784961373** (all 8 build configs)
- Apple `store-assets/apple/WHATS-NEW.md`: uk + en `## 1.5.1` block

## Verified locally (pre-push, Node 22)

- ✅ build · ✅ e2e-fast (20 passed) · ✅ metrics (fallow: no issues) · ✅ README parity · ✅ typecheck (19 projects)

## After merge

- Tag `extension-v1.5.1` on the release commit → Chrome/Firefox/Edge store jobs park on `production` approval.
- Safari submitted manually via Xcode Organizer (its CI job 401s on headless provisioning — leave parked).

🤖 Generated with [Claude Code](https://claude.com/claude-code)