### PR TITLE
fix(extension): re-conceal content after a UI-language change

### DIFF
--- a/.changeset/content-runtime-relocale-reconceal.md
+++ b/.changeset/content-runtime-relocale-reconceal.md
@@ -1,0 +1,5 @@
+---
+'@movar/extension': patch
+---
+
+content-runtime: re-apply concealment after a UI-language change, so previously-hidden/blocked content is re-concealed in the new locale instead of being revealed and left permanently visible until reload. Closes #288.

--- a/apps/extension/src/entrypoints/__tests__/content.test.ts
+++ b/apps/extension/src/entrypoints/__tests__/content.test.ts
@@ -847,6 +847,66 @@ describe('toggle-off race', () => {
   });
 });
 
+describe('UI-language change mid-classify re-conceals (#288)', () => {
+  it('re-applies concealment once the in-flight tick clears, instead of leaving the page revealed', async () => {
+    // A fake facade whose applyContentModification suspends until released —
+    // stands in for a real tick parked at its classify round-trip.
+    const releases: (() => void)[] = [];
+    const apply = vi.fn<ConcealMod['applyContentModification']>(async () => {
+      await new Promise<void>((resolve) => releases.push(resolve));
+      return [];
+    });
+    const mod = { ...fakeConcealModule(), applyContentModification: apply };
+    installFakeChunks({ 'features/conceal.js': mod });
+
+    const settings = {
+      ...defaultSettings,
+      contentModification: true,
+      concealMode: 'hide' as const,
+      uiLanguage: 'en' as const,
+    };
+    const live = { current: settings };
+    runtime.installSettingsListener(live);
+
+    // Tick A (e.g. a MutationObserver tick) parks mid-classify.
+    const tickA = runtime.applyOnce(live.current);
+    await vi.waitFor(() => {
+      expect(apply).toHaveBeenCalledTimes(1);
+    });
+
+    // A UI-language change lands while tick A is still in flight: the settings
+    // listener tears down (revealing everything already concealed) and tries
+    // to re-apply — but applyOnce's concurrency guard is still held by tick A.
+    void fakeBrowser.storage.onChanged.trigger(
+      { settings: { newValue: { ...settings, uiLanguage: 'uk' } } },
+      'sync',
+    );
+    await vi.waitFor(() => {
+      expect(mod.teardownContentModification).toHaveBeenCalledOnce();
+    });
+    // Pre-fix, the follow-up apply is silently dropped here, and nothing short
+    // of an unrelated DOM mutation would ever re-run it.
+    expect(apply).toHaveBeenCalledTimes(1);
+
+    // Tick A's classify round-trip resolves; it is now stale (the settings
+    // change bumped the generation), so it contributes no concealment.
+    releases[0]!();
+    await tickA;
+
+    // The dropped re-apply must still run once tick A clears: the page gets
+    // re-concealed — in the new locale's settings — instead of staying
+    // revealed until an unrelated mutation happens to retrigger the observer.
+    await vi.waitFor(() => {
+      expect(apply).toHaveBeenCalledTimes(2);
+    });
+    expect(apply.mock.calls[1]![0]).toMatchObject({ settings: { uiLanguage: 'uk' } });
+
+    // Let the re-applied tick's own classify settle so it doesn't dangle past
+    // this test.
+    releases[1]!();
+  });
+});
+
 describe('SPA / history location-change re-trigger', () => {
   beforeEach(() => {
     clearAttempt();

--- a/apps/extension/src/lib/content-runtime.ts
+++ b/apps/extension/src/lib/content-runtime.ts
@@ -496,9 +496,21 @@ const TIER7_ENGINES = [chromeAiEngine, backgroundFrancEngine];
 
 /** True while applyOnce is mid-tick. The MutationObserver fires the next tick
  *  150 ms after a mutation, and a slow tier-7 call could let two ticks race.
- *  The guard drops overlapping calls — the next mutation triggers a fresh
- *  apply with the latest DOM, so dropped ticks aren't lost. */
+ *  The guard drops overlapping calls; {@link rerunPending} (below) makes sure
+ *  a dropped call still runs once the in-flight tick clears, rather than
+ *  relying solely on some future mutation or route change to redrive it. */
 let applyingInFlight = false;
+
+/** Settings snapshot for a follow-up tick, recorded when {@link applyOnce} is
+ *  called while a previous tick is still in flight — the `applyingInFlight`
+ *  guard would otherwise drop that call silently. Consumed once, from the
+ *  finally of the in-flight applyOnce, so a settings change that lands
+ *  mid-tick (e.g. a UI-language change, whose teardown may already have
+ *  revealed concealed content — #288) still gets its follow-up apply
+ *  re-driven instead of leaving the page revealed until an unrelated
+ *  mutation happens to retrigger it. Repeated drops overwrite rather than
+ *  queue: only the latest requested settings matter for a re-apply. */
+let rerunPending: MovarSettings | null = null;
 
 /** Monotonically-increasing epoch. Incremented whenever a settings change or
  *  restoreAll() invalidates any in-flight apply tick, so a tick that resumes
@@ -513,7 +525,11 @@ function invalidateInFlightApplies(): void {
 // fallow-ignore-next-line complexity
 async function applyOnce(settings: MovarSettings): Promise<boolean> {
   if (pausedActive || snoozedActive) return false;
-  if (applyingInFlight) return false;
+  if (applyingInFlight) {
+    // Remember the request instead of dropping it — see rerunPending.
+    rerunPending = settings;
+    return false;
+  }
   applyingInFlight = true;
   const generation = applyGeneration;
   currentDetectionEngine = null;
@@ -525,7 +541,23 @@ async function applyOnce(settings: MovarSettings): Promise<boolean> {
     // Concealment for this tick has settled — push the current summary so the
     // toolbar icon + count badge track it (deduped; a no-op when unchanged).
     notifyHiddenChanged();
+    // A call landed while this tick was in flight and got dropped above —
+    // re-drive it now that the guard is clear, so it runs for real instead of
+    // being silently lost (#288).
+    runPendingRerun();
   }
+}
+
+/** Re-invoke {@link applyOnce} with the settings snapshot a caller recorded in
+ *  {@link rerunPending} while this tick was in flight, if any. Called from
+ *  applyOnce's `finally`, after `applyingInFlight` is already cleared, so the
+ *  follow-up call runs the real pipeline instead of hitting the same guard.
+ *  No-op when nothing was dropped. */
+function runPendingRerun(): void {
+  if (rerunPending == null) return;
+  const pending = rerunPending;
+  rerunPending = null;
+  void applyOnce(pending);
 }
 
 /** Tier-7 fallback: sample the visible body text and run it through the engine

--- a/docs/REFACTORING-QUEUE.md
+++ b/docs/REFACTORING-QUEUE.md
@@ -13,7 +13,7 @@ summary: Auto-generated agent task queue from fallow refactoring targets.
 - Source report: [.metrics/fallow.md](../.metrics/fallow.md)
 - Health score: **81 (B)**
 - Targets surfaced: **1** (parsed: 1)
-- Generated: 2026-07-26T10:34:53.634Z
+- Generated: 2026-07-26T10:59:11.683Z
 
 ## How to consume
 

--- a/scripts/readme-metrics.snapshot.json
+++ b/scripts/readme-metrics.snapshot.json
@@ -4,14 +4,14 @@
     "score": 81,
     "grade": "B"
   },
-  "loc": 43185,
+  "loc": 43217,
   "suppressions": {
     "eslint": 43,
     "fallow": 24
   },
   "coverage": {
     "lines": 94.5,
-    "branches": 87.7
+    "branches": 87.8
   },
   "bundle": {
     "contentKb": 41


### PR DESCRIPTION
## Summary

- `applyOnce`'s `applyingInFlight` concurrency guard silently dropped the settings listener's follow-up apply when a UI-language change landed while a tick was parked at its classify/tier-7 `await`. The listener's `teardownContentModification()` had already revealed all concealed content, so the page was left fully revealed with nothing scheduled to re-conceal it — until an unrelated DOM mutation happened to redrive the `MutationObserver`.
- Fix: add a `rerunPending` snapshot. When `applyOnce` is called while a tick is already in flight, remember the requested settings instead of dropping the call, then re-invoke `applyOnce` with them from the in-flight tick's `finally`, once the guard clears. This reuses the existing apply/re-eval path (no new pipeline), is idempotent (a no-op rerun while paused/snoozed/user-overridden short-circuits at `applyOnce`'s/`applyOnceInner`'s existing guards), and doesn't add any decision points to `applyOnce` itself (no new fallow suppression needed — the suppression count is unchanged at 24).

## Files changed

- `apps/extension/src/lib/content-runtime.ts` — the fix (`rerunPending` + `runPendingRerun`).
- `apps/extension/src/entrypoints/__tests__/content.test.ts` — new regression test.
- `.changeset/content-runtime-relocale-reconceal.md` — patch changeset.
- `docs/REFACTORING-QUEUE.md`, `scripts/readme-metrics.snapshot.json` — regenerated by `pnpm metrics`.

## Test plan

- [x] Added `UI-language change mid-classify re-conceals (#288)` in `content.test.ts`, which parks a fake `applyContentModification` mid-classify, fires a UI-language settings change (teardown + dropped re-apply), releases the parked tick, and asserts `applyContentModification` is called a **second** time with the new locale's settings.
- [x] Confirmed the new test **fails** against pre-fix code (`git stash` on just the fix): `expected "vi.fn()" to be called 2 times, but got 1 times` — reproducing #288 exactly.
- [x] `pnpm test` — 17 projects, extension: 82 files / 1327 tests passed.
- [x] `pnpm lint` — clean (after fixing one `array-type` nit in the new test).
- [x] `pnpm exec prettier --write . && pnpm exec prettier --check .` — clean.
- [x] `pnpm metrics` then prettier again — health score unchanged (81 B), coverage ticked up slightly (87.7% → 87.8% branches).
- [x] `pnpm metrics:audit` — `✓ No issues in 5 changed files`.
- [x] Full local pre-commit/pre-push gates (lefthook: eslint, prettier, readme-parity, suppressions, test, typecheck, build, e2e-fast, metrics) all passed on first try.

Closes #288

🤖 Generated with [Claude Code](https://claude.com/claude-code)