### PR TITLE
fix(lang-pickers): never activate a collapsed switcher's dropdown toggle

### DIFF
--- a/.changeset/lang-pickers-no-disclosure-toggle-target.md
+++ b/.changeset/lang-pickers-no-disclosure-toggle-target.md
@@ -1,0 +1,9 @@
+---
+'@movar/lang-pickers': patch
+---
+
+lang-pickers: never hand back a collapsed switcher's dropdown toggle as a redirect target, and stop reading an off-canvas drawer as a blocking language gate.
+
+A collapsed switcher labels its toggle with the language the page is **already** in, so on a page already serving the preferred language that toggle was the picker's only matching entry — `pickRedirectTarget` returned it and `trySatisfyLanguageGate` (#355, the one pass that acts on an already-correct page) clicked it, popping the site's language menu open unprompted. Disclosure controls (`aria-haspopup`, `aria-expanded`, `data-toggle`/`data-bs-toggle="dropdown"`, `role="combobox"`) are now refused, and a priority language that is present but inert ends the search instead of falling through — switching an already-Ukrainian page to English would have been a downgrade.
+
+`findGateOverlay` also measured only a box's width and height, so a parked off-canvas nav drawer (full-viewport-sized, `translateX(-100%)`) read as page-blocking. It now measures the overlay's actual overlap with the viewport.

--- a/apps/extension/src/lib/language-gate.test.ts
+++ b/apps/extension/src/lib/language-gate.test.ts
@@ -123,6 +123,67 @@ describe('trySatisfyLanguageGate', () => {
     expect(deps.record).not.toHaveBeenCalled();
   });
 
