### PR TITLE
fix(security): make verify-release.sh leak scan SIGPIPE-safe (here-strings)

### DIFF
--- a/docs/REFACTORING-QUEUE.md
+++ b/docs/REFACTORING-QUEUE.md
@@ -13,7 +13,7 @@ summary: Auto-generated agent task queue from fallow refactoring targets.
 - Source report: [.metrics/fallow.md](../.metrics/fallow.md)
 - Health score: **80 (B)**
 - Targets surfaced: **1** (parsed: 1)
-- Generated: 2026-07-25T15:05:00.346Z
+- Generated: 2026-07-25T16:51:55.300Z
 
 ## How to consume
 

--- a/scripts/verify-release.sh
+++ b/scripts/verify-release.sh
@@ -56,10 +56,18 @@ inspect_zip() {
   contents=$(unzip -l "$zip")
 
   local leaks=()
-  echo "$contents" | grep -qE '\.map$' && leaks+=("sourcemap (.map)")
-  echo "$contents" | grep -qE '(^|/)\.env(\.|$)' && leaks+=(".env file")
-  echo "$contents" | grep -q '\.DS_Store' && leaks+=(".DS_Store")
-  echo "$contents" | grep -q 'node_modules/' && leaks+=("node_modules/")
+  # Match against `$contents` with a here-string, NOT `echo "$contents" | grep`.
+  # Under `set -o pipefail`, `grep -q` closes the pipe the instant it matches,
+  # `echo` then dies of SIGPIPE (exit 141), and pipefail reports the whole
+  # pipeline as failed — so a leak that IS present gets silently dropped by
+  # the `&&` (leaks stays empty) instead of being recorded, and this gate
+  # wrongly reports the zip as clean. A here-string feeds grep without a
+  # pipe, so there is no upstream process to receive SIGPIPE. See
+  # scripts/pack-amo-source.sh for the same fix.
+  grep -qE '\.map$' <<<"$contents" && leaks+=("sourcemap (.map)")
+  grep -qE '(^|/)\.env(\.|$)' <<<"$contents" && leaks+=(".env file")
+  grep -q '\.DS_Store' <<<"$contents" && leaks+=(".DS_Store")
+  grep -q 'node_modules/' <<<"$contents" && leaks+=("node_modules/")
 
   if [ "${#leaks[@]}" -gt 0 ]; then
     for leak in "${leaks[@]}"; do


### PR DESCRIPTION
## Summary

`scripts/verify-release.sh` runs under `set -euo pipefail`. Its store-zip leak scan (lines ~58-70) fed `grep -q` through a pipe:

```bash
echo "$contents" | grep -qE '\.map$'      && leaks+=("sourcemap (.map)")
echo "$contents" | grep -qE '(^|/)\.env(\.|$)' && leaks+=(".env file")
echo "$contents" | grep -q '\.DS_Store'   && leaks+=(".DS_Store")
echo "$contents" | grep -q 'node_modules/' && leaks+=("node_modules/")
```

When a leak **is** present, `grep -q` matches and closes the pipe immediately. The still-writing `echo` then dies of **SIGPIPE (exit 141)**. Under `pipefail` the pipeline's exit status is non-zero, and because of the `&&`, that failure is silently swallowed — `leaks+=(...)` never runs. `leaks` stays empty, `inspect_zip` prints "clean", and the gate exits 0 while the leak ships.

The sibling `scripts/pack-amo-source.sh` (~lines 95-107) already documents and fixes this exact race with here-strings. This PR applies the same fix to `verify-release.sh`.

## Fix

Every `echo "$contents" | grep ...` in the leak scan is now `grep ... <<<"$contents"` — a here-string feeds `grep` without a pipe, so there is no upstream process left to receive SIGPIPE. Added a comment mirroring `pack-amo-source.sh`'s explanation. No change to what counts as a leak or to control flow.

```diff
   local leaks=()
-  echo "$contents" | grep -qE '\.map$' && leaks+=("sourcemap (.map)")
-  echo "$contents" | grep -qE '(^|/)\.env(\.|$)' && leaks+=(".env file")
-  echo "$contents" | grep -q '\.DS_Store' && leaks+=(".DS_Store")
-  echo "$contents" | grep -q 'node_modules/' && leaks+=("node_modules/")
+  # Match against `$contents` with a here-string, NOT `echo "$contents" | grep`.
+  # Under `set -o pipefail`, `grep -q` closes the pipe the instant it matches,
+  # `echo` then dies of SIGPIPE (exit 141), and pipefail reports the whole
+  # pipeline as failed — so a leak that IS present gets silently dropped by
+  # the `&&` (leaks stays empty) instead of being recorded, and this gate
+  # wrongly reports the zip as clean. A here-string feeds grep without a
+  # pipe, so there is no upstream process to receive SIGPIPE. See
+  # scripts/pack-amo-source.sh for the same fix.
+  grep -qE '\.map$' <<<"$contents" && leaks+=("sourcemap (.map)")
+  grep -qE '(^|/)\.env(\.|$)' <<<"$contents" && leaks+=(".env file")
+  grep -q '\.DS_Store' <<<"$contents" && leaks+=(".DS_Store")
+  grep -q 'node_modules/' <<<"$contents" && leaks+=("node_modules/")
```

I audited the rest of the file (every `|` in it) for the same fail-unsafe shape (`piped-into-early-exiting-reader && action`, under `pipefail`, silently skipping the `&&` action). No other instance exists:
- The two `ls -t *.zip | head -n1` assignments (lines 40/46) are bare statements, not `&&`-gated — a SIGPIPE there would trip `set -e` and abort loudly, the opposite (fail-safe) failure mode, and in practice the `ls` output for a handful of zip filenames is far below any pipe buffer size, so the race can't fire.
- `find | sort -z | xargs -0 shasum`, `jq ... | sort`, `awk ... | sort` all pipe into commands that consume their entire input before producing output — no early-exit reader, so no SIGPIPE hazard.
- `pack-amo-source.sh` and the rest of `scripts/` were also grepped; no other occurrence of `echo ... | grep -q ... &&` anywhere in the repo.

`docs/REFACTORING-QUEUE.md` changed too — that's the standard `pnpm metrics` regen byproduct (timestamp only, then `prettier --write`'d per the project's metrics-gate workflow), not a manual edit.

## Security impact

High. This gate is the last automated check before a `pnpm verify:release` artifact is uploaded to the Chrome Web Store / AMO / Edge. The bug made the *worst* leaks (a `node_modules/` dump, which itself inflates the `unzip -l` listing well past the SIGPIPE race threshold) the *most* reliably silently-passed, per the original report. With this fix, a real leak now reliably fails the gate as intended.

## Manual proof (before/after)

Built a large synthetic `contents` string (~40,000 lines, ~2 MB) mimicking `unzip -l` output, with a `node_modules/...` entry (and separately a nested `.env` entry) placed near the top so `grep -q` matches almost immediately while the writer still has ~2 MB left to write — reproducing the race deterministically on this machine (macOS/zsh, bash 3.2 `/bin/bash`).

```
### node_modules/ case
--- OLD form: printf '%s' "$big" | grep -q 'node_modules/' && echo LEAK ---
trial 1: pipeline exit=141  output=<nothing printed>
trial 2: pipeline exit=141  output=<nothing printed>
trial 3: pipeline exit=141  output=<nothing printed>
trial 4: pipeline exit=141  output=<nothing printed>
trial 5: pipeline exit=141  output=<nothing printed>

--- NEW form: grep -q 'node_modules/' <<<"$big" && echo LEAK ---
trial 1: exit=0  output=LEAK
trial 2: exit=0  output=LEAK
trial 3: exit=0  output=LEAK
trial 4: exit=0  output=LEAK
trial 5: exit=0  output=LEAK

### .env case (real script pattern: (^|/)\.env(\.|$) )
--- OLD form: printf '%s' "$big" | grep -qE '(^|/)\.env(\.|$)' && echo LEAK ---
trial 1-5: pipeline exit=141  output=<nothing printed>   (same for all 5 trials)

--- NEW form: grep -qE '(^|/)\.env(\.|$)' <<<"$big" && echo LEAK ---
trial 1-5: exit=0  output=LEAK   (same for all 5 trials)

### Exact leaks+=() idiom used in the real script, under `set -e`
OLD idiom: script did NOT abort; leaks has 0 entries: <empty -- LEAK MISSED>
NEW idiom: leaks has 1 entries: node_modules/
```

The OLD form missed the leak 5/5 trials (pipeline exit 141, SIGPIPE); the NEW form caught it 5/5 trials (exit 0). The last block reproduces the exact `leaks+=()` idiom from the script: under `set -e`, the buggy `&&` form does not crash the script (the `A && B` idiom exempts `A` from `-e`) — it just silently leaves `leaks` empty.

## Verification

- `bash -n scripts/verify-release.sh` — syntax OK.
- No `shellcheck`/`shfmt` configured in this repo (checked `lefthook.yml`, `package.json`, and repo-wide) — skipped.
- `pnpm lint` — pass (19/19 projects).
- `pnpm exec prettier --check .` — pass.
- `pnpm metrics` — pass; regenerated `docs/REFACTORING-QUEUE.md` (timestamp only, `readme-metrics.snapshot.json` unchanged — no coverage delta to reconcile).
- `pnpm metrics:audit` (`fallow audit --base origin/main`) — pass, no issues in the 2 changed files.
- No changeset: this only touches a release-gate script, not a shipped package — mirrors how PR #325 (closing #309, also a `scripts/*.sh` fix) shipped without one.

Closes #307
