### PR TITLE
chore(release): extension v1.6.1

### DIFF
--- a/.changeset/capability-chunk-retry-and-gap-sentinel.md
+++ b/.changeset/capability-chunk-retry-and-gap-sentinel.md
@@ -1,7 +1,0 @@
----
-'@movar/extension': patch
----
-
-Recover from a failed capability-chunk load instead of disabling concealment for the page's life, and leave a diagnosable mark when it happens.
-
-A dynamic `import()` that failed was memoized as `null`, so one transient miss (cold service worker, a chunk fetch racing a navigation) permanently switched content filtering off in that tab — and the facade's `!contentModel` early return left no trace, producing a DOM identical to a clean, fully-scanned page. Failures are no longer cached, and each retry gets a distinct module specifier (`?retry=N`), because the realm's module map replays a stored import failure without issuing a new fetch — so evicting only our own cache would have retried straight into the cached error. A tick that still cannot provision what concealment needs now stamps `data-movar-capability-gap` on `<html>` with the missing chunk paths, cleared as soon as a later tick succeeds.

--- a/apps/extension/CHANGELOG.md
+++ b/apps/extension/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @movar/extension
 
+## 1.6.1
+
+### Patch Changes
+
+- 2fdc552: Recover from a failed capability-chunk load instead of disabling concealment for the page's life, and leave a diagnosable mark when it happens.
+
+  A dynamic `import()` that failed was memoized as `null`, so one transient miss (cold service worker, a chunk fetch racing a navigation) permanently switched content filtering off in that tab — and the facade's `!contentModel` early return left no trace, producing a DOM identical to a clean, fully-scanned page. Failures are no longer cached, and each retry gets a distinct module specifier (`?retry=N`), because the realm's module map replays a stored import failure without issuing a new fetch — so evicting only our own cache would have retried straight into the cached error. A tick that still cannot provision what concealment needs now stamps `data-movar-capability-gap` on `<html>` with the missing chunk paths, cleared as soon as a later tick succeeds.
+
 ## 1.6.0
 
 ### Minor Changes

--- a/apps/extension/package.json
+++ b/apps/extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@movar/extension",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/extension/safari/Movar/Movar.xcodeproj/project.pbxproj
+++ b/apps/extension/safari/Movar/Movar.xcodeproj/project.pbxproj
@@ -684,7 +684,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1786286363;
+				CURRENT_PROJECT_VERSION = 1786375258;
 				DEVELOPMENT_TEAM = RQSR4UU3VB;
 				CODE_SIGN_ENTITLEMENTS = "iOS (Extension)/Movar Extension.entitlements";
 				REGISTER_APP_GROUPS = YES;
