### PR TITLE
chore(release): extension v1.5.2

### DIFF
--- a/.changeset/chrome-ai-honor-abortsignal.md
+++ b/.changeset/chrome-ai-honor-abortsignal.md
@@ -1,5 +1,0 @@
----
-'@movar/lang-detect': patch
----
-
-lang-detect/chrome-ai: honor the AbortSignal / detection time budget so a hung on-device model no longer stalls detection past the intended deadline — an aborted or over-budget detection now resolves to "no detection" instead of blocking. Closes #292.

--- a/.changeset/chrome-ai-reject-und.md
+++ b/.changeset/chrome-ai-reject-und.md
@@ -1,5 +1,0 @@
----
-'@movar/lang-detect': patch
----
-
-lang-detect/chrome-ai: reject Chrome's `und` (undetermined) result and validate the detected code against the known LanguageCode set before returning, mirroring the franc engine — so an undetermined result is treated as "no detection" instead of a positive `und` that violates the type contract and defeats the loop guard. Closes #305.

--- a/.changeset/content-conceal-hide-curtain-empty.md
+++ b/.changeset/content-conceal-hide-curtain-empty.md
@@ -1,5 +1,0 @@
----
-'@movar/extension': patch
----
-
-content-conceal: don't add a spurious empty curtain over already-emptied containers when switching conceal mode from hide to curtain. Closes #296.

--- a/.changeset/content-conceal-superseded-checked.md
+++ b/.changeset/content-conceal-superseded-checked.md
@@ -1,5 +1,0 @@
----
-'@movar/extension': patch
----
-
-content-conceal: don't leave cards marked CHECKED when a scan is superseded, so a subsequent scan correctly re-evaluates them instead of permanently skipping cards that should be (re-)assessed for blocking. Closes #289.

--- a/.changeset/content-runtime-locale-retry.md
+++ b/.changeset/content-runtime-locale-retry.md
@@ -1,5 +1,0 @@
----
-'@movar/extension': patch
----
-
-content-runtime: don't memoize a failed content-locale/message load, so a retry can re-attempt loadContentMessages instead of permanently pinning hide-mode live-region strings to English after a transient first-load failure. Closes #316.

--- a/.changeset/content-runtime-relocale-reconceal.md
+++ b/.changeset/content-runtime-relocale-reconceal.md
@@ -1,5 +1,0 @@
----
-'@movar/extension': patch
----
-
-content-runtime: re-apply concealment after a UI-language change, so previously-hidden/blocked content is re-concealed in the new locale instead of being revealed and left permanently visible until reload. Closes #288.

--- a/.changeset/content-runtime-showall-spa-leak.md
+++ b/.changeset/content-runtime-showall-spa-leak.md
@@ -1,5 +1,0 @@
----
-'@movar/extension': patch
----
-
-content-runtime: reset the per-page "Show everything on this page" override on SPA navigations instead of letting it leak across a same-pathname route change, so Movar isn't silently disabled on the new page. Closes #314.

--- a/.changeset/corrections-log-serialized-writer.md
+++ b/.changeset/corrections-log-serialized-writer.md
@@ -1,5 +1,0 @@
----
-'@movar/extension': patch
----
-
-events: funnel correction-log appends through a single serialized writer in the background service worker, fixing a cross-tab lost-update race where two tabs recording corrections concurrently could drop one tab's append (undercounting the on-device insights dashboard). The previous per-tab `applyingInFlight` guard only serialized within a single tab. Closes #310.

--- a/.changeset/curtain-overflow-longhand.md
+++ b/.changeset/curtain-overflow-longhand.md
@@ -1,5 +1,0 @@
----
-'@movar/extension': patch
----
-
-curtain: snapshot and restore a site's inline `overflow-x`/`overflow-y` longhands individually when covering/revealing content, so revealing a cover-curtain no longer permanently strips an element's own single inline overflow longhand (e.g. `overflow-y: auto`). Closes #302.

--- a/.changeset/dnr-sw-wake-respect-suspend.md
+++ b/.changeset/dnr-sw-wake-respect-suspend.md
@@ -1,5 +1,0 @@
----
-'@movar/extension': patch
----
-
-background/dnr: on service-worker wake, respect an active empty-SERP-retry suspension instead of unconditionally re-installing the Google redirect rule — so a SW restart mid-retry no longer re-rewrites the retry request and defeats the empty-SERP recovery. Closes #301.

--- a/.changeset/firefox-onboarding-browser-label.md
+++ b/.changeset/firefox-onboarding-browser-label.md
@@ -1,5 +1,0 @@
----
-'@movar/extension': patch
----
-
-onboarding: derive the pin-step browser label from the resolved onboarding flow so Firefox users see "Firefox" (and Safari its own label) instead of a hardcoded "Chrome". Closes #294.

