### PR TITLE
fix(extension): detach a survivor tooltip when its link is later hidden

### DIFF
--- a/.changeset/tooltip-survivor-leak.md
+++ b/.changeset/tooltip-survivor-leak.md
@@ -1,0 +1,5 @@
+---
+'@movar/extension': patch
+---
+
+tooltip: detach a surviving link's tooltip (host + registry entry) when the link later becomes hidden or is SPA-replaced, instead of skipping it — fixing a bounded per-session detached-DOM / registry leak that accumulated on dynamic picker sites until the feature was turned off. Closes #303.

--- a/apps/extension/src/lib/picker-filter.ts
+++ b/apps/extension/src/lib/picker-filter.ts
@@ -334,6 +334,20 @@ function restorePickerInPlace(picker: Picker): void {
 }
 /* eslint-enable sonarjs/cognitive-complexity -- re-enable after restorePickerInPlace */
 
+/** Detach `link`'s previously-attached survivor tooltip, if any — removing
+ *  both its host (appended to `document.body`, outside the picker subtree)
+ *  and its entry in tooltip.ts's `tooltipRegistry` — and drop it from
+ *  `anchorTooltips`. Idempotent: a no-op when the link never had one. Must
+ *  run for every link leaving tooltip-eligibility, not just re-annotated
+ *  survivors — otherwise the host/registry entry orphans permanently
+ *  (movar#303). */
+function detachSurvivorTooltip(link: ClassifiedLink): void {
+  const existing = anchorTooltips.get(link.el);
+  if (!existing) return;
+  existing.detach();
+  anchorTooltips.delete(link.el);
+}
+
 /**
  * Attach a styled tooltip to every surviving classified link in this
  * picker. Carries a short title, body listing the hidden languages by
@@ -342,9 +356,12 @@ function restorePickerInPlace(picker: Picker): void {
  * container — without touching curtains or other pickers).
  *
  * Idempotent across MutationObserver re-fires: each anchor's previous
- * tooltip handle is tracked in `anchorTooltips` and detached before a
- * new tooltip is attached, so the body stays in sync if the hidden-
- * language list changed since the last call.
+ * tooltip handle is tracked in `anchorTooltips` and always detached first
+ * (via {@link detachSurvivorTooltip}), so the body stays in sync if the
+ * hidden-language list changed since the last call. That detach runs even
+ * for links this pass then skips — now HIDDEN_ATTR, or no visible
+ * presenter — so a link that stops being a tooltip candidate never leaves
+ * its old host/registry entry behind.
  */
 function annotateSurvivingLinks(
   picker: Picker,
@@ -354,16 +371,9 @@ function annotateSurvivingLinks(
   if (hiddenLanguages.length === 0) return;
 
   for (const link of picker.links) {
+    detachSurvivorTooltip(link);
     if (link.el.hasAttribute(HIDDEN_ATTR)) continue;
-    // Always detach + re-attach so the body text reflects the current
-    // hidden-language list. Cheap: detach removes a few listeners and
-    // one DOM node.
-    const existing = anchorTooltips.get(link.el);
-    if (existing) existing.detach();
-    if (presenter?.hasVisiblePresentation !== true) {
-      anchorTooltips.delete(link.el);
-      continue;
-    }
+    if (presenter?.hasVisiblePresentation !== true) continue;
     const handle = presenter.attachPickerSurvivorTooltip({
       anchor: link.el,
       hiddenLanguages,

--- a/apps/extension/src/lib/picker.filter.test.ts
+++ b/apps/extension/src/lib/picker.filter.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import { findLanguagePickers } from '@movar/lang-pickers/extract';
 import { filterPickers as filterPickersWithPresenter } from './picker-filter';
 import { testContentPresenter } from './dom-test-helpers';
+import { detachAllTooltips } from './tooltip';
 import {
   setBody,
   setup001ComUaPicker,
@@ -862,11 +863,16 @@ describe('filterPickers — divider element edge cases', () => {
 });
 
 describe('filterPickers — survivor tooltip re-fire', () => {
-  // annotateSurvivingLinks detaches a previously-attached tooltip before
-  // re-attaching, so a MutationObserver re-fire that hides a SECOND language
-  // refreshes the body text on a link that survives BOTH passes rather than
-  // stacking a duplicate. Exercises the `if (existing) existing.detach()`
-  // branch on the re-annotated survivor (UA here).
+  // annotateSurvivingLinks always detaches a link's previously-attached
+  // tooltip first (detachSurvivorTooltip), before deciding what to do next.
+  // Two outcomes exercise that:
+  //  - a link that survives BOTH passes gets its body refreshed instead of
+  //    stacking a duplicate (UA here);
+  //  - a link that WAS a survivor but is hidden by the second pass has its
+  //    stale tooltip detached rather than orphaned — host removed from
+  //    `document.body`, entry dropped from tooltip.ts's registry (DE here;
+  //    regression coverage for movar#303, which used to `continue` on a
+  //    HIDDEN_ATTR link before reaching the detach).
 
   it('refreshes a surviving link tooltip body when the hidden set grows', () => {
     setBody(`
@@ -880,16 +886,41 @@ describe('filterPickers — survivor tooltip re-fire', () => {
     filterPickers(findLanguagePickers(), ['uk', 'de'], { blocked: ['ru'] });
 
     // Second pass also blocks DE. UA survives again: its existing tooltip is
-    // detached and re-attached with the refreshed hidden list (ru + de).
+    // detached and re-attached with the refreshed hidden list (ru + de). DE
+    // stops surviving and its pass-1 tooltip is detached along with it —
+    // not left behind (movar#303) — so exactly one host remains.
     filterPickers(findLanguagePickers(), ['uk'], { blocked: ['ru', 'de'] });
 
-    // Exactly one tooltip body now lists BOTH hidden languages — UA's,
-    // re-annotated. (DE's pass-1 tooltip lingers with only "русск" since it
-    // is no longer a survivor, so we look for the refreshed one specifically.)
-    const refreshed = getTooltipHosts()
-      .map((h) => (h.shadowRoot!.querySelector('.body')?.textContent ?? '').toLowerCase())
-      .filter((b) => b.includes('русск') && b.includes('deutsch'));
-    expect(refreshed).toHaveLength(1);
+    expect(getTooltipHosts()).toHaveLength(1);
+    const bodyText =
+      getTooltipHosts()[0]!.shadowRoot!.querySelector('.body')?.textContent.toLowerCase() ?? '';
+    expect(bodyText).toContain('русск');
+    expect(bodyText).toContain('deutsch');
+  });
+
+  it('detaches a survivor tooltip (host + registry entry) when the link is later hidden', () => {
+    // movar#303: annotateSurvivingLinks's `if (link.el.hasAttribute(HIDDEN_ATTR))
+    // continue;` used to run BEFORE the detach-existing branch, so a link
+    // that had a survivor tooltip attached and later became HIDDEN_ATTR (a
+    // subsequent pass hides it, or an SPA replaces it with a fresh node
+    // carrying the marker) kept its old tooltip forever: the host — appended
+    // to document.body, outside the picker subtree — was never removed, and
+    // its AttachState stayed in tooltip.ts's registry.
+    setupTwoLanguagePicker();
+    filterPickers(findLanguagePickers(), ['uk'], { blocked: ['ru'] });
+    // UA survives (RU is hidden) and gets a survivor tooltip.
+    expect(getTooltipHosts()).toHaveLength(1);
+
+    // UA becomes ineligible after its tooltip was attached. Re-running the
+    // very same filter pass must not leave UA's now-stale tooltip behind.
+    document.querySelector<HTMLAnchorElement>('#ua')!.setAttribute('data-movar-hidden', '');
+    filterPickers(findLanguagePickers(), ['uk'], { blocked: ['ru'] });
+
+    // No orphaned host anywhere in the document...
+    expect(getTooltipHosts()).toHaveLength(0);
+    // ...and nothing left in the registry for the page-wide sweep to find.
+    detachAllTooltips();
+    expect(getTooltipHosts()).toHaveLength(0);
   });
 });
 

--- a/docs/REFACTORING-QUEUE.md
+++ b/docs/REFACTORING-QUEUE.md
@@ -13,7 +13,7 @@ summary: Auto-generated agent task queue from fallow refactoring targets.
 - Source report: [.metrics/fallow.md](../.metrics/fallow.md)
 - Health score: **80 (B)**
 - Targets surfaced: **1** (parsed: 1)
-- Generated: 2026-07-25T17:14:13.916Z
+- Generated: 2026-07-25T17:39:46.282Z
 
 ## How to consume
 

--- a/docs/REFACTORING-QUEUE.md
+++ b/docs/REFACTORING-QUEUE.md
@@ -13,7 +13,7 @@ summary: Auto-generated agent task queue from fallow refactoring targets.
 - Source report: [.metrics/fallow.md](../.metrics/fallow.md)
 - Health score: **80 (B)**
 - Targets surfaced: **1** (parsed: 1)
-- Generated: 2026-07-25T17:57:08.770Z
+- Generated: 2026-07-25T18:24:22.057Z
 
 ## How to consume
 

--- a/docs/REFACTORING-QUEUE.md
+++ b/docs/REFACTORING-QUEUE.md
@@ -13,7 +13,7 @@ summary: Auto-generated agent task queue from fallow refactoring targets.
 - Source report: [.metrics/fallow.md](../.metrics/fallow.md)
 - Health score: **80 (B)**
 - Targets surfaced: **1** (parsed: 1)
-- Generated: 2026-07-25T17:39:46.282Z
+- Generated: 2026-07-25T18:06:46.786Z
 
 ## How to consume
 

--- a/scripts/readme-metrics.snapshot.json
+++ b/scripts/readme-metrics.snapshot.json
@@ -4,7 +4,7 @@
     "score": 80,
     "grade": "B"
   },
-  "loc": 42737,
+  "loc": 42718,
   "suppressions": {
     "eslint": 43,
     "fallow": 25

--- a/scripts/readme-metrics.snapshot.json
+++ b/scripts/readme-metrics.snapshot.json
@@ -4,7 +4,7 @@
     "score": 80,
     "grade": "B"
   },
-  "loc": 42718,
+  "loc": 42747,
   "suppressions": {
     "eslint": 43,
     "fallow": 25


### PR DESCRIPTION
## Summary

- `annotateSurvivingLinks` (`apps/extension/src/lib/picker-filter.ts`) skipped its detach-existing branch for a link that had become `HIDDEN_ATTR` since its survivor tooltip was attached — the `continue` ran before the detach. The tooltip host (appended to `document.body`, outside the picker subtree) was never removed, and its `AttachState` stayed in `tooltip.ts`'s strong `tooltipRegistry`, pinning the detached anchor.
- Net effect: a bounded per-session detached-DOM / registry leak that accumulates on dynamic (SPA) picker sites where links get hidden or replaced across ticks, until the feature is turned off or "Show everything" is used.
- Fix: extracted `detachSurvivorTooltip(link)` and run it unconditionally at the top of `annotateSurvivingLinks`'s loop, before the `HIDDEN_ATTR` / presenter-visibility checks that decide whether to skip re-attaching. Matches the existing detach idiom already used in `restorePickerInPlace`.

## Files changed

- `apps/extension/src/lib/picker-filter.ts` — the fix (extract + reorder detach-before-skip).
- `apps/extension/src/lib/picker.filter.test.ts` — new regression test, plus strengthened the neighboring "survivor tooltip re-fire" test (its comment previously documented the leak as expected: "DE's pass-1 tooltip lingers...").
- `.changeset/tooltip-survivor-leak.md` — patch changeset for `@movar/extension`.
- `docs/REFACTORING-QUEUE.md`, `scripts/readme-metrics.snapshot.json` — `pnpm metrics` regen.

## Test plan

- [x] Added `filterPickers — survivor tooltip re-fire > detaches a survivor tooltip (host + registry entry) when the link is later hidden`: attaches a survivor tooltip, marks the link `HIDDEN_ATTR`, re-runs the filter pass, and asserts the tooltip host is gone from the DOM and a subsequent `detachAllTooltips()` finds nothing left.
- [x] Confirmed the new test (and the strengthened neighboring test) **fail against pre-fix code** — verified locally by temporarily reverting the source fix and re-running: both failed with an orphaned host still present (`toHaveLength(0)` got `1`; `toHaveLength(1)` got `2`), then passed again once the fix was restored.
- [x] `pnpm test` — 17/17 projects pass (extension: 82 files / 1294 tests).
- [x] `pnpm lint` — 19/19 projects clean.
- [x] `pnpm exec prettier --check .` — clean.
- [x] `pnpm metrics` + prettier — clean; coverage for the touched file is 93.27% stmts / 100% functions, with the only uncovered lines being pre-existing, unrelated edge cases.
- [x] `pnpm metrics:audit` (fallow) — "No issues in 5 changed files."
- [x] Local `pre-commit` and `pre-push` hooks (build, e2e-fast 20/20, metrics audit) all passed.

Note: one unrelated `App.test.tsx` (options allowlist) test failed once during an early `pnpm test:coverage` run under heavy parallel load; Nx's own flaky-task detector flagged and auto-retried it, and it passed cleanly on every other run (isolated, full-suite, and via the exact nx-orchestrated invocation) both with and without this change — pre-existing flakiness, unrelated to this diff.

Closes #303