+  it('does not activate a collapsed dropdown toggle — that would just open the menu', async () => {
+    // The regression this pass introduced: a `.btn-group` switcher (tradeport,
+    // yato) inside a full-viewport fixed box, on a page ALREADY serving the
+    // preferred language. The toggle wears the current language, so it is the
+    // picker's only `uk` entry — and clicking it pops the menu open in the
+    // visitor's face instead of switching anything. `pickRedirectTarget` now
+    // refuses disclosure controls, so the gate finds nothing to satisfy.
+    document.body.innerHTML = `
+      <div id="backdrop" style="position:fixed;inset:0;">
+        <div class="btn-group">
+          <button id="toggle" class="dropdown-toggle" data-toggle="dropdown" data-lang="uk">УКР</button>
+          <ul class="dropdown-menu">
+            <li><a id="ru" href="https://shop.example/thing" data-lang="ru">Русский</a></li>
+          </ul>
+        </div>
+      </div>
+    `;
+    const backdrop = document.querySelector('#backdrop');
+    if (backdrop) stubFullViewport(backdrop);
+    const clicked = vi.fn();
+    document.querySelector('#toggle')?.addEventListener('click', clicked);
+    const deps = makeDeps();
+
+    expect(await trySatisfyLanguageGate(deps, findLanguagePickers(), settings)).toBe(false);
+    expect(clicked).not.toHaveBeenCalled();
+    expect(deps.markSatisfied).not.toHaveBeenCalled();
+    expect(deps.record).not.toHaveBeenCalled();
+  });
+
+  it('does nothing for a full-size overlay parked off-canvas (a closed drawer)', async () => {
+    // Same shape as the gate, but the box sits outside the viewport — a mobile
+    // nav drawer at rest. It blocks nothing, so it is not a gate.
+    const { innerWidth: width, innerHeight: height } = globalThis;
+    document.body.innerHTML = `
+      <div id="drawer" style="position:fixed;top:0;left:0;">
+        <a id="uk" href="https://shop.example/ua/thing">Українська</a>
+        <a id="ru" href="https://shop.example/thing">Русский</a>
+      </div>
+    `;
+    const drawer = document.querySelector('#drawer');
+    if (drawer)
+      drawer.getBoundingClientRect = (): DOMRect =>
+        ({
+          x: -width,
+          y: 0,
+          top: 0,
+          left: -width,
+          right: 0,
+          bottom: height,
+          width,
+          height,
+        }) as DOMRect;
+    const clicked = vi.fn();
+    document.querySelector('#uk')?.addEventListener('click', clicked);
+    const deps = makeDeps();
+
+    expect(await trySatisfyLanguageGate(deps, findLanguagePickers(), settings)).toBe(false);
+    expect(clicked).not.toHaveBeenCalled();
+    expect(deps.markSatisfied).not.toHaveBeenCalled();
+  });
+
   it('does nothing once the visitor has interacted with the page', async () => {
     const { pickers, uk } = setupGate();
     const clicked = vi.fn();

--- a/docs/REFACTORING-QUEUE.md
+++ b/docs/REFACTORING-QUEUE.md
@@ -13,7 +13,7 @@ summary: Auto-generated agent task queue from fallow refactoring targets.
 - Source report: [.metrics/fallow.md](../.metrics/fallow.md)
 - Health score: **81 (B)**
 - Targets surfaced: **1** (parsed: 1)
-- Generated: 2026-08-07T11:55:49.548Z
+- Generated: 2026-08-07T15:24:35.003Z
 
 ## How to consume
 

--- a/packages/lang-pickers/AGENTS.md
+++ b/packages/lang-pickers/AGENTS.md
@@ -48,7 +48,10 @@ also works directly, e.g. `@movar/lang-pickers/extract`):
   `findLanguagePickers(root?)`.
 - **build-model** — `buildPickerModel(pickers, currentHref)`.
 - **detect-page-language** — `detectPickerActiveLanguage(model)`.
-- **redirect** — `pickRedirectTarget(pickers, priority)`.
+- **redirect** — `pickRedirectTarget(pickers, priority)`. Returns the first
+  priority language with an _activatable_ entry; disclosure controls (dropdown
+  toggles) never qualify, and a priority language that is present but inert
+  stops the search rather than falling through to a worse one.
 - **gate** — `findGateOverlay(picker, viewport?)`, `MIN_GATE_COVERAGE`, type
   `GateViewport`. Answers "is this picker inside an overlay that blocks the page
   until you choose?" — the interstitial-modal pattern. Pure geometry + computed
@@ -127,6 +130,19 @@ and `<html lang>` so DOM state never leaks between cases.
   `getBoundingClientRect` there is a zero box, so unit tests must stub the rect
   per element (see `src/picker.gate.test.ts`). The native-`<dialog>` branch is
   gated on `:modal`, which jsdom throws on, so that path is e2e-only.
+- **Gate geometry measures OVERLAP with the viewport, not box size.** A closed
+  off-canvas drawer (`position:fixed` + full size + `translateX(-100%)`) is a
+  full-viewport-sized box that blocks nothing, and mobile drawers routinely
+  carry the switcher — so the rect is clamped to the viewport before the
+  `MIN_GATE_COVERAGE` comparison. Stub `left`/`top` in tests, not just w/h.
+- **A collapsed switcher's toggle wears the CURRENT language.** On a page
+  already serving the preferred language, `<button class="dropdown-toggle">УКР`
+  is the picker's only `uk` entry, so `pickRedirectTarget` would hand it back
+  and activating it just opens the menu. It is rejected via
+  `DISCLOSURE_SELECTOR` (`aria-haspopup` ≠ false, `aria-expanded`,
+  `data-toggle`/`data-bs-toggle="dropdown"`, `role="combobox"`). Only
+  `trySatisfyLanguageGate` acts on an already-correct page, which is why the
+  symptom showed up there.
 - **Key test files**: `src/picker.classify.test.ts` (element-level signal
   matrix), `src/picker.redirect.test.ts` (redirect + bosch-style form-POST
   fallback); real-site regression tests live in

--- a/packages/lang-pickers/src/gate.ts
+++ b/packages/lang-pickers/src/gate.ts
@@ -52,12 +52,22 @@ function isVisible(style: CSSStyleDeclaration): boolean {
   return Number.isNaN(opacity) || opacity > 0;
 }
 
+/** How much of each viewport axis the element's box actually OVERLAPS —
+ *  clamped to the viewport, so a box parked outside it contributes nothing.
+ *  Size alone is not blocking: a closed off-canvas drawer
+ *  (`position:fixed;width:100%;height:100%` + `transform:translateX(-100%)`, or
+ *  `left:-100vw`) is a full-viewport-sized box that covers nothing, and mobile
+ *  nav drawers routinely carry the language switcher. */
+function overlap(start: number, end: number, extent: number): number {
+  return Math.min(end, extent) - Math.max(start, 0);
+}
+
 function coversViewport(el: HTMLElement, viewport: GateViewport): boolean {
   if (viewport.width <= 0 || viewport.height <= 0) return false;
   const rect = el.getBoundingClientRect();
   return (
-    rect.width >= viewport.width * MIN_GATE_COVERAGE &&
-    rect.height >= viewport.height * MIN_GATE_COVERAGE
+    overlap(rect.left, rect.right, viewport.width) >= viewport.width * MIN_GATE_COVERAGE &&
+    overlap(rect.top, rect.bottom, viewport.height) >= viewport.height * MIN_GATE_COVERAGE
   );
 }
 

--- a/packages/lang-pickers/src/picker.gate.test.ts
+++ b/packages/lang-pickers/src/picker.gate.test.ts
@@ -9,9 +9,18 @@ const VIEWPORT: GateViewport = { width: 1000, height: 800 };
 /** jsdom has no layout — every `getBoundingClientRect` is a zero box — so the
  *  geometry half of gate detection has to be stubbed per element. Sizes are in
  *  the same units as `VIEWPORT`. */
-function stubRect(el: Element, width: number, height: number): void {
+function stubRect(el: Element, width: number, height: number, left = 0, top = 0): void {
   el.getBoundingClientRect = (): DOMRect =>
-    ({ x: 0, y: 0, top: 0, left: 0, right: width, bottom: height, width, height }) as DOMRect;
+    ({
+      x: left,
+      y: top,
+      top,
+      left,
+      right: left + width,
+      bottom: top + height,
+      width,
+      height,
+    }) as DOMRect;
 }
 
 /** The tradeport.ua «Оберіть мову / Выберите язык» interstitial, reduced to the
@@ -107,6 +116,46 @@ describe('findGateOverlay', () => {
 
     stubRect(backdrop, VIEWPORT.width * MIN_GATE_COVERAGE, VIEWPORT.height * MIN_GATE_COVERAGE - 1);
     expect(findGateOverlay(picker, VIEWPORT)).toBeNull();
+  });
+
+  // Placement, not just size. A full-viewport-SIZED box parked outside the
+  // viewport blocks nothing — and an off-canvas nav drawer, which is exactly
+  // that shape, routinely carries the site's language switcher.
+  it.each([
+    ['parked off to the left (translateX(-100%))', -VIEWPORT.width, 0],
+    ['parked above the fold (translateY(-100%))', 0, -VIEWPORT.height],
+    ['parked just far enough left to fall under the coverage threshold', -251, 0],
+  ])('ignores a fixed full-size overlay %s', (_label, left, top) => {
+    setBody(`
+      <div id="drawer" style="position:fixed;top:0;left:0;">
+        <a href="/ua/x" hreflang="uk">Українська</a>
+        <a href="/x" hreflang="ru">Русский</a>
+      </div>
+    `);
+    const drawer = document.querySelector('#drawer');
+    if (drawer) stubRect(drawer, VIEWPORT.width, VIEWPORT.height, left, top);
+    const [picker] = findLanguagePickers();
+    expect(picker).toBeDefined();
+    if (!picker) return;
+    expect(findGateOverlay(picker, VIEWPORT)).toBeNull();
+  });
+
+  it('still accepts an overlay that overhangs the viewport on both edges', () => {
+    // A backdrop wider/taller than the viewport (e.g. `width:120vw`, or one
+    // shifted by a scrollbar) covers it completely — clamping to the viewport
+    // is what keeps the overhang from being counted or penalised.
+    setBody(`
+      <div id="backdrop" style="position:fixed;inset:0;">
+        <a href="/ua/x" hreflang="uk">Українська</a>
+        <a href="/x" hreflang="ru">Русский</a>
+      </div>
+    `);
+    const backdrop = document.querySelector('#backdrop');
+    if (backdrop) stubRect(backdrop, VIEWPORT.width + 200, VIEWPORT.height + 200, -100, -100);
+    const [picker] = findLanguagePickers();
+    expect(picker).toBeDefined();
+    if (!picker) return;
+    expect(findGateOverlay(picker, VIEWPORT)?.id).toBe('backdrop');
   });
 
   it('ignores an absolutely-positioned full-viewport box (only `fixed` blocks)', () => {

--- a/packages/lang-pickers/src/picker.redirect.test.ts
+++ b/packages/lang-pickers/src/picker.redirect.test.ts
@@ -39,6 +39,94 @@ describe('pickRedirectTarget — descend into wrappers', () => {
   });
 });
 
+describe('pickRedirectTarget — collapsed switchers', () => {
+  it('never returns a dropdown toggle — activating it only opens the menu', () => {
+    // The Bootstrap `.btn-group` shape (tradeport.ua, yato.com.ua) as it renders
+    // on a page that is ALREADY Ukrainian: the toggle wears the language you are
+    // currently in and the menu holds the alternative. The toggle is therefore
+    // the picker's only `uk` entry, so a naive priority match hands it back.
+    setBody(`
+      <div id="switcher">
+        <button id="toggle" class="dropdown-toggle" data-toggle="dropdown" data-lang="uk">УКР</button>
+        <ul class="dropdown-menu">
+          <li><a id="ru" href="/ru/x" data-lang="ru">Русский</a></li>
+        </ul>
+      </div>
+    `);
+    const pickers = findLanguagePickers();
+    // The toggle must be in the picker for this to be a real test — otherwise
+    // the null below would be a trivial "no uk entry" pass.
+    expect(pickers[0]?.links.map((l) => l.language).toSorted()).toEqual(['ru', 'uk']);
+    expect(pickRedirectTarget(pickers, ['uk'])).toBeNull();
+  });
+
+  it.each([
+    ['aria-haspopup="true"'],
+    ['aria-haspopup="menu"'],
+    ['aria-expanded="false"'],
+    ['data-toggle="dropdown"'],
+    ['data-bs-toggle="dropdown"'],
+    ['role="combobox"'],
+  ])('rejects a toggle marked with %s', (attr) => {
+    setBody(`
+      <div id="switcher">
+        <button id="toggle" ${attr} data-lang="uk">УКР</button>
+        <ul><li><a id="ru" href="/ru/x" data-lang="ru">Русский</a></li></ul>
+      </div>
+    `);
+    expect(pickRedirectTarget(findLanguagePickers(), ['uk'])).toBeNull();
+  });
+
+  it('still returns a button that merely declares it opens nothing', () => {
+    // `aria-haspopup="false"` is the explicit "I am not a menu opener" value —
+    // the guard must not read the attribute's mere presence as a toggle.
+    setBody(`
+      <div id="switcher">
+        <button id="uk-btn" aria-haspopup="false" data-lang="uk">УКР</button>
+        <button id="ru-btn" data-lang="ru">РУС</button>
+      </div>
+    `);
+    expect(pickRedirectTarget(findLanguagePickers(), ['uk'])?.target.id).toBe('uk-btn');
+  });
+
+  it('does not downgrade to a lower-priority language when the preferred one is inert', () => {
+    setBody(`
+      <div id="switcher">
+        <button id="toggle" data-toggle="dropdown" data-lang="uk">УКР</button>
+        <a id="ru" href="/ru/x" data-lang="ru">Русский</a>
+        <a id="en" href="/en/x" data-lang="en">English</a>
+      </div>
+    `);
+    const pickers = findLanguagePickers();
+    // 'uk' IS on offer — the page is already serving it, which is precisely why
+    // its only entry is the toggle. Falling through to 'en' would switch an
+    // already-Ukrainian page into English.
+    expect(pickRedirectTarget(pickers, ['uk', 'en'])).toBeNull();
+    // The same picker still resolves normally for a preference it can satisfy.
+    expect(pickRedirectTarget(pickers, ['en', 'uk'])?.target.id).toBe('en');
+  });
+
+  it('takes a usable entry from another picker rather than giving up', () => {
+    setBody(`
+      <header>
+        <div id="header-switcher">
+          <button id="toggle" data-toggle="dropdown" data-lang="uk">УКР</button>
+          <ul><li><a id="header-ru" href="/ru/x" data-lang="ru">Русский</a></li></ul>
+        </div>
+      </header>
+      <footer id="footer-switcher">
+        <a id="footer-uk" href="/uk/x" data-lang="uk">Українська</a>
+        <a id="footer-ru" href="/x" data-lang="ru">Русский</a>
+      </footer>
+    `);
+    const pickers = findLanguagePickers();
+    expect(pickers).toHaveLength(2);
+    // The header toggle is the first 'uk' entry in DOM order; skipping it must
+    // not abandon the real footer switcher behind it.
+    expect(pickRedirectTarget(pickers, ['uk'])?.target.id).toBe('footer-uk');
+  });
+});
+
 describe('pickRedirectTarget', () => {
   it('returns the highest-priority available anchor', () => {
     setBody(`

--- a/packages/lang-pickers/src/redirect.ts
+++ b/packages/lang-pickers/src/redirect.ts
@@ -1,10 +1,50 @@
 import type { LanguageCode } from '@movar/lang-detect';
-import type { Picker, PickedRedirect } from './types';
+import type { Picker, PickedRedirect, RedirectTarget } from './types';
+
+/**
+ * Attributes and roles that mark an element as a *disclosure control* — its job
+ * is to REVEAL the picker, not to choose a language. Bootstrap's
+ * `data-toggle="dropdown"` (3/4) and `data-bs-toggle` (5), plus the ARIA
+ * disclosure and combobox patterns, cover the shapes seen in the wild.
+ *
+ * This matters most on a page that is ALREADY serving the preferred language,
+ * because a collapsed switcher labels its toggle with the language you are
+ * currently in (`<button class="dropdown-toggle">УКР</button>`). That toggle is
+ * then the first — often only — entry matching the top of the priority list, so
+ * a naive match hands it back as the redirect target and activating it merely
+ * pops the menu open in the visitor's face. Nothing clicked on such a page
+ * before `trySatisfyLanguageGate` existed, which is why it surfaced with it.
+ */
+const DISCLOSURE_SELECTOR = [
+  '[aria-haspopup]:not([aria-haspopup="false"])',
+  '[aria-expanded]',
+  '[data-toggle~="dropdown"]',
+  '[data-bs-toggle~="dropdown"]',
+  '[role="combobox"]',
+].join(',');
+
+function isDisclosureControl(el: Element): boolean {
+  return el.matches(DISCLOSURE_SELECTOR);
+}
+
+/** The element to activate for one classified entry, or null when the entry
+ *  offers no way to switch INTO its language — a bare "you are here" marker, a
+ *  wrapper with nothing interactive inside, or a control that only opens the
+ *  menu (see {@link DISCLOSURE_SELECTOR}). */
+function activatableTarget(el: HTMLElement): RedirectTarget | null {
+  const clickable =
+    el instanceof HTMLAnchorElement || el instanceof HTMLButtonElement
+      ? el
+      : // Wrapper element (e.g. <li data-lang>) — look inside for an anchor or button.
+        el.querySelector<HTMLAnchorElement | HTMLButtonElement>('a[href], button');
+  if (clickable === null) return null;
+  return isDisclosureControl(clickable) ? null : clickable;
+}
 
 /** Returns the clickable element for the highest-priority language the picker
- *  actually has a link for, paired with that matched language — `lang` here,
- *  NOT `priority[0]`, since an earlier priority language may have no link at
- *  all. Callers must record the returned `language`, not the priority list's
+ *  actually has a *usable* entry for, paired with that matched language — `lang`
+ *  here, NOT `priority[0]`, since an earlier priority language may have no link
+ *  at all. Callers must record the returned `language`, not the priority list's
  *  head (issue #299). */
 export function pickRedirectTarget(
   pickers: Picker[],
@@ -12,13 +52,20 @@ export function pickRedirectTarget(
 ): PickedRedirect | null {
   const all = pickers.flatMap((p) => p.links);
   for (const lang of priority) {
-    const match = all.find((l) => l.language === lang);
-    if (!match) continue;
-    if (match.el instanceof HTMLAnchorElement) return { target: match.el, language: lang };
-    if (match.el instanceof HTMLButtonElement) return { target: match.el, language: lang };
-    // Wrapper element (e.g. <li data-lang>) — look inside for an anchor or button.
-    const inner = match.el.querySelector<HTMLAnchorElement | HTMLButtonElement>('a[href], button');
-    if (inner) return { target: inner, language: lang };
+    const matches = all.filter((l) => l.language === lang);
+    // Language absent from every picker — try the next preference down.
+    if (matches.length === 0) continue;
+    for (const match of matches) {
+      const target = activatableTarget(match.el);
+      if (target) return { target, language: lang };
+    }
+    // The page OFFERS this language but nothing here switches INTO it: every
+    // entry is an inert marker or a menu opener, which is exactly what a picker
+    // looks like when the page is already serving that language. Stop instead
+    // of falling through — activating a lower-priority language would DOWNGRADE
+    // a page that is already at the best one on offer (uk → en on an
+    // already-Ukrainian page).
+    return null;
   }
   return null;
 }

--- a/scripts/readme-metrics.snapshot.json
+++ b/scripts/readme-metrics.snapshot.json
@@ -4,13 +4,13 @@
     "score": 81,
     "grade": "B"
   },
-  "loc": 44290,
+  "loc": 44347,
   "suppressions": {
     "eslint": 43,
     "fallow": 23
   },
   "coverage": {
-    "lines": 95.1,
+    "lines": 95.2,
     "branches": 88.5
   },
   "bundle": {


### PR DESCRIPTION
Movar was popping a site's language menu open on pages that were **already** in the target language.

## Why

A collapsed language switcher labels its toggle with the language you are currently in:

```html
<div class="btn-group">
  <button class="dropdown-toggle" data-toggle="dropdown">УКР</button>   ← the only `uk` entry
  <ul class="dropdown-menu">
    <li><a href="…-ru">РУС</a></li>
  </ul>
</div>
```

On an already-Ukrainian page that toggle is therefore the picker's only `uk` entry, so `pickRedirectTarget` handed it back as the redirect target. Activating it switches nothing — it just opens the menu.

The mis-resolution is older than the symptom. Nothing clicked on an already-correct page until #355 added `trySatisfyLanguageGate`: the redirect ladder returns at [language-switch.ts:201](https://github.com/rejifald/movar/blob/main/apps/extension/src/lib/language-switch.ts#L201) unless `pageLang` is BLOCKED, and no shipped rule uses a `click` strategy. That pass is where it surfaced, but the bug sits in the model layer both paths share, so the fix goes there.

## What changed

**`pickRedirectTarget` ([redirect.ts](https://github.com/rejifald/movar/blob/claude/language-selector-redundant-open-c52936/packages/lang-pickers/src/redirect.ts))**

- Disclosure controls are never activatable targets: `aria-haspopup` (other than `"false"`), `aria-expanded`, Bootstrap's `data-toggle` / `data-bs-toggle="dropdown"`, `role="combobox"`. Their job is to reveal the picker, not to choose a language.
- A priority language that is **present but inert** ends the search instead of falling through. This matters as much as the guard itself: rejecting the `uk` toggle would otherwise have walked down to `en` and switched an already-Ukrainian page into English.
- Entries are scanned across every picker, so a header toggle no longer masks a real footer switcher behind it.

**`findGateOverlay` ([gate.ts](https://github.com/rejifald/movar/blob/claude/language-selector-redundant-open-c52936/packages/lang-pickers/src/gate.ts))** — second hole in the same pass. `coversViewport` measured `rect.width`/`rect.height` and never `left`/`top`, so a parked off-canvas nav drawer (`position:fixed`, full-viewport-sized, `translateX(-100%)`) read as page-blocking — and mobile drawers routinely carry the switcher. It now measures the overlay's real overlap with the viewport, clamped to it.

## Verification

Each guard was verified by neutering it, so the tests demonstrably catch the real defect rather than just passing alongside it:

| Guard disabled | Result |
| --- | --- |
| disclosure check | 9 redirect tests fail |
| overlap clamp | 3 gate tests fail |

The #354 tradeport gate still fires: `language-gate.test.ts` clicks «Українська» in the modal while leaving that same capture's `data-toggle="dropdown"` header switcher untouched — exactly the discrimination that was missing.

Full repo suite green (17 projects, 1359 extension + 92 lang-pickers), plus typecheck, lint, prettier, `check:readme`, `check:suppressions`. Pre-push: build ✓, offline e2e 20/20 ✓, `fallow audit` clean on all 9 changed files.

Metrics snapshot refreshed: coverage 95.1 → 95.2% lines (branches unchanged at 88.5), LOC 44290 → 44347, health score unchanged at 81.

## Trade-off worth a second opinion

Rejecting `aria-expanded` / `aria-haspopup` outright means a site that puts those on a switcher that genuinely *is* a language link gets skipped. That's rare, and the failure mode is "Movar does nothing" rather than "Movar clicks something you didn't ask for" — the safe direction for a pass that acts unprompted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
