### PR TITLE
chore(release): extension v1.5.3

### DIFF
--- a/.changeset/lang-pickers-no-disclosure-toggle-target.md
+++ b/.changeset/lang-pickers-no-disclosure-toggle-target.md
@@ -1,9 +1,0 @@
----
-'@movar/lang-pickers': patch
----
-
-lang-pickers: never hand back a collapsed switcher's dropdown toggle as a redirect target, and stop reading an off-canvas drawer as a blocking language gate.
-
-A collapsed switcher labels its toggle with the language the page is **already** in, so on a page already serving the preferred language that toggle was the picker's only matching entry — `pickRedirectTarget` returned it and `trySatisfyLanguageGate` (#355, the one pass that acts on an already-correct page) clicked it, popping the site's language menu open unprompted. Disclosure controls (`aria-haspopup`, `aria-expanded`, `data-toggle`/`data-bs-toggle="dropdown"`, `role="combobox"`) are now refused, and a priority language that is present but inert ends the search instead of falling through — switching an already-Ukrainian page to English would have been a downgrade.
-
-`findGateOverlay` also measured only a box's width and height, so a parked off-canvas nav drawer (full-viewport-sized, `translateX(-100%)`) read as page-blocking. It now measures the overlay's actual overlap with the viewport.

--- a/apps/diagnostics/CHANGELOG.md
+++ b/apps/diagnostics/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @movar/diagnostics
 
+## 0.0.3
+
+### Patch Changes
+
+- Updated dependencies [a52de05]
+  - @movar/lang-pickers@0.0.2
+  - @movar/page-language@0.0.2
+
 ## 0.0.2
 
 ### Patch Changes

--- a/apps/diagnostics/package.json
+++ b/apps/diagnostics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@movar/diagnostics",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/extension/CHANGELOG.md
+++ b/apps/extension/CHANGELOG.md
@@ -1,5 +1,21 @@
 # @movar/extension
 
+## 1.5.3
+
+### Patch Changes
+
+- onboarding: draw the real browser UI the install steps point at.
+
+  The first-run page's step illustrations were four abstract grey-bar shapes shared across every browser, so a Firefox user was shown a Chrome menu and an iPhone user a desktop one. Each flow now gets a recreation of the interface it actually points at — Chrome's toolbar and site-access menu, Firefox's unified-extensions panel and about:addons permissions, the macOS Safari Extensions pane, the iOS Settings screen — drawn from each platform's own palette and metrics, in the page's language, light and dark.
+
+  The same illustrations render on the marketing site's install guide, so the pre-install and post-install guidance now show the same picture for the same step instead of being kept in step by hand.
+
+- Updated dependencies [a52de05]
+- Updated dependencies
+  - @movar/lang-pickers@0.0.2
+  - @movar/browser-ui@0.0.1
+  - @movar/page-language@0.0.2
+
 ## 1.5.2
 
 ### Patch Changes

--- a/apps/extension/package.json
+++ b/apps/extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@movar/extension",
-  "version": "1.5.2",
+  "version": "1.5.3",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/marketing/CHANGELOG.md
+++ b/apps/marketing/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @movar/marketing
 
+## 0.0.2
+
+### Patch Changes
+
+- Updated dependencies
+  - @movar/browser-ui@0.0.1
+
 ## 0.0.1
 
 ### Patch Changes

--- a/apps/marketing/package.json
+++ b/apps/marketing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@movar/marketing",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/browser-ui/CHANGELOG.md
+++ b/packages/browser-ui/CHANGELOG.md
@@ -1,0 +1,11 @@
+# @movar/browser-ui
+
+## 0.0.1
+
+### Patch Changes
+
+- onboarding: draw the real browser UI the install steps point at.
+
+  The first-run page's step illustrations were four abstract grey-bar shapes shared across every browser, so a Firefox user was shown a Chrome menu and an iPhone user a desktop one. Each flow now gets a recreation of the interface it actually points at — Chrome's toolbar and site-access menu, Firefox's unified-extensions panel and about:addons permissions, the macOS Safari Extensions pane, the iOS Settings screen — drawn from each platform's own palette and metrics, in the page's language, light and dark.
+
+  The same illustrations render on the marketing site's install guide, so the pre-install and post-install guidance now show the same picture for the same step instead of being kept in step by hand.