@@ -698,7 +698,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.6.0;
+				MARKETING_VERSION = 1.6.1;
 				OTHER_LDFLAGS = (
 					"-framework",
 					SafariServices,
@@ -720,7 +720,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1786286363;
+				CURRENT_PROJECT_VERSION = 1786375258;
 				DEVELOPMENT_TEAM = RQSR4UU3VB;
 				CODE_SIGN_ENTITLEMENTS = "iOS (Extension)/Movar Extension.entitlements";
 				REGISTER_APP_GROUPS = YES;
@@ -734,7 +734,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.6.0;
+				MARKETING_VERSION = 1.6.1;
 				OTHER_LDFLAGS = (
 					"-framework",
 					SafariServices,
@@ -759,7 +759,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1786286363;
+				CURRENT_PROJECT_VERSION = 1786375258;
 				DEVELOPMENT_TEAM = RQSR4UU3VB;
 				CODE_SIGN_ENTITLEMENTS = "iOS (App)/Movar.entitlements";
 				REGISTER_APP_GROUPS = YES;
@@ -776,7 +776,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.6.0;
+				MARKETING_VERSION = 1.6.1;
 				OTHER_LDFLAGS = (
 					"-framework",
 					SafariServices,
@@ -802,7 +802,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1786286363;
+				CURRENT_PROJECT_VERSION = 1786375258;
 				DEVELOPMENT_TEAM = RQSR4UU3VB;
 				CODE_SIGN_ENTITLEMENTS = "iOS (App)/Movar.entitlements";
 				REGISTER_APP_GROUPS = YES;
@@ -819,7 +819,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.6.0;
+				MARKETING_VERSION = 1.6.1;
 				OTHER_LDFLAGS = (
 					"-framework",
 					SafariServices,
@@ -844,7 +844,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1786286363;
+				CURRENT_PROJECT_VERSION = 1786375258;
 				DEVELOPMENT_TEAM = RQSR4UU3VB;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -861,7 +861,7 @@
 					"@executable_path/../../../../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 11.0;
-				MARKETING_VERSION = 1.6.0;
+				MARKETING_VERSION = 1.6.1;
 				OTHER_LDFLAGS = (
 					"-framework",
 					SafariServices,
@@ -882,7 +882,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1786286363;
+				CURRENT_PROJECT_VERSION = 1786375258;
 				DEVELOPMENT_TEAM = RQSR4UU3VB;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -899,7 +899,7 @@
 					"@executable_path/../../../../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 11.0;
-				MARKETING_VERSION = 1.6.0;
+				MARKETING_VERSION = 1.6.1;
 				OTHER_LDFLAGS = (
 					"-framework",
 					SafariServices,
@@ -922,7 +922,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1786286363;
+				CURRENT_PROJECT_VERSION = 1786375258;
 				DEVELOPMENT_TEAM = RQSR4UU3VB;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -939,7 +939,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 11.0;
-				MARKETING_VERSION = 1.6.0;
+				MARKETING_VERSION = 1.6.1;
 				OTHER_LDFLAGS = (
 					"-framework",
 					SafariServices,
@@ -965,7 +965,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1786286363;
+				CURRENT_PROJECT_VERSION = 1786375258;
 				DEVELOPMENT_TEAM = RQSR4UU3VB;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -982,7 +982,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 11.0;
-				MARKETING_VERSION = 1.6.0;
+				MARKETING_VERSION = 1.6.1;
 				OTHER_LDFLAGS = (
 					"-framework",
 					SafariServices,

--- a/apps/extension/store-assets/apple/WHATS-NEW.md
+++ b/apps/extension/store-assets/apple/WHATS-NEW.md
@@ -17,6 +17,28 @@ user's voice (what changed for them), not the developer changelog.
 
 ---
 
+## 1.6.1
+
+Single-fix release. The user-visible symptom was filtering that quietly stopped
+working on a tab — most often a search results page — with nothing to say why,
+and no way back short of reopening the page.
+
+### Українська (uk)
+
+```
+Що нового у версії 1.6.1
+
+• Виправлено рідкісний випадок, коли на вкладці мовчки припинялося приховування російськомовного вмісту — і не відновлювалося, доки ви не відкриєте сторінку заново. Тепер Мовар повертається до роботи сам.
+```
+
+### English (en)
+
+```
+What's new in 1.6.1
+
+• Fixed a rare case where hiding Russian-language content quietly stopped working on a tab and stayed off until you reopened the page. Movar now recovers on its own.
+```
+
 ## 1.6.0
 
 **1.5.3 was never built for Safari** (the pbxproj stayed at 1.5.2), so Apple


### PR DESCRIPTION
Patch release for [#380](https://github.com/rejifald/movar/pull/380) — a failed capability chunk no longer disables content filtering for the life of a tab, and a provisioning failure is now visible on the page instead of looking exactly like "there was nothing to hide".

## What `changeset version` did

`@movar/extension` 1.6.0 → **1.6.1** + CHANGELOG. **No cascade this time:** the changeset was scoped to `@movar/extension`, which nothing depends on — hence 3 files, where v1.6.0 (#376) touched ~20.

## Hand-bumped (the two surfaces `changeset version` cannot see)

- **Safari** `MARKETING_VERSION` 1.6.0 → 1.6.1 across all 8 build configurations, and `CURRENT_PROJECT_VERSION` 1786286363 → **1786375258** — App Store Connect requires a strictly increasing build number, and the convention here is a Unix timestamp.
- **`store-assets/apple/WHATS-NEW.md`** — a 1.6.1 block in **both locales, Ukrainian leading**. ASC requires "What's New" per localization on every version after the first, so neither is optional. Kept in the user's voice: the symptom was filtering that quietly stopped working on a tab, so that is what the note describes — not the module-map mechanics.

## After merge

Publishing the **GitHub Release** is what ships this. A pushed tag ships nothing — v1.5.1 was tagged, never published, and reached no store. Publishing runs `release-chrome` / `release-firefox` / `release-edge`, which park on the `production` environment approval; `release-safari` 401s on headless provisioning as always and is submitted by hand from Xcode Organizer, for which the version and build number above are already in place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)