### PR TITLE
fix(google): count data-hveid cards, not <h3>, for the empty-SERP retry

### DIFF
--- a/.changeset/google-empty-serp-retry-h3-less-results.md
+++ b/.changeset/google-empty-serp-retry-h3-less-results.md
@@ -1,0 +1,5 @@
+---
+'@movar/extension': patch
+---
+
+fix(google): count `data-hveid` result cards, not `<h3>` titles, for the empty-SERP retry — a shopping/product-only SERP (title rendered as a `role="heading"` div, no `<h3>` anywhere on the page) was misread as zero results, firing a spurious retry that suspended the Google redirect rule, stripped the `lr` language filter, and forced an unwanted navigation on an already-healthy page.

--- a/apps/extension/src/lib/google-empty-serp-retry.integration.test.ts
+++ b/apps/extension/src/lib/google-empty-serp-retry.integration.test.ts
@@ -50,6 +50,18 @@ const HEALTHY_SERP_BODY = `
     <div data-hveid="2"><a href="https://rozetka.com.ua/"><h3>Реле напруги ZUBR</h3></a></div>
   </div></div>`;
 
+/** Healthy SERP, shopping/product shape: title is a `role="heading"` div, NOT
+ *  an `<h3>` — the real shape @movar/page-content's fixture corpus captured
+ *  (packages/page-content/fixtures/google-serp/shopping-role-heading), which
+ *  has zero `<h3>` anywhere on the page. `resultsSelector` must key on
+ *  `data-hveid` card presence, not `<h3>`, or this reads as empty and fires a
+ *  spurious retry on a page that was never empty. */
+const HEALTHY_SHOPPING_SERP_BODY = `
+  <div id="search"><div id="rso">
+    <div data-hveid="1"><div lang="uk"><div role="heading" aria-level="3">Реле напруги</div></div></div>
+    <div data-hveid="2"><div lang="uk"><div role="heading" aria-level="3">Реле напруги ZUBR</div></div></div>
+  </div></div>`;
+
 /** Mutable stand-in for the page `location`, shared by the ladder deps and the
  *  retry deps exactly like the content script shares its real `location`. */
 function makeLocation(href: string): { href: string; replace(url: string): void; reload(): void } {
@@ -129,7 +141,7 @@ describe('google.com — emptyResultsRetry + loop guard + enforce ladder integra
     expect(rule?.emptyResultsRetry).toEqual({
       dropParam: 'lr',
       containerSelector: '#search',
-      resultsSelector: '#search a h3',
+      resultsSelector: '#rso [data-hveid]',
     });
   });
 
@@ -194,6 +206,20 @@ describe('google.com — emptyResultsRetry + loop guard + enforce ladder integra
     const rule = getRuleForHost('www.google.com');
     if (!rule?.emptyResultsRetry) return;
     document.body.innerHTML = HEALTHY_SERP_BODY;
+    const loc = makeLocation(PINNED_URL);
+    const retryDeps = makeRetryDeps(loc);
+
+    maybeScheduleEmptyResultsRetry(rule.emptyResultsRetry, 'uk', retryDeps);
+    await vi.runAllTimersAsync();
+
+    expect(loc.href).toBe(PINNED_URL);
+    expect(retryDeps.record).not.toHaveBeenCalled();
+  });
+
+  it('leaves a healthy shopping/product SERP alone — h3-less role="heading" cards still count as results', async () => {
+    const rule = getRuleForHost('www.google.com');
+    if (!rule?.emptyResultsRetry) return;
+    document.body.innerHTML = HEALTHY_SHOPPING_SERP_BODY;
     const loc = makeLocation(PINNED_URL);
     const retryDeps = makeRetryDeps(loc);
 

--- a/apps/extension/src/sites/google/index.ts
+++ b/apps/extension/src/sites/google/index.ts
@@ -140,13 +140,24 @@ export const googleRule: SiteRule = {
   // the durable fix: a settled SERP with `lr` present and a rendered-but-
   // empty results area is retried exactly once without `lr` (`hl` stays, so
   // the interface language holds). `#search` is the results area Google has
-  // rendered for years; organic hits are the `<a><h3>` title links inside it
-  // (same shape @movar/page-content's extractor keys on) — a DOM count, so
-  // no localized "About 0 results" string parsing.
+  // rendered for years — a DOM count, so no localized "About 0 results"
+  // string parsing.
+  //
+  // resultsSelector anchors on `[data-hveid]` presence inside `#rso`, NOT
+  // `<h3>`: product/shopping results render their title as a `role="heading"`
+  // div, not an `<h3>` (@movar/page-content's DECLARED_RESULT_SELECTOR fix,
+  // PR #186) — so an `h3`-only count reads a healthy shopping-only SERP as
+  // zero results and fires a spurious retry (suspends the DNR rule, strips
+  // `lr`, forces a navigation) on a page that was never empty. `data-hveid`
+  // is the same card-boundary anchor @movar/page-content climbs to for EVERY
+  // organic result regardless of title shape (its ORGANIC_CONTAINER), so it
+  // covers both cases; verified against the real shopping-role-heading corpus
+  // capture (packages/page-content/fixtures/google-serp), which has zero
+  // `<h3>` anywhere on the page yet two legitimate result cards.
   emptyResultsRetry: {
     dropParam: 'lr',
     containerSelector: '#search',
-    resultsSelector: '#search a h3',
+    resultsSelector: '#rso [data-hveid]',
   },
 };
 


### PR DESCRIPTION
## Summary

- The empty-SERP-retry `resultsSelector` (`#search a h3`, added in PR #208) only counts organic results whose title is an `<h3>`. PR #186 — merged two days *earlier* — had already documented that Google's product/shopping results render their title as a `role="heading"` div, with **no `<h3>` anywhere on the page**, and fixed the content extractor for it. The empty-SERP retry never got the same fix.
- Verified against the real anonymized SERP capture in `packages/page-content/fixtures/google-serp/shopping-role-heading.fixture.html`: `#search a h3` returns 0 even though the page has two legitimate, rendered result cards.
- Net effect: any shopping/product-style Google search was misread as an empty SERP, which fired the recovery path — suspending the Google DNR redirect rule, stripping the `lr` language-result filter, and forcing an unwanted page navigation — on a page that was never broken.
- Fix: anchor `resultsSelector` on `#rso [data-hveid]` instead of `<h3>`. `data-hveid` is the same card-boundary attribute `@movar/page-content`'s extractor already climbs to for every organic result regardless of title shape (its `ORGANIC_CONTAINER`), so it covers both the plain-h3 and h3-less shapes.

## Test plan

- [x] Added a regression test (`google-empty-serp-retry.integration.test.ts`) using the real h3-less shopping-card shape, asserting the retry does not fire on a healthy shopping SERP.
- [x] Updated the existing exact-match assertion pinning the rule's `emptyResultsRetry` shape to the new selector.
- [x] Full extension suite green: 1328/1328 tests, typecheck, lint.
- [x] `pnpm validate` (pre-commit) and build + e2e-fast + metrics audit (pre-push) all passed locally.
- [ ] Live-network verification against real Google was not possible from this environment — Google's bot detection blocks this sandbox's egress IP (confirmed independently via the live e2e suite, an in-app browser fetch, and Firecrawl, all hit the same `/sorry/` CAPTCHA wall or provider limit). Recommend a manual check of a shopping-style Google search with the built extension before shipping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)