--- a/.changeset/google-empty-serp-retry-h3-less-results.md
+++ b/.changeset/google-empty-serp-retry-h3-less-results.md
@@ -1,5 +1,0 @@
----
-'@movar/extension': patch
----
-
-fix(google): count `data-hveid` result cards, not `<h3>` titles, for the empty-SERP retry — a shopping/product-only SERP (title rendered as a `role="heading"` div, no `<h3>` anywhere on the page) was misread as zero results, firing a spurious retry that suspended the Google redirect rule, stripped the `lr` language filter, and forced an unwanted navigation on an already-healthy page.

--- a/.changeset/hidden-summary-count-wrappers.md
+++ b/.changeset/hidden-summary-count-wrappers.md
@@ -1,5 +1,0 @@
----
-'@movar/extension': patch
----
-
-hidden-summary: exclude empty-container cleanup wrappers from the "N hidden" count so it reflects the real number of concealed content items instead of being inflated. Closes #297.

--- a/.changeset/host-match-trailing-dot.md
+++ b/.changeset/host-match-trailing-dot.md
@@ -1,5 +1,0 @@
----
-'@movar/host-match': patch
----
-
-host-match: strip a trailing dot from FQDN hostnames so `isGoogleHost`/`isYouTubeHost` match `google.com.` and `youtube.com.` (previously the content-script site rule and model chunk silently no-op'd on trailing-dot hosts). Closes #295.

--- a/.changeset/lang-pickers-blocked-variant-leak.md
+++ b/.changeset/lang-pickers-blocked-variant-leak.md
@@ -1,5 +1,0 @@
----
-'@movar/extension': patch
----
-
-lang-pickers: treat regional variants of a blocked language as blocked (e.g. `pt-BR` when `pt` is blocked), so a blocked language no longer leaks through a picker's regional-variant links. Closes #293.

--- a/.changeset/language-switch-picker-target-lang.md
+++ b/.changeset/language-switch-picker-target-lang.md
@@ -1,5 +1,0 @@
----
-'@movar/extension': patch
----
-
-language-switch: record the correct target language on a picker-based redirect, so the local corrections/insights dashboard no longer attributes the switch to the wrong language. Closes #299.

--- a/.changeset/language-switch-scheme-allowlist.md
+++ b/.changeset/language-switch-scheme-allowlist.md
@@ -1,5 +1,0 @@
----
-'@movar/extension': patch
----
-
-security: validate the language-switch redirect target's scheme before navigating — Movar now only follows `http:`/`https:` alternates from a page's `hreflang`/picker links, closing a confused-deputy open-redirect where an injected `<link rel="alternate">` could force an off-site navigation. Closes #306.

--- a/.changeset/loop-guard-persist-migrated-ts.md
+++ b/.changeset/loop-guard-persist-migrated-ts.md
@@ -1,5 +1,0 @@
----
-'@movar/extension': patch
----
-
-loop-guard/session-choice: persist migrated legacy storage entries with a fixed timestamp on first read, so a pre-#184 legacy entry can finally cross SUPPRESSION_TTL_MS and TTL-expire. Previously each read re-derived `ts: now`, keeping migrated entries immortal — a bounced language switch could bail forever and a stale session pick could pin a host to a blocked language indefinitely. Closes #304.

--- a/.changeset/native-settings-seenrev-after-sync.md
+++ b/.changeset/native-settings-seenrev-after-sync.md
@@ -1,5 +1,0 @@
----
-'@movar/extension': patch
----
-
-native-settings (Safari): advance `seenRev` only after the `storage.sync` write succeeds during host-app settings adoption, so a rejected sync write (quota, rate-limit, transient iCloud unavailability) no longer silently drops the host app's change — the reconcile now catches the failure, leaves `seenRev` behind, and re-adopts on the next wake. Closes #315.

--- a/.changeset/options-priority-focus-restore.md
+++ b/.changeset/options-priority-focus-restore.md
@@ -1,6 +1,0 @@
----
-'@movar/options-ui': patch
-'@movar/ui': patch
----
-
-options: restore keyboard focus after reordering or removing a priority language, so keyboard/screen-reader users no longer get dropped to <body> when a move lands on a boundary or a row is removed (WCAG 2.4.3). Closes #313.

--- a/.changeset/picker-filter-restore-display.md
+++ b/.changeset/picker-filter-restore-display.md
@@ -1,5 +1,0 @@
----
-'@movar/extension': patch
----
-
-picker-filter: restore a hidden picker link's original inline `display` (and its priority) on reveal/teardown instead of unconditionally removing it — previously `removeProperty('display')` wiped an element's own inline display, shifting layout or leaving CSS-`display:none` elements invisible after "Show hidden options"/"Show everything". Closes #300.

--- a/.changeset/popup-clear-snooze-on-exempt.md
+++ b/.changeset/popup-clear-snooze-on-exempt.md
@@ -1,5 +1,0 @@
----
-'@movar/extension': patch
----
-
-popup: clear a host's active snooze when escalating to "Always skip this site" or "Turn on for this site", so later un-exempting the host resumes Movar immediately instead of leaving it inert until the stale snooze window expires. Closes #298.

--- a/.changeset/serialize-svg-not-hidden.md
+++ b/.changeset/serialize-svg-not-hidden.md
@@ -1,5 +1,0 @@
----
-'@movar/page-content': patch
----
-
-page-content/serialize: stop misclassifying inline `<svg>` elements as hidden. `isHiddenElement` now guards the `hidden` IDL check with `el instanceof HTMLElement` (the `hidden` property doesn't exist on `SVGElement`), so a container whose only remaining visible content is a lone `<svg>` icon is no longer judged empty and hard-hidden. Closes #291.

--- a/.changeset/settings-reaction-reapply-open-tabs.md
+++ b/.changeset/settings-reaction-reapply-open-tabs.md
@@ -1,5 +1,0 @@
----
-'@movar/extension': patch
----
-
-settings-reaction: re-apply priority/blocked language changes to already-open tabs instead of only affecting future evaluations, so changing your languages updates open pages without a manual reload. Closes #290.

--- a/.changeset/tooltip-survivor-leak.md
+++ b/.changeset/tooltip-survivor-leak.md
@@ -1,5 +1,0 @@
----
-'@movar/extension': patch
----
-
-tooltip: detach a surviving link's tooltip (host + registry entry) when the link later becomes hidden or is SPA-replaced, instead of skipping it — fixing a bounded per-session detached-DOM / registry leak that accumulated on dynamic picker sites until the feature was turned off. Closes #303.

--- a/apps/diagnostics/CHANGELOG.md
+++ b/apps/diagnostics/CHANGELOG.md
@@ -1,5 +1,21 @@
 # @movar/diagnostics
 
+## 0.0.2
+
+### Patch Changes
+
+- Updated dependencies [c4689b0]
+- Updated dependencies [3a5ca20]
+- Updated dependencies [f558db5]
+- Updated dependencies [55b2740]
+  - @movar/lang-detect@0.0.1
+  - @movar/ui@0.0.1
+  - @movar/page-content@0.0.2
+  - @movar/lang-pickers@0.0.1
+  - @movar/page-language@0.0.1
+  - @movar/settings@0.0.1
+  - @movar/app-shell@0.0.1
+
 ## 0.0.1
 
 ### Patch Changes

--- a/apps/diagnostics/package.json
+++ b/apps/diagnostics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@movar/diagnostics",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/e2e/CHANGELOG.md
+++ b/apps/e2e/CHANGELOG.md
@@ -1,0 +1,11 @@
+# @movar/e2e
+
+## 0.0.1
+
+### Patch Changes
+
+- Updated dependencies [c4689b0]
+- Updated dependencies [3a5ca20]
+  - @movar/lang-detect@0.0.1
+  - @movar/events@0.0.1
+  - @movar/settings@0.0.1

--- a/apps/e2e/package.json
+++ b/apps/e2e/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@movar/e2e",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "private": true,
   "type": "module",
   "description": "End-to-end suites for Movar. The default suite (`pnpm test`) is deterministic and CI-gated — popup + options + content-script + behavior specs under `src/offline/`. The live suite (`pnpm test:live`) drives the real internet against rule-bearing sites and is manual-only.",

--- a/apps/extension/CHANGELOG.md
+++ b/apps/extension/CHANGELOG.md
@@ -1,5 +1,46 @@
 # @movar/extension
 
+## 1.5.2
+
+### Patch Changes
+
+- 0fb400a: content-conceal: don't add a spurious empty curtain over already-emptied containers when switching conceal mode from hide to curtain. Closes #296.
+- b3cfa7f: content-conceal: don't leave cards marked CHECKED when a scan is superseded, so a subsequent scan correctly re-evaluates them instead of permanently skipping cards that should be (re-)assessed for blocking. Closes #289.
+- 8e0d860: content-runtime: don't memoize a failed content-locale/message load, so a retry can re-attempt loadContentMessages instead of permanently pinning hide-mode live-region strings to English after a transient first-load failure. Closes #316.
+- 9ba179a: content-runtime: re-apply concealment after a UI-language change, so previously-hidden/blocked content is re-concealed in the new locale instead of being revealed and left permanently visible until reload. Closes #288.
+- 1c32637: content-runtime: reset the per-page "Show everything on this page" override on SPA navigations instead of letting it leak across a same-pathname route change, so Movar isn't silently disabled on the new page. Closes #314.
+- 480dec1: events: funnel correction-log appends through a single serialized writer in the background service worker, fixing a cross-tab lost-update race where two tabs recording corrections concurrently could drop one tab's append (undercounting the on-device insights dashboard). The previous per-tab `applyingInFlight` guard only serialized within a single tab. Closes #310.
+- 5922433: curtain: snapshot and restore a site's inline `overflow-x`/`overflow-y` longhands individually when covering/revealing content, so revealing a cover-curtain no longer permanently strips an element's own single inline overflow longhand (e.g. `overflow-y: auto`). Closes #302.
+- 529c7d0: background/dnr: on service-worker wake, respect an active empty-SERP-retry suspension instead of unconditionally re-installing the Google redirect rule — so a SW restart mid-retry no longer re-rewrites the retry request and defeats the empty-SERP recovery. Closes #301.
+- f8e7d41: onboarding: derive the pin-step browser label from the resolved onboarding flow so Firefox users see "Firefox" (and Safari its own label) instead of a hardcoded "Chrome". Closes #294.
+- 6b94de6: fix(google): count `data-hveid` result cards, not `<h3>` titles, for the empty-SERP retry — a shopping/product-only SERP (title rendered as a `role="heading"` div, no `<h3>` anywhere on the page) was misread as zero results, firing a spurious retry that suspended the Google redirect rule, stripped the `lr` language filter, and forced an unwanted navigation on an already-healthy page.
+- 66b3a50: hidden-summary: exclude empty-container cleanup wrappers from the "N hidden" count so it reflects the real number of concealed content items instead of being inflated. Closes #297.
+- 8254dcb: lang-pickers: treat regional variants of a blocked language as blocked (e.g. `pt-BR` when `pt` is blocked), so a blocked language no longer leaks through a picker's regional-variant links. Closes #293.
+- 4ca7dca: language-switch: record the correct target language on a picker-based redirect, so the local corrections/insights dashboard no longer attributes the switch to the wrong language. Closes #299.
+- 98735d8: security: validate the language-switch redirect target's scheme before navigating — Movar now only follows `http:`/`https:` alternates from a page's `hreflang`/picker links, closing a confused-deputy open-redirect where an injected `<link rel="alternate">` could force an off-site navigation. Closes #306.
+- 93616c2: loop-guard/session-choice: persist migrated legacy storage entries with a fixed timestamp on first read, so a pre-#184 legacy entry can finally cross SUPPRESSION_TTL_MS and TTL-expire. Previously each read re-derived `ts: now`, keeping migrated entries immortal — a bounced language switch could bail forever and a stale session pick could pin a host to a blocked language indefinitely. Closes #304.
+- 85f1160: native-settings (Safari): advance `seenRev` only after the `storage.sync` write succeeds during host-app settings adoption, so a rejected sync write (quota, rate-limit, transient iCloud unavailability) no longer silently drops the host app's change — the reconcile now catches the failure, leaves `seenRev` behind, and re-adopts on the next wake. Closes #315.
+- 5cdc65a: picker-filter: restore a hidden picker link's original inline `display` (and its priority) on reveal/teardown instead of unconditionally removing it — previously `removeProperty('display')` wiped an element's own inline display, shifting layout or leaving CSS-`display:none` elements invisible after "Show hidden options"/"Show everything". Closes #300.
+- 967a884: popup: clear a host's active snooze when escalating to "Always skip this site" or "Turn on for this site", so later un-exempting the host resumes Movar immediately instead of leaving it inert until the stale snooze window expires. Closes #298.
+- 90e70ca: settings-reaction: re-apply priority/blocked language changes to already-open tabs instead of only affecting future evaluations, so changing your languages updates open pages without a manual reload. Closes #290.
+- de23856: tooltip: detach a surviving link's tooltip (host + registry entry) when the link later becomes hidden or is SPA-replaced, instead of skipping it — fixing a bounded per-session detached-DOM / registry leak that accumulated on dynamic picker sites until the feature was turned off. Closes #303.
+- Updated dependencies [c4689b0]
+- Updated dependencies [3a5ca20]
+- Updated dependencies [afa3888]
+- Updated dependencies [f558db5]
+- Updated dependencies [55b2740]
+  - @movar/lang-detect@0.0.1
+  - @movar/host-match@0.1.1
+  - @movar/options-ui@0.0.1
+  - @movar/ui@0.0.1
+  - @movar/page-content@0.0.2
+  - @movar/events@0.0.1
+  - @movar/i18n@0.0.1
+  - @movar/lang-pickers@0.0.1
+  - @movar/page-language@0.0.1
+  - @movar/settings@0.0.1
+  - @movar/app-shell@0.0.1
+
 ## 1.5.1
 
 ### Patch Changes

--- a/apps/extension/package.json
+++ b/apps/extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@movar/extension",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/extension/safari/Movar/Movar.xcodeproj/project.pbxproj
+++ b/apps/extension/safari/Movar/Movar.xcodeproj/project.pbxproj
@@ -684,7 +684,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1784961373;
+				CURRENT_PROJECT_VERSION = 1785959230;
 				DEVELOPMENT_TEAM = RQSR4UU3VB;
 				CODE_SIGN_ENTITLEMENTS = "iOS (Extension)/Movar Extension.entitlements";
 				REGISTER_APP_GROUPS = YES;
@@ -698,7 +698,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.5.1;
+				MARKETING_VERSION = 1.5.2;
 				OTHER_LDFLAGS = (
 					"-framework",
 					SafariServices,
@@ -720,7 +720,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1784961373;
+				CURRENT_PROJECT_VERSION = 1785959230;
 				DEVELOPMENT_TEAM = RQSR4UU3VB;
 				CODE_SIGN_ENTITLEMENTS = "iOS (Extension)/Movar Extension.entitlements";
 				REGISTER_APP_GROUPS = YES;
@@ -734,7 +734,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.5.1;
+				MARKETING_VERSION = 1.5.2;
 				OTHER_LDFLAGS = (
 					"-framework",
 					SafariServices,
@@ -759,7 +759,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1784961373;
+				CURRENT_PROJECT_VERSION = 1785959230;
 				DEVELOPMENT_TEAM = RQSR4UU3VB;
 				CODE_SIGN_ENTITLEMENTS = "iOS (App)/Movar.entitlements";
 				REGISTER_APP_GROUPS = YES;
@@ -776,7 +776,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.5.1;
+				MARKETING_VERSION = 1.5.2;
 				OTHER_LDFLAGS = (
 					"-framework",
 					SafariServices,
@@ -802,7 +802,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1784961373;
+				CURRENT_PROJECT_VERSION = 1785959230;
 				DEVELOPMENT_TEAM = RQSR4UU3VB;
 				CODE_SIGN_ENTITLEMENTS = "iOS (App)/Movar.entitlements";
 				REGISTER_APP_GROUPS = YES;
@@ -819,7 +819,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.5.1;
+				MARKETING_VERSION = 1.5.2;
 				OTHER_LDFLAGS = (
 					"-framework",
 					SafariServices,
@@ -844,7 +844,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1784961373;
+				CURRENT_PROJECT_VERSION = 1785959230;
 				DEVELOPMENT_TEAM = RQSR4UU3VB;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -861,7 +861,7 @@
 					"@executable_path/../../../../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 11.0;
-				MARKETING_VERSION = 1.5.1;
+				MARKETING_VERSION = 1.5.2;
 				OTHER_LDFLAGS = (
 					"-framework",
 					SafariServices,
@@ -882,7 +882,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1784961373;
+				CURRENT_PROJECT_VERSION = 1785959230;
 				DEVELOPMENT_TEAM = RQSR4UU3VB;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -899,7 +899,7 @@
 					"@executable_path/../../../../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 11.0;
-				MARKETING_VERSION = 1.5.1;
+				MARKETING_VERSION = 1.5.2;
 				OTHER_LDFLAGS = (
 					"-framework",
 					SafariServices,
@@ -922,7 +922,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1784961373;
+				CURRENT_PROJECT_VERSION = 1785959230;
 				DEVELOPMENT_TEAM = RQSR4UU3VB;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -939,7 +939,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 11.0;
-				MARKETING_VERSION = 1.5.1;
+				MARKETING_VERSION = 1.5.2;
 				OTHER_LDFLAGS = (
 					"-framework",
 					SafariServices,
@@ -965,7 +965,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1784961373;
+				CURRENT_PROJECT_VERSION = 1785959230;
 				DEVELOPMENT_TEAM = RQSR4UU3VB;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -982,7 +982,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 11.0;
-				MARKETING_VERSION = 1.5.1;
+				MARKETING_VERSION = 1.5.2;
 				OTHER_LDFLAGS = (
 					"-framework",
 					SafariServices,

--- a/apps/extension/store-assets/apple/WHATS-NEW.md
+++ b/apps/extension/store-assets/apple/WHATS-NEW.md
@@ -17,6 +17,42 @@ user's voice (what changed for them), not the developer changelog.
 
 ---
 
+## 1.5.2
+
+Bug-fix release — no new capability. If the 1.5.1 build was never submitted to
+App Store Connect, fold its YouTube bullet (below) into this block before pasting,
+since Apple users would be coming from 1.5.0.
+
+### Українська (uk)
+
+```
+Що нового у версії 1.5.2
+
+• Зміна мов тепер одразу застосовується до вже відкритих вкладок — більше не треба перезавантажувати сторінку.
+• Прихований вміст залишається прихованим після зміни мови інтерфейсу Мовара.
+• «Показати все на цій сторінці» більше не переноситься на наступну сторінку на сайтах, що не перезавантажуються.
+• Мовар більше не перериває пошук Google на сторінках, де є лише картки товарів.
+• Заблокована мова більше не проходить через регіональні варіанти в перемикачах мов на сайтах.
+• Виправлено кілька випадків, коли після «Показати все» ламалася верстка сайту або його власний перемикач мов.
+• «Завжди пропускати цей сайт» тепер знімає активну паузу, тож Мовар одразу відновлює роботу, коли ви прибираєте сайт із винятків.
+• Точніший підрахунок прихованих елементів і краща робота з клавіатурою в налаштуваннях.
+```
+
+### English (en)
+
+```
+What's New in 1.5.2
+
+• Changing your languages now applies to tabs you already have open — no reload needed.
+• Concealed content stays concealed after you switch Movar's interface language.
+• "Show everything on this page" no longer carries over to the next page on sites that don't reload.
+• Movar no longer interrupts Google searches on results pages that contain only product cards.
+• A blocked language no longer slips through regional variants in sites' own language switchers.
+• Fixed several cases where revealing content left a site's layout or its own language switcher broken.
+• "Always skip this site" now clears an active pause, so Movar resumes right away when you un-skip the site.
+• More accurate hidden-item counts, and better keyboard handling in settings.
+```
+
 ## 1.5.1
 
 ### Українська (uk)

--- a/apps/marketing/CHANGELOG.md
+++ b/apps/marketing/CHANGELOG.md
@@ -1,0 +1,8 @@
+# @movar/marketing
+
+## 0.0.1
+
+### Patch Changes
+
+- Updated dependencies [f558db5]
+  - @movar/ui@0.0.1

--- a/apps/marketing/package.json
+++ b/apps/marketing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@movar/marketing",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/safari-host-app/CHANGELOG.md
+++ b/apps/safari-host-app/CHANGELOG.md
@@ -1,0 +1,15 @@
+# @movar/safari-host-app
+
+## 0.0.1
+
+### Patch Changes
+
+- Updated dependencies [c4689b0]
+- Updated dependencies [3a5ca20]
+- Updated dependencies [f558db5]
+  - @movar/lang-detect@0.0.1
+  - @movar/options-ui@0.0.1
+  - @movar/ui@0.0.1
+  - @movar/i18n@0.0.1
+  - @movar/settings@0.0.1
+  - @movar/app-shell@0.0.1

--- a/apps/safari-host-app/package.json
+++ b/apps/safari-host-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@movar/safari-host-app",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "private": true,
   "type": "module",
   "description": "Unified React host app for the Safari Web Extension wrapper (macOS/iOS) — Detector / Settings / About tabs bundled to a single CSP-safe JS + CSS the WKWebView loads from the app bundle. Replaces the static Main.html/Style.css/Script.js.",

--- a/packages/app-shell/CHANGELOG.md
+++ b/packages/app-shell/CHANGELOG.md
@@ -1,0 +1,9 @@
+# @movar/app-shell
+
+## 0.0.1
+
+### Patch Changes
+
+- Updated dependencies [f558db5]
+  - @movar/ui@0.0.1
+  - @movar/i18n@0.0.1

--- a/packages/app-shell/package.json
+++ b/packages/app-shell/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@movar/app-shell",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "private": true,
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/events/CHANGELOG.md
+++ b/packages/events/CHANGELOG.md
@@ -1,0 +1,9 @@
+# @movar/events
+
+## 0.0.1
+
+### Patch Changes
+
+- Updated dependencies [c4689b0]
+- Updated dependencies [3a5ca20]
+  - @movar/lang-detect@0.0.1

--- a/packages/events/package.json
+++ b/packages/events/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@movar/events",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "private": true,
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/host-match/CHANGELOG.md
+++ b/packages/host-match/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @movar/host-match
 
+## 0.1.1
+
+### Patch Changes
+
+- afa3888: host-match: strip a trailing dot from FQDN hostnames so `isGoogleHost`/`isYouTubeHost` match `google.com.` and `youtube.com.` (previously the content-script site rule and model chunk silently no-op'd on trailing-dot hosts). Closes #295.
+
 ## 0.1.0
 
 ### Minor Changes

--- a/packages/host-match/package.json
+++ b/packages/host-match/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@movar/host-match",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": true,
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/i18n/CHANGELOG.md
+++ b/packages/i18n/CHANGELOG.md
@@ -1,0 +1,11 @@
+# @movar/i18n
+
+## 0.0.1
+
+### Patch Changes
+
+- Updated dependencies [c4689b0]
+- Updated dependencies [3a5ca20]
+  - @movar/lang-detect@0.0.1
+  - @movar/events@0.0.1
+  - @movar/settings@0.0.1

--- a/packages/i18n/package.json
+++ b/packages/i18n/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@movar/i18n",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "private": true,
   "type": "module",
   "main": "./src/index.tsx",

--- a/packages/lang-detect/CHANGELOG.md
+++ b/packages/lang-detect/CHANGELOG.md
@@ -1,0 +1,8 @@
+# @movar/lang-detect
+
+## 0.0.1
+
+### Patch Changes
+
+- c4689b0: lang-detect/chrome-ai: honor the AbortSignal / detection time budget so a hung on-device model no longer stalls detection past the intended deadline — an aborted or over-budget detection now resolves to "no detection" instead of blocking. Closes #292.
+- 3a5ca20: lang-detect/chrome-ai: reject Chrome's `und` (undetermined) result and validate the detected code against the known LanguageCode set before returning, mirroring the franc engine — so an undetermined result is treated as "no detection" instead of a positive `und` that violates the type contract and defeats the loop guard. Closes #305.

--- a/packages/lang-detect/package.json
+++ b/packages/lang-detect/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@movar/lang-detect",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "private": true,
   "type": "module",
   "sideEffects": false,

--- a/packages/lang-pickers/CHANGELOG.md
+++ b/packages/lang-pickers/CHANGELOG.md
@@ -1,0 +1,9 @@
+# @movar/lang-pickers
+
+## 0.0.1
+
+### Patch Changes
+
+- Updated dependencies [c4689b0]
+- Updated dependencies [3a5ca20]
+  - @movar/lang-detect@0.0.1

--- a/packages/lang-pickers/package.json
+++ b/packages/lang-pickers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@movar/lang-pickers",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "private": true,
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/options-ui/CHANGELOG.md
+++ b/packages/options-ui/CHANGELOG.md
@@ -1,0 +1,14 @@
+# @movar/options-ui
+
+## 0.0.1
+
+### Patch Changes
+
+- f558db5: options: restore keyboard focus after reordering or removing a priority language, so keyboard/screen-reader users no longer get dropped to <body> when a move lands on a boundary or a row is removed (WCAG 2.4.3). Closes #313.
+- Updated dependencies [c4689b0]
+- Updated dependencies [3a5ca20]
+- Updated dependencies [f558db5]
+  - @movar/lang-detect@0.0.1
+  - @movar/ui@0.0.1
+  - @movar/i18n@0.0.1
+  - @movar/settings@0.0.1

--- a/packages/options-ui/package.json
+++ b/packages/options-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@movar/options-ui",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "private": true,
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/page-content/CHANGELOG.md
+++ b/packages/page-content/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @movar/page-content
 
+## 0.0.2
+
+### Patch Changes
+
+- 55b2740: page-content/serialize: stop misclassifying inline `<svg>` elements as hidden. `isHiddenElement` now guards the `hidden` IDL check with `el instanceof HTMLElement` (the `hidden` property doesn't exist on `SVGElement`), so a container whose only remaining visible content is a lone `<svg>` icon is no longer judged empty and hard-hidden. Closes #291.
+- Updated dependencies [c4689b0]
+- Updated dependencies [3a5ca20]
+- Updated dependencies [afa3888]
+  - @movar/lang-detect@0.0.1
+  - @movar/host-match@0.1.1
+
 ## 0.0.1
 
 ### Patch Changes

--- a/packages/page-content/package.json
+++ b/packages/page-content/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@movar/page-content",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "private": true,
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/page-language/CHANGELOG.md
+++ b/packages/page-language/CHANGELOG.md
@@ -1,0 +1,10 @@
+# @movar/page-language
+
+## 0.0.1
+
+### Patch Changes
+
+- Updated dependencies [c4689b0]
+- Updated dependencies [3a5ca20]
+  - @movar/lang-detect@0.0.1
+  - @movar/lang-pickers@0.0.1

--- a/packages/page-language/package.json
+++ b/packages/page-language/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@movar/page-language",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "private": true,
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/settings/CHANGELOG.md
+++ b/packages/settings/CHANGELOG.md
@@ -1,0 +1,9 @@
+# @movar/settings
+
+## 0.0.1
+
+### Patch Changes
+
+- Updated dependencies [c4689b0]
+- Updated dependencies [3a5ca20]
+  - @movar/lang-detect@0.0.1

--- a/packages/settings/package.json
+++ b/packages/settings/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@movar/settings",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "private": true,
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -1,0 +1,7 @@
+# @movar/ui
+
+## 0.0.1
+
+### Patch Changes
+
+- f558db5: options: restore keyboard focus after reordering or removing a priority language, so keyboard/screen-reader users no longer get dropped to <body> when a move lands on a boundary or a row is removed (WCAG 2.4.3). Closes #313.

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@movar/ui",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "private": true,
   "type": "module",
   "main": "./src/index.ts",


### PR DESCRIPTION
## Summary

Cuts **`@movar/extension` v1.5.2** — a pure bug-fix release that also **folds in the never-published v1.5.1**.

v1.5.1 was tagged (`extension-v1.5.1` → `3575d61`) but no GitHub Release was ever published on that tag, and [`release.yml`](.github/workflows/release.yml) triggers on `release: [published]`, not on a tag push — so no store job ran and 1.5.1 never reached a user. The stores have been on v1.5.0 since 2026-07-21. Rather than submit twice, v1.5.2 carries both: its own 25 fixes plus 1.5.1's YouTube fix (which keeps its own `## 1.5.1` CHANGELOG section, since that's accurate history).

**Contents** — 25 changesets, all `patch`, closing #288–#316:

- **Conceal / curtain correctness** — no spurious curtain over emptied containers (#296), superseded scans no longer leave cards `CHECKED` (#289), `overflow-x`/`-y` longhands restored individually (#302), inline `<svg>` no longer misread as hidden (#291), cleanup wrappers excluded from the hidden count (#297)
- **Lifecycle races** — re-conceal after a UI-language change (#288), "Show everything" reset on same-pathname SPA navs (#314), content-locale load retried instead of memoizing a failure (#316), empty-SERP-retry suspension respected on service-worker wake (#301), serialized correction-log writer closing a cross-tab lost update (#310), migrated legacy loop-guard entries can finally TTL-expire (#304)
- **Language switching / pickers** — blocked language no longer leaks via regional variants (#293), correct target language recorded on a picker redirect (#299), original inline `display` restored on reveal (#300), priority/blocked changes re-applied to open tabs (#290), snooze cleared when exempting a host (#298)
- **Security** — language-switch redirect targets validated to `http:`/`https:`, closing a confused-deputy open redirect via an injected `<link rel="alternate">` (#306)
- **Platform** — `isGoogleHost`/`isYouTubeHost` match trailing-dot FQDNs (#295), Chrome AI detector honours the abort/time budget (#292) and rejects `und` (#305), Safari `seenRev` advanced only after a successful sync write (#315), Firefox onboarding shows the right browser label (#294), keyboard focus restored after a priority move/remove — WCAG 2.4.3 (#313)

**No new capability and no manifest-permission change since v1.5.0**, so the permission-justification surfaces need no re-sync.

## Notes for the reviewer

- **The dependent-package bump cascade is expected.** This is the first cut with package-scoped changesets in quantity (`lang-detect`, `host-match`, `page-content`, `options-ui`, `ui`), so the repo's `updateInternalDependencies: "patch"` cascades a patch to every dependent — that's why members without their own changeset move `0.0.0 → 0.0.1` and pick up a `CHANGELOG.md`. Past releases carried extension-only changesets, so the cascade never showed. All are private, never-published packages; only `@movar/extension`'s version is load-bearing.
- **Safari** `MARKETING_VERSION` is hand-bumped to `1.5.2` across all 8 build configs, with a fresh increasing build number (`1785959230`).
- **App Store "What's New"** gains a bilingual (uk + en) 1.5.2 block. It carries a note: if the 1.5.1 build was never submitted to App Store Connect either, fold its YouTube bullet in before pasting, since Apple users would be coming from 1.5.0. **Please confirm whether Safari 1.5.1 was submitted** — I couldn't verify that from the repo.
- **The Ukrainian store listings are stale.** The «Мовар» rename changed `store-assets/copy/summary.uk.md` and `description.uk.md`; the CWS, AMO, and Edge Ukrainian listings still carry the old wordmark and should be re-uploaded with this submission.

## After merge

1. Tag `extension-v1.5.2` on the merge commit and push it.
2. **Publish** the GitHub Release on that tag — a bare tag push submits nothing.
3. Approve the `production` gate on each store job.
4. Submit Safari locally through Xcode Organizer (`release-safari` 401s on headless provisioning).
5. Update `docs/ROADMAP.md`'s "Last published" line to name v1.5.2.

## Test plan

- [x] `pnpm validate` clean (typecheck + lint + test + publint + README/SOURCE parity + suppressions + release governance + action pins + content bundle)
- [x] `pnpm check:readme` — metrics block up to date, all product promises hold
- [x] Full pre-push suite passed (build, e2e-fast, fallow metrics audit)
- [x] Safari version bump verified: 8/8 `MARKETING_VERSION` and 8/8 `CURRENT_PROJECT_VERSION` updated, no stale values left
- [x] Pushing to `release/**` runs the Release workflow's implicit dry-run — build + validate + audit, store jobs excluded by their `if:` guard

🤖 Generated with [Claude Code](https://claude.com/claude-code)