### PR TITLE
fix(scripts): skip a missing optional zip in build-artifacts.sh instead of aborting

### DIFF
--- a/docs/REFACTORING-QUEUE.md
+++ b/docs/REFACTORING-QUEUE.md
@@ -13,7 +13,7 @@ summary: Auto-generated agent task queue from fallow refactoring targets.
 - Source report: [.metrics/fallow.md](../.metrics/fallow.md)
 - Health score: **80 (B)**
 - Targets surfaced: **1** (parsed: 1)
-- Generated: 2026-07-25T16:51:55.300Z
+- Generated: 2026-07-25T17:43:19.965Z
 
 ## How to consume
 

--- a/docs/REFACTORING-QUEUE.md
+++ b/docs/REFACTORING-QUEUE.md
@@ -13,7 +13,7 @@ summary: Auto-generated agent task queue from fallow refactoring targets.
 - Source report: [.metrics/fallow.md](../.metrics/fallow.md)
 - Health score: **80 (B)**
 - Targets surfaced: **1** (parsed: 1)
-- Generated: 2026-07-25T17:14:13.916Z
+- Generated: 2026-07-25T17:57:08.770Z
 
 ## How to consume
 

--- a/scripts/build-artifacts.sh
+++ b/scripts/build-artifacts.sh
@@ -43,7 +43,12 @@ step "Collecting versioned artifacts into the repo root"
 # `$2 = optional` downgrades a missing zip from a hard failure to a skip.
 collect() {
   local kind="$1" req="${2:-required}" src dest
-  src="$(ls -t "$out"/*-"$kind".zip 2>/dev/null | head -n1)"
+  # `local kind=... src dest` (declared separately, above) means the
+  # assignment below is a plain statement, so under `set -o pipefail` a
+  # no-match glob's `ls` failure propagates through `head` and trips
+  # `set -e` before the `[ -z "$src" ]` optional-skip check ever runs.
+  # `|| true` absorbs that so a missing zip can be detected and handled.
+  src="$(ls -t "$out"/*-"$kind".zip 2>/dev/null | head -n1 || true)"
   if [ -z "$src" ]; then
     [ "$req" = optional ] && {
       printf '    (no %s zip — skipped)\n' "$kind"


### PR DESCRIPTION
## Summary

`scripts/build-artifacts.sh` runs under `set -euo pipefail`. Its `collect()` helper (used by `collect sources optional` at line 61) did:

```bash
local kind="$1" req="${2:-required}" src dest
src="$(ls -t "$out"/*-"$kind".zip 2>/dev/null | head -n1)"
```

Because `local` is declared separately from the assignment, the bare `src="$(...)"` statement inherits the pipeline's exit status. When the glob matches nothing, `ls` exits non-zero, `pipefail` propagates that through `head -n1`, and `set -e` aborts the entire script — before the `[ -z "$src" ]` optional-skip check on the next line ever runs. This makes the "optional" sources-zip collection dead for exactly the missing-file case it exists to tolerate, and the macOS `.dmg` step never runs afterward.

## Fix

```diff
   local kind="$1" req="${2:-required}" src dest
-  src="$(ls -t "$out"/*-"$kind".zip 2>/dev/null | head -n1)"
+  # `local kind=... src dest` (declared separately, above) means the
+  # assignment below is a plain statement, so under `set -o pipefail` a
+  # no-match glob's `ls` failure propagates through `head` and trips
+  # `set -e` before the `[ -z "$src" ]` optional-skip check ever runs.
+  # `|| true` absorbs that so a missing zip can be detected and handled.
+  src="$(ls -t "$out"/*-"$kind".zip 2>/dev/null | head -n1 || true)"
```

`|| true` absorbs the pipeline failure so `set -e` doesn't trip, letting the existing `[ -z "$src" ]` branch do its job: skip when `optional`, still fail loudly via `fail()` when required. This is a single fix point — all four `collect` call sites (`chrome`, `firefox`, `safari`, `sources optional`) go through the same function.

I scanned the rest of the script for the same shape: the only other conditional path is `if command -v xcodebuild >/dev/null 2>&1; then ... else ... fi`, which is already `set -e`-safe (commands in an `if` condition are exempt). No other instance found in this file.

Note: `scripts/verify-release.sh:40,46` has the same pipefail-fragile assignment shape (`chrome_zip=$(ls -t ... | head -n1)`), but on *required* paths — a missing zip there still fails either way, it just loses the friendly `fail()` message. Left untouched as out of scope for this issue (different file, different symptom).

## Verification

- `bash -n scripts/build-artifacts.sh` — syntax OK.
- No `shellcheck`/`shfmt` configured in this repo (checked `lefthook.yml`, `package.json`, repo-wide) — skipped.
- Manual proof: extracted the real `collect()` function verbatim from the file and drove it with `set -euo pipefail` against an empty `.output` dir:
  - optional + missing (`sources`) → prints the skip message and the script continues (previously: silent abort).
  - required + present (`chrome`) → collected normally.
  - required + missing (`firefox`) → still fails, now via the intended `fail()` message instead of a bare abort.
- `pnpm lint` — pass (19/19 projects).
- `pnpm exec prettier --check .` — pass.
- `pnpm metrics` — regenerated `docs/REFACTORING-QUEUE.md` (timestamp only, then `prettier --write`'d per the project's metrics-gate workflow).
- `pnpm metrics:audit` (`fallow audit --base origin/main`) — pass, no issues in the 2 changed files.
- No changeset: this only touches a build/release script, not the shipped package — mirrors PR #325 and PR #329.

Closes #308
