### PR TITLE
fix(lang-pickers): stop blocked language leaking through regional-variant picker links

### DIFF
--- a/.changeset/lang-pickers-blocked-variant-leak.md
+++ b/.changeset/lang-pickers-blocked-variant-leak.md
@@ -1,0 +1,5 @@
+---
+'@movar/extension': patch
+---
+
+lang-pickers: treat regional variants of a blocked language as blocked (e.g. `pt-BR` when `pt` is blocked), so a blocked language no longer leaks through a picker's regional-variant links. Closes #293.

--- a/apps/extension/src/lib/picker-filter.ts
+++ b/apps/extension/src/lib/picker-filter.ts
@@ -286,8 +286,12 @@ export function restoreOriginalDisplay(el: HTMLElement): void {
 /* eslint-disable sonarjs/cognitive-complexity -- inverse of the four-pass filter pipeline; splitting forces four coupled exports */
 // fallow-ignore-next-line complexity
 function restorePickerInPlace(picker: Picker): void {
-  // Un-hide classified links.
-  for (const link of picker.links) {
+  // Un-hide classified links. Iterates the full pre-dedup set (falling back
+  // to `links` when a caller never populated it) so a regional-variant
+  // duplicate that filterPickerLinks hid via `allLinks` — and which may not
+  // be a direct child of the container — is also restored, not just the
+  // deduped display entries.
+  for (const link of picker.allLinks ?? picker.links) {
     if (!link.el.hasAttribute(HIDDEN_ATTR)) continue;
     link.el.removeAttribute(HIDDEN_ATTR);
     restoreOriginalDisplay(link.el);
@@ -446,23 +450,29 @@ function attachPickerContainerCurtain(
  * whole container is replaced by a chip overlay marking which language
  * the user's preference collapsed to (or sigil-only when zero remain).
  */
-/** Hide blocked links in a single picker; return the surviving (visible) entries. */
+/** Hide blocked links in a single picker; return the surviving (visible) entries.
+ *
+ *  Hides every classified element in `picker.allLinks` (the full pre-dedup
+ *  set) whose language is blocked — not just the first-per-language entries
+ *  in `picker.links`. `dedupByLanguage` (extract.ts) collapses regional
+ *  variants (e.g. `ru-RU`/`ru-UA`) down to one display entry, so hiding only
+ *  `picker.links` would leave a second same-language element fully visible
+ *  and clickable, letting the blocked language leak through it (movar#293).
+ *  Survivors are still reported from `picker.links` — dedup is for
+ *  display/tooltip purposes only, so language counting elsewhere (curtain
+ *  trigger, tooltip body) is unaffected. */
 function filterPickerLinks(
   picker: Picker,
   shouldHide: (lang: LanguageCode) => boolean,
   hiddenLinks: ClassifiedLink[],
 ): ClassifiedLink[] {
-  const survivors: ClassifiedLink[] = [];
-  for (const link of picker.links) {
-    if (!shouldHide(link.language)) {
-      survivors.push(link);
-      continue;
-    }
+  for (const link of picker.allLinks ?? picker.links) {
+    if (!shouldHide(link.language)) continue;
     if (link.el.hasAttribute(HIDDEN_ATTR)) continue;
     hideElement(link.el, 'not-in-priority');
     hiddenLinks.push(link);
   }
-  return survivors;
+  return picker.links.filter((link) => !shouldHide(link.language));
 }
 
 /** Every language currently hidden in this picker, in DOM order, deduped. The

--- a/apps/extension/src/lib/picker.filter.test.ts
+++ b/apps/extension/src/lib/picker.filter.test.ts
@@ -1052,3 +1052,69 @@ describe('filterPickers — hideElement is idempotent on an already-hidden link'
     ).toBe('pre-existing');
   });
 });
+
+describe('filterPickers — regional-variant duplicates of a blocked language (movar#293)', () => {
+  // normalizeBCP47 already collapses ru-RU/ru-UA to the base 'ru', so the
+  // language MATCH isn't the problem — dedupByLanguage (extract.ts) then
+  // keeps only the first same-language entry in picker.links for display.
+  // Pre-fix, filterPickerLinks only ever looked at picker.links, so it hid
+  // just that first RU anchor; the second RU regional-variant link was
+  // never referenced again and stayed fully visible and clickable — the
+  // blocked language leaked through it.
+
+  it('hides EVERY regional-variant duplicate of a blocked base language, not just the first', () => {
+    setBody(`
+      <div id="picker">
+        <a id="ru-ru" href="/x" hreflang="ru-RU">RU</a>
+        <a id="ru-ua" href="/y" hreflang="ru-UA">RU</a>
+        <a id="uk" href="/z" hreflang="uk">UK</a>
+      </div>
+    `);
+    const result = filterPickers(findLanguagePickers(), ['uk'], { blocked: ['ru'] });
+    expect(document.querySelector<HTMLElement>('#ru-ru')!.style.display).toBe('none');
+    expect(document.querySelector<HTMLElement>('#ru-ua')!.style.display).toBe('none');
+    expect(result.hiddenLinks.map((l) => l.language)).toEqual(['ru', 'ru']);
+    // The non-blocked language is untouched.
+    expect(document.querySelector<HTMLElement>('#uk')!.style.display).toBe('');
+  });
+
+  it('does not over-match — a non-blocked language with duplicates stays fully visible', () => {
+    setBody(`
+      <div id="picker">
+        <a id="en-us" href="/x" hreflang="en-US">EN</a>
+        <a id="en-gb" href="/y" hreflang="en-GB">EN</a>
+        <a id="ru" href="/z" hreflang="ru">RU</a>
+      </div>
+    `);
+    const result = filterPickers(findLanguagePickers(), ['uk', 'en'], { blocked: ['ru'] });
+    expect(document.querySelector<HTMLElement>('#en-us')!.style.display).toBe('');
+    expect(document.querySelector<HTMLElement>('#en-gb')!.style.display).toBe('');
+    expect(result.hiddenLinks.map((l) => l.language)).toEqual(['ru']);
+  });
+
+  it('restores every regional-variant duplicate (not just the deduped display entry) on per-picker restore', () => {
+    setBody(`
+      <div id="picker">
+        <a id="ru-ru" href="/x" hreflang="ru-RU">RU</a>
+        <a id="ru-ua" href="/y" hreflang="ru-UA">RU</a>
+        <a id="uk" href="/z" hreflang="uk">UK</a>
+      </div>
+    `);
+    filterPickers(findLanguagePickers(), ['uk'], { blocked: ['ru'] });
+    expect(document.querySelector<HTMLElement>('#ru-ru')!.style.display).toBe('none');
+    expect(document.querySelector<HTMLElement>('#ru-ua')!.style.display).toBe('none');
+
+    const uk = document.querySelector<HTMLAnchorElement>('#uk')!;
+    uk.focus();
+    getTooltipHosts()[0]!.shadowRoot!.querySelector<HTMLButtonElement>('.action')!.click();
+
+    expect(document.querySelector<HTMLElement>('#ru-ru')!.style.display).toBe('');
+    expect(document.querySelector<HTMLElement>('#ru-ua')!.style.display).toBe('');
+    expect(document.querySelector<HTMLElement>('#ru-ru')!.hasAttribute('data-movar-hidden')).toBe(
+      false,
+    );
+    expect(document.querySelector<HTMLElement>('#ru-ua')!.hasAttribute('data-movar-hidden')).toBe(
+      false,
+    );
+  });
+});

--- a/docs/REFACTORING-QUEUE.md
+++ b/docs/REFACTORING-QUEUE.md
@@ -13,7 +13,7 @@ summary: Auto-generated agent task queue from fallow refactoring targets.
 - Source report: [.metrics/fallow.md](../.metrics/fallow.md)
 - Health score: **80 (B)**
 - Targets surfaced: **1** (parsed: 1)
-- Generated: 2026-07-25T20:27:17.348Z
+- Generated: 2026-07-25T21:12:55.445Z
 
 ## How to consume
 

--- a/packages/lang-pickers/src/extract.ts
+++ b/packages/lang-pickers/src/extract.ts
@@ -158,6 +158,9 @@ export function findLanguagePickers(root: ParentNode = document): Picker[] {
   const minimal = pruneOuterContainers([...byContainer.keys()]);
   return minimal.map((container) => {
     const links = byContainer.get(container) ?? [];
-    return { container, links: dedupByLanguage(links) };
+    // `allLinks` keeps the full pre-dedup set so filterPickerLinks can hide
+    // every regional-variant duplicate, not just the one dedup kept for
+    // display in `links` (movar#293).
+    return { container, links: dedupByLanguage(links), allLinks: links };
   });
 }

--- a/packages/lang-pickers/src/types.ts
+++ b/packages/lang-pickers/src/types.ts
@@ -141,7 +141,18 @@ export interface ClassifiedLink {
 
 export interface Picker {
   container: HTMLElement;
+  /** Deduped-by-language display set (see `dedupByLanguage` in extract.ts) —
+   *  one entry per distinct language, for counting/labelling/tooltip use. */
   links: ClassifiedLink[];
+  /** Every classified link inside the container BEFORE the language dedup
+   *  that produces `links` above — includes regional-variant duplicates
+   *  (e.g. both `ru-RU` and `ru-UA`) that dedup collapsed away. Filtering
+   *  must hide/restore against this full set, or a duplicate dropped from
+   *  `links` never gets touched and stays visible/clickable — the blocked
+   *  language "leaks" through it (movar#293). Optional so pre-existing
+   *  hand-built test fixtures that only set `links` keep compiling;
+   *  consumers fall back to `links` when it's absent. */
+  allLinks?: ClassifiedLink[];
 }
 
 export interface FilterResult {

--- a/scripts/readme-metrics.snapshot.json
+++ b/scripts/readme-metrics.snapshot.json
@@ -4,7 +4,7 @@
     "score": 80,
     "grade": "B"
   },
-  "loc": 42898,
+  "loc": 42922,
   "suppressions": {
     "eslint": 43,
     "fallow": 25


### PR DESCRIPTION
## Summary

- `dedupByLanguage` (`packages/lang-pickers/src/extract.ts`) collapses regional variants of a language (e.g. `ru-RU` + `ru-UA`, both normalized to base `ru` by `normalizeBCP47`) to a single display entry in `picker.links` *before* filtering runs.
- `filterPickerLinks` (`apps/extension/src/lib/picker-filter.ts`) only ever hid elements present in that deduped `picker.links`. The second same-language link that dedup dropped was never referenced again, so it stayed fully visible and clickable — the user's blocked language leaked through it, and the survivor tooltip would announce the language as hidden while a link to it was still live.
- Fix: `Picker` now carries an additional `allLinks` field — the full pre-dedup set of classified links in the container. `filterPickerLinks` hides every element in `allLinks` whose language is blocked (not just the deduped entries), and `restorePickerInPlace` restores against the same full set so "Show hidden options" / "Show everything" fully undoes it. `picker.links` (deduped) is untouched and continues to drive display/tooltip/curtain-counting logic exactly as before.

## Files changed

- `packages/lang-pickers/src/types.ts` — add optional `Picker.allLinks` (full pre-dedup set), documented alongside `links`.
- `packages/lang-pickers/src/extract.ts` — populate `allLinks` in `findLanguagePickers`.
- `apps/extension/src/lib/picker-filter.ts` — `filterPickerLinks` hides against `allLinks` (survivors still computed from deduped `links`); `restorePickerInPlace` un-hides against `allLinks` too, so restore is symmetric with hide.
- `apps/extension/src/lib/picker.filter.test.ts` — new `describe('filterPickers — regional-variant duplicates of a blocked language (movar#293)')` block: hides every `ru-RU`/`ru-UA` duplicate when `ru` is blocked (not just the first), leaves a non-blocked duplicated language (`en-US`/`en-GB`) fully visible, and confirms per-picker restore un-hides both duplicates.
- `.changeset/lang-pickers-blocked-variant-leak.md` — patch changeset for `@movar/extension`.

## Test plan

- [x] Added tests reproduce the bug: verified by stashing the source fix (keeping only the new tests) and re-running — 2 of the 3 new tests failed with `expected '' to be 'none'` on the second regional-variant link, confirming they exercise the leak. Restored the fix and all tests pass again.
- [x] `pnpm test` — all 17 projects pass (extension: 1307/1307, lang-pickers: 68/68).
- [x] `pnpm lint` — clean across all 19 projects.
- [x] `pnpm exec prettier --write . && pnpm exec prettier --check .` — clean.
- [x] `pnpm metrics` — content bundle within budget (40 KB / 80 KB budget), README metrics current, fallow health score unchanged at 80 (B).
- [x] `pnpm metrics:audit` — `No issues in 7 changed files`.
- [x] Pre-push hooks (build, `e2e-fast`, metrics audit) passed on first attempt.

Closes #293

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>