### PR TITLE
fix(native-settings): advance seenRev only after the sync write during Safari adoption

### DIFF
--- a/.changeset/native-settings-seenrev-after-sync.md
+++ b/.changeset/native-settings-seenrev-after-sync.md
@@ -1,0 +1,5 @@
+---
+'@movar/extension': patch
+---
+
+native-settings (Safari): advance `seenRev` only after the `storage.sync` write succeeds during host-app settings adoption, so a rejected sync write (quota, rate-limit, transient iCloud unavailability) no longer silently drops the host app's change — the reconcile now catches the failure, leaves `seenRev` behind, and re-adopts on the next wake. Closes #315.

--- a/apps/extension/src/lib/native-settings.test.ts
+++ b/apps/extension/src/lib/native-settings.test.ts
@@ -114,6 +114,69 @@ describe('reconcileNativeSettings', () => {
     await expect(reconcileNativeSettings()).resolves.toBeUndefined();
     expect(await seenRev()).toBeUndefined();
   });
+
+  it('re-adopts on the next reconcile when the sync write rejected (no silent drop, #315)', async () => {
+    mockNative((msg) =>
+      msg.type === 'getSettings'
+        ? { rev: 5, settings: { ...defaultSettings, enabled: false } }
+        : { ok: true, rev: 6 },
+    );
+    const setSpy = vi
+      .spyOn(fakeBrowser.storage.sync, 'set')
+      .mockRejectedValueOnce(new Error('QUOTA_BYTES_PER_ITEM'));
+
+    // The sync write rejects mid-adoption. The rejection must be swallowed (not
+    // surface as an unhandled rejection) and — the crux of #315 — `seenRev` must
+    // NOT advance, or the change is dropped forever.
+    await expect(reconcileNativeSettings()).resolves.toBeUndefined();
+    expect(setSpy).toHaveBeenCalledTimes(1);
+    expect(await seenRev()).toBeUndefined();
+    expect(await storedSync()).toBeUndefined();
+
+    // Next reconcile: nativeRev (5) still outranks seenRev, so adoption retries —
+    // this time the write lands and the host app's change is finally adopted.
+    setSpy.mockRestore();
+    await reconcileNativeSettings();
+    expect((await storedSync()).enabled).toBe(false);
+    expect(await seenRev()).toBe(5);
+  });
+
+  it('does not re-adopt after its own push-back advances the rev, even if the push-back lands first (loop-safe)', async () => {
+    // A stateful App Group: getSettings returns the current blob+rev; a
+    // setSettings FROM the extension (the push-back) assigns the next rev —
+    // exactly the native side's contract.
+    const store = { rev: 5, settings: { ...defaultSettings, enabled: false } as unknown };
+    const native = mockNative((msg) => {
+      if (msg.type === 'getSettings') return { rev: store.rev, settings: store.settings };
+      store.rev += 1;
+      store.settings = msg.settings;
+      return { ok: true, rev: store.rev };
+    });
+
+    // Force the worst-case interleave: the push-back (background.ts
+    // onSettingsChange → pushSettingsToNative) completes — recording the higher
+    // rev — BEFORE the adopting reconcile records its own. Only a monotonic
+    // seenRev keeps this from regressing into a re-adopt loop.
+    const realSet = fakeBrowser.storage.sync.set.bind(fakeBrowser.storage.sync);
+    const setSpy = vi.spyOn(fakeBrowser.storage.sync, 'set').mockImplementation(async (items) => {
+      await realSet(items);
+      await pushSettingsToNative();
+    });
+
+    await reconcileNativeSettings(); // adopts rev 5; the racing push-back records rev 6
+
+    // seenRev held at 6 (never regressed to 5) and the App Group advanced once.
+    expect(await seenRev()).toBe(6);
+    expect(store.rev).toBe(6);
+
+    setSpy.mockRestore();
+    native.mockClear();
+    await reconcileNativeSettings(); // rev 6 == seenRev 6 → nothing to adopt, no push-back
+    expect(native).toHaveBeenCalledTimes(1);
+    expect(native).toHaveBeenCalledWith(expect.anything(), { type: 'getSettings' });
+    expect(await seenRev()).toBe(6);
+    expect(store.rev).toBe(6);
+  });
 });
 
 describe('pushSettingsToNative', () => {

--- a/apps/extension/src/lib/native-settings.ts
+++ b/apps/extension/src/lib/native-settings.ts
@@ -61,6 +61,14 @@ async function readSeenRev(): Promise<number> {
 }
 
 async function writeSeenRev(rev: number): Promise<void> {
+  // Monotonic — the seen rev must never regress. Adopting a host-app change
+  // writes storage.sync, which fires onSettingsChange → pushSettingsToNative
+  // (background.ts); that push-back's native round-trip can record a HIGHER rev
+  // before the adopting reconcile records its own. Clamping here keeps the
+  // advance and stops the next reconcile from re-adopting in a loop — the guard
+  // the pre-#315 write-order gave implicitly by recording the rev before the
+  // sync write.
+  if (rev <= (await readSeenRev())) return;
   await browser.storage.local.set({ [NATIVE_REV_KEY]: rev });
 }
 
@@ -78,14 +86,36 @@ export async function pushSettingsToNative(): Promise<void> {
 }
 
 /**
+ * Fold one host-app blob into `storage.sync`, then record its rev.
+ *
+ * Order matters: the rev advances ONLY after the sync write resolves. A
+ * `storage.sync.set` on Safari can reject (QUOTA_BYTES_PER_ITEM, the sync
+ * write-rate limit, or transient iCloud unavailability); recording the rev
+ * first would strand `seenRev` ahead of a write that never landed, so every
+ * later reconcile would treat the change as already adopted and silently drop
+ * it (#315). On rejection we swallow and return with `seenRev` untouched, so
+ * the next reconcile re-adopts.
+ *
+ * The adopted write fires `onSettingsChange` → `pushSettingsToNative`
+ * (background.ts), which lands a rev above this one; `writeSeenRev` is monotonic
+ * so recording `rev` here can't clobber that push-back into a re-adopt loop.
+ */
+async function adoptNativeSettings(settings: unknown, rev: number): Promise<void> {
+  try {
+    await setSettings(enforceLockedLanguages(migrateSettings(settings)));
+  } catch {
+    // storage.sync unavailable / over quota — leave `seenRev` behind and retry
+    // on the next reconcile rather than dropping the host app's change (#315).
+    return;
+  }
+  await writeSeenRev(rev);
+}
+
+/**
  * Reconcile the App Group with `storage.sync`:
  *   - app wrote a newer blob (rev advanced)  → adopt it into storage.sync
  *   - App Group is empty (first run)          → seed it from current settings
  *   - otherwise (we're current or ahead)      → nothing to do
- *
- * Adoption records the new rev BEFORE writing storage.sync, so the resulting
- * `onSettingsChange` → `pushSettingsToNative` lands a rev above it rather than
- * re-adopting in a loop.
  */
 export async function reconcileNativeSettings(): Promise<void> {
   const native = await sendNative<NativeGetResult>({ type: 'getSettings' });
@@ -95,8 +125,7 @@ export async function reconcileNativeSettings(): Promise<void> {
   const seenRev = await readSeenRev();
 
   if (native.settings != null && nativeRev > seenRev) {
-    await writeSeenRev(nativeRev);
-    await setSettings(enforceLockedLanguages(migrateSettings(native.settings)));
+    await adoptNativeSettings(native.settings, nativeRev);
     return;
   }
 

--- a/docs/REFACTORING-QUEUE.md
+++ b/docs/REFACTORING-QUEUE.md
@@ -13,7 +13,7 @@ summary: Auto-generated agent task queue from fallow refactoring targets.
 - Source report: [.metrics/fallow.md](../.metrics/fallow.md)
 - Health score: **80 (B)**
 - Targets surfaced: **1** (parsed: 1)
-- Generated: 2026-07-25T16:51:55.300Z
+- Generated: 2026-07-25T17:14:13.916Z
 
 ## How to consume
 

--- a/docs/REFACTORING-QUEUE.md
+++ b/docs/REFACTORING-QUEUE.md
@@ -13,7 +13,7 @@ summary: Auto-generated agent task queue from fallow refactoring targets.
 - Source report: [.metrics/fallow.md](../.metrics/fallow.md)
 - Health score: **80 (B)**
 - Targets surfaced: **1** (parsed: 1)
-- Generated: 2026-07-25T15:05:00.346Z
+- Generated: 2026-07-25T17:02:25.376Z
 
 ## How to consume
 

--- a/scripts/readme-metrics.snapshot.json
+++ b/scripts/readme-metrics.snapshot.json
@@ -4,7 +4,7 @@
     "score": 80,
     "grade": "B"
   },
-  "loc": 42708,
+  "loc": 42737,
   "suppressions": {
     "eslint": 43,
     "fallow": 25


### PR DESCRIPTION
## Summary

Fixes a Safari-only bug where a host-app settings change could be **silently dropped** during adoption.

`reconcileNativeSettings` (`apps/extension/src/lib/native-settings.ts`) committed `seenRev` **before** the `storage.sync` write when adopting the host app's blob:

```js
await writeSeenRev(nativeRev);                 // storage.local — committed first
await setSettings(migrate(native.settings));   // storage.sync — can reject
```

On Safari that `storage.sync.set` can reject (`QUOTA_BYTES_PER_ITEM`, the sync write-rate limit, or transient iCloud unavailability). Because `seenRev` had already advanced — and the reconcile callers are bare `void (async …)()` — the rejection surfaced as an *unhandled* rejection while every later reconcile saw `nativeRev > seenRev` as false. The change was never re-adopted: no retry, no surfaced error, and it was **permanently** lost once the extension pushed its own settings first.

## Fix

Adoption now runs through a small `adoptNativeSettings` helper that writes `storage.sync` **first**, inside a `try/catch`:

- **on rejection** — swallow (matching the module/codebase bare-`catch` idiom; `no-console` is `error` in `src/lib`) and return with `seenRev` **untouched**, so the next reconcile re-adopts instead of dropping the change;
- **on success** — record the rev.

## Loop-safety justification

The old write-first order existed to stop an adopt → push-back loop: the adopting `storage.sync` write fires `onSettingsChange → pushSettingsToNative` (background.ts), which round-trips to native and records a **higher** rev as `seenRev`. Simply swapping the awaits would let reconcile's later `writeSeenRev(nativeRev)` regress `seenRev` below that push-back's rev, and the next reconcile would re-adopt — a loop.

Rather than re-introduce that hazard, `writeSeenRev` is now **monotonic** (it never lowers the stored rev). This preserves the exact same steady state the old ordering produced (`seenRev == nativeRev+1` after a push-back) but makes it **independent of write ordering** instead of relying on it — the module's whole conflict model is "last writer wins by rev", so guarding the rev's monotonicity is the natural place for it. The post-adoption push-back still bumps the native rev exactly once, as before; it just can no longer be clobbered into a re-adopt loop. `background.ts` is **unchanged**.

## Test plan

`apps/extension/src/lib/native-settings.test.ts` — added:

1. **Reject → retry (#315):** `storage.sync.set` rejects mid-adoption → the promise still resolves (no unhandled rejection), `seenRev` stays un-advanced, `storage.sync` is not written; the next reconcile re-adopts and *then* advances `seenRev`. Confirmed this test **fails against pre-fix code** (`promise rejected "Error: QUOTA_BYTES_PER_ITEM" instead of resolving`).
2. **Loop-safety (worst-case interleave):** forces the push-back to record the higher rev *before* the adopting reconcile records its own; asserts `seenRev` holds at the higher rev (never regresses) and a subsequent reconcile does **not** re-adopt. This test fails against a naive await-swap without the monotonic guard.

All existing `native-settings` tests still pass.

Local verification (all green): `pnpm test` (1295 extension tests), `pnpm lint`, `pnpm exec prettier --check .`, `pnpm metrics`, `pnpm metrics:audit` ("No issues in 5 changed files"). Lefthook pre-commit (eslint/prettier/readme-parity/suppressions/test/typecheck/commitlint) and pre-push (build/e2e-fast/metrics) both passed.

Closes #315.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
