### PR TITLE
fix(e2e): assert YouTube's settled outcome, not its transient hl param

### DIFF
--- a/apps/e2e/src/live/sites.spec.ts
+++ b/apps/e2e/src/live/sites.spec.ts
@@ -82,17 +82,10 @@ async function navigateAndSettleMovar(
       /* continue: a missing URL transition is the previous test's concern,
          not this one's. */
     });
-    // YouTube's polymer router can match the waitForURL pattern on a
-    // transient mid-redirect URL. Add a positive structural signal for
-    // YouTube to ensure the final URL truly includes `hl=uk`.
-    if (page.url().includes('youtube.com')) {
-      await page
-        .waitForFunction(() => location.search.includes('hl=uk'), undefined, { timeout: 5_000 })
-        .catch(() => {
-          /* best-effort; if the param never lands, the URL assertion in
-             test 3 will catch it */
-        });
-    }
+    // NOTE: no fixture asserts a param that only exists transiently anymore.
+    // YouTube — whose polymer router strips Movar's hl/gl back off via
+    // replaceState — settles on the BARE url by design (docs/pitfalls.md §5)
+    // and asserts its outcome via `afterMovar.htmlLangPrefix` instead.
   }
   await page.waitForLoadState('domcontentloaded');
   await waitForMovarSettled(page, { timeoutMs: 10_000 });

--- a/apps/e2e/src/live/sites/youtube.ts
+++ b/apps/e2e/src/live/sites/youtube.ts
@@ -26,7 +26,15 @@ export const siteYouTube: SiteFixture = {
     bodyDetected: ['ru', 'unknown'],
   },
   afterMovar: {
-    url: /[?&]hl=uk\b/,
+    // The SETTLED state, not the transient one: Movar rewrites the URL with
+    // hl=uk&gl=UA, YouTube's polymer router strips the params back off via
+    // history.replaceState, and the loop guard keeps that bare URL settled
+    // (docs/pitfalls.md §5). Asserting `hl=uk` in the FINAL url therefore
+    // raced the strip — it passed only when the readout sampled inside the
+    // params window. The rewrite's real, durable outcome is the interface
+    // language; the mechanism='search' CorrectionEvent (test 2) is what
+    // proves the rewrite itself fired.
+    htmlLangPrefix: ['uk'],
     minHiddenLinks: 0,
     // At least one RU video card should be blurred. Loose threshold —
     // YouTube's ranking shifts daily; tightening this would flake.


### PR DESCRIPTION
The live YouTube switches-language spec raced its readout against the polymer router's param strip — the settled URL is bare by design (pitfalls §5), and the guard-retention fix in v1.6.0 regularised the timing enough to expose the race deterministically. Assert the durable outcome (`htmlLangPrefix: ['uk']`) instead; the `mechanism='search'` correction event in test 2 is what proves the rewrite fired. Verified live: all four YouTube specs green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)