--- a/packages/browser-ui/package.json
+++ b/packages/browser-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@movar/browser-ui",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "private": true,
   "type": "module",
   "sideEffects": [

--- a/packages/lang-pickers/CHANGELOG.md
+++ b/packages/lang-pickers/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @movar/lang-pickers
 
+## 0.0.2
+
+### Patch Changes
+
+- a52de05: lang-pickers: never hand back a collapsed switcher's dropdown toggle as a redirect target, and stop reading an off-canvas drawer as a blocking language gate.
+
+  A collapsed switcher labels its toggle with the language the page is **already** in, so on a page already serving the preferred language that toggle was the picker's only matching entry — `pickRedirectTarget` returned it and `trySatisfyLanguageGate` (#355, the one pass that acts on an already-correct page) clicked it, popping the site's language menu open unprompted. Disclosure controls (`aria-haspopup`, `aria-expanded`, `data-toggle`/`data-bs-toggle="dropdown"`, `role="combobox"`) are now refused, and a priority language that is present but inert ends the search instead of falling through — switching an already-Ukrainian page to English would have been a downgrade.
+
+  `findGateOverlay` also measured only a box's width and height, so a parked off-canvas nav drawer (full-viewport-sized, `translateX(-100%)`) read as page-blocking. It now measures the overlay's actual overlap with the viewport.
+
 ## 0.0.1
 
 ### Patch Changes

--- a/packages/lang-pickers/package.json
+++ b/packages/lang-pickers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@movar/lang-pickers",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "private": true,
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/page-language/CHANGELOG.md
+++ b/packages/page-language/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @movar/page-language
 
+## 0.0.2
+
+### Patch Changes
+
+- Updated dependencies [a52de05]
+  - @movar/lang-pickers@0.0.2
+
 ## 0.0.1
 
 ### Patch Changes

--- a/packages/page-language/package.json
+++ b/packages/page-language/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@movar/page-language",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "private": true,
   "type": "module",
   "main": "./src/index.ts",


### PR DESCRIPTION
Cuts **v1.5.3** for Chrome / Firefox / Edge.

## What reaches users

**Onboarding illustrations redrawn.** The first-run page's step illustrations were four abstract grey-bar shapes shared across every browser, so a Firefox user was shown a Chrome menu and an iPhone user a desktop one. Each flow now gets a recreation of the interface it actually points at — Chrome's toolbar and site-access menu, Firefox's unified-extensions panel and about:addons permissions, the macOS Safari Extensions pane, the iOS Settings screen — drawn from each platform's own palette and metrics, in the page's language, light and dark. (#359)

**Language-picker redirect fix.** A collapsed switcher labels its toggle with the language the page is *already* in, so on an already-correct page Movar clicked it and popped the site's language menu open unprompted. Also stops reading a parked off-canvas nav drawer as a page-blocking language gate. Landed in #358 and reaches users for the first time here.

## Scope

**Safari stays on 1.5.2, by decision.** Its submission is manual through Xcode Organizer and `release-safari` parks on headless provisioning, so it's cut separately rather than dragged along. `MARKETING_VERSION` and the App Store "What's New" are deliberately untouched — nothing to paste into App Store Connect for this one.

The dependency bumps across diagnostics / marketing / lang-pickers / page-language / browser-ui are changesets cascading a patch to every dependent, as expected.

## After merge

Pushing this branch only dry-runs the release workflow. The store submission fires on a **published GitHub Release** — a pushed tag alone ships nothing (v1.5.1 was tagged, never published, and reached no store). I'll publish `extension-v1.5.3` once this is merged; the store jobs then park on the `production` environment approval, which is yours.

🤖 Generated with [Claude Code](https://claude.com/claude-code)