### PR TITLE
chore(release): extension v1.6.2

### DIFF
--- a/.changeset/extension-emitted-bundle-egress-guard.md
+++ b/.changeset/extension-emitted-bundle-egress-guard.md
@@ -1,5 +1,0 @@
----
-'@movar/extension': patch
----
-
-extension: fail the build on any network-egress primitive in the EMITTED bundle, not just in our own source. `assertNoNetworkEgress` (wxt.config.ts `build:done`) scans every emitted `.js`/`.html` for `fetch` / `XMLHttpRequest` / `WebSocket` / `sendBeacon` / `EventSource`, closing the gap its source-side companion (`scanForEgress` in scripts/lib/promises.mts) can't reach: a dependency could bundle a request into the shipped package without a line of our code changing. It asserts absence with no allowlist, which is why `vite.build.modulePreload.polyfill` is now `false` — that polyfill's cache-warming `fetch()` was the single (benign) egress call in the artifact, and every browser Movar targets has native modulepreload well below its MV3 floor, so dropping it costs a preload hint at worst.

--- a/.changeset/firefox-searchparams-iterator-crash.md
+++ b/.changeset/firefox-searchparams-iterator-crash.md
@@ -1,7 +1,0 @@
----
-'@movar/extension': patch
----
-
-Fix a crash that disabled Movar entirely on Google in Firefox.
-
-`scrubSearchParams` iterated `url.searchParams.keys()`. A Firefox content script is an Xray-wrapped sandbox where `URLSearchParams`'s WebIDL iterator methods do not survive the wrapper, so that `for…of` threw `TypeError: searchParams.keys() is not iterable` — out of `applyStrategy`, out of `applyOnce`, out of the content-script bootstrap. On Google (the only host whose rule scrubs params) Firefox users therefore got no `hl`/`lr` rewrite — so Google served the Russian corpus — and no content filtering at all, while the popup kept answering normally because its message bridge is installed before the throw. Now uses `forEach`, and a `no-restricted-syntax` guard bans these iterator methods repo-wide: Chromium and jsdom both iterate them fine, so no unit test or Chromium e2e run can catch a reintroduction. Note `Array.from(searchParams.keys())` does not throw in that sandbox — it silently returns `[]`, which would have scrubbed nothing while looking correct.

--- a/apps/extension/CHANGELOG.md
+++ b/apps/extension/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @movar/extension
 
+## 1.6.2
+
+### Patch Changes
+
+- c58e24f: extension: fail the build on any network-egress primitive in the EMITTED bundle, not just in our own source. `assertNoNetworkEgress` (wxt.config.ts `build:done`) scans every emitted `.js`/`.html` for `fetch` / `XMLHttpRequest` / `WebSocket` / `sendBeacon` / `EventSource`, closing the gap its source-side companion (`scanForEgress` in scripts/lib/promises.mts) can't reach: a dependency could bundle a request into the shipped package without a line of our code changing. It asserts absence with no allowlist, which is why `vite.build.modulePreload.polyfill` is now `false` — that polyfill's cache-warming `fetch()` was the single (benign) egress call in the artifact, and every browser Movar targets has native modulepreload well below its MV3 floor, so dropping it costs a preload hint at worst.
+- 005744f: Fix a crash that disabled Movar entirely on Google in Firefox.
+
+  `scrubSearchParams` iterated `url.searchParams.keys()`. A Firefox content script is an Xray-wrapped sandbox where `URLSearchParams`'s WebIDL iterator methods do not survive the wrapper, so that `for…of` threw `TypeError: searchParams.keys() is not iterable` — out of `applyStrategy`, out of `applyOnce`, out of the content-script bootstrap. On Google (the only host whose rule scrubs params) Firefox users therefore got no `hl`/`lr` rewrite — so Google served the Russian corpus — and no content filtering at all, while the popup kept answering normally because its message bridge is installed before the throw. Now uses `forEach`, and a `no-restricted-syntax` guard bans these iterator methods repo-wide: Chromium and jsdom both iterate them fine, so no unit test or Chromium e2e run can catch a reintroduction. Note `Array.from(searchParams.keys())` does not throw in that sandbox — it silently returns `[]`, which would have scrubbed nothing while looking correct.
+
 ## 1.6.1
 
 ### Patch Changes

--- a/apps/extension/package.json
+++ b/apps/extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@movar/extension",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/extension/safari/Movar/Movar.xcodeproj/project.pbxproj
+++ b/apps/extension/safari/Movar/Movar.xcodeproj/project.pbxproj
@@ -684,7 +684,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1786375258;
+				CURRENT_PROJECT_VERSION = 1786386205;
 				DEVELOPMENT_TEAM = RQSR4UU3VB;
 				CODE_SIGN_ENTITLEMENTS = "iOS (Extension)/Movar Extension.entitlements";
 				REGISTER_APP_GROUPS = YES;
@@ -698,7 +698,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.6.1;
+				MARKETING_VERSION = 1.6.2;
 				OTHER_LDFLAGS = (
 					"-framework",
 					SafariServices,
@@ -720,7 +720,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1786375258;
+				CURRENT_PROJECT_VERSION = 1786386205;
 				DEVELOPMENT_TEAM = RQSR4UU3VB;
 				CODE_SIGN_ENTITLEMENTS = "iOS (Extension)/Movar Extension.entitlements";
 				REGISTER_APP_GROUPS = YES;
@@ -734,7 +734,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.6.1;
+				MARKETING_VERSION = 1.6.2;
 				OTHER_LDFLAGS = (
 					"-framework",
 					SafariServices,
@@ -759,7 +759,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1786375258;
+				CURRENT_PROJECT_VERSION = 1786386205;
 				DEVELOPMENT_TEAM = RQSR4UU3VB;
 				CODE_SIGN_ENTITLEMENTS = "iOS (App)/Movar.entitlements";
 				REGISTER_APP_GROUPS = YES;
@@ -776,7 +776,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.6.1;
+				MARKETING_VERSION = 1.6.2;
 				OTHER_LDFLAGS = (
 					"-framework",
 					SafariServices,
@@ -802,7 +802,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1786375258;
+				CURRENT_PROJECT_VERSION = 1786386205;
 				DEVELOPMENT_TEAM = RQSR4UU3VB;
 				CODE_SIGN_ENTITLEMENTS = "iOS (App)/Movar.entitlements";
 				REGISTER_APP_GROUPS = YES;
@@ -819,7 +819,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.6.1;
+				MARKETING_VERSION = 1.6.2;
 				OTHER_LDFLAGS = (
 					"-framework",
 					SafariServices,
@@ -844,7 +844,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1786375258;
+				CURRENT_PROJECT_VERSION = 1786386205;
 				DEVELOPMENT_TEAM = RQSR4UU3VB;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -861,7 +861,7 @@
 					"@executable_path/../../../../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 11.0;
-				MARKETING_VERSION = 1.6.1;
+				MARKETING_VERSION = 1.6.2;
 				OTHER_LDFLAGS = (
 					"-framework",
 					SafariServices,
@@ -882,7 +882,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1786375258;
+				CURRENT_PROJECT_VERSION = 1786386205;
 				DEVELOPMENT_TEAM = RQSR4UU3VB;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -899,7 +899,7 @@
 					"@executable_path/../../../../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 11.0;
-				MARKETING_VERSION = 1.6.1;
+				MARKETING_VERSION = 1.6.2;
 				OTHER_LDFLAGS = (
 					"-framework",
 					SafariServices,
@@ -922,7 +922,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1786375258;
+				CURRENT_PROJECT_VERSION = 1786386205;
 				DEVELOPMENT_TEAM = RQSR4UU3VB;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -939,7 +939,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 11.0;
-				MARKETING_VERSION = 1.6.1;
+				MARKETING_VERSION = 1.6.2;
 				OTHER_LDFLAGS = (
 					"-framework",
 					SafariServices,
@@ -965,7 +965,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1786375258;
+				CURRENT_PROJECT_VERSION = 1786386205;
 				DEVELOPMENT_TEAM = RQSR4UU3VB;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -982,7 +982,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 11.0;
-				MARKETING_VERSION = 1.6.1;
+				MARKETING_VERSION = 1.6.2;
 				OTHER_LDFLAGS = (
 					"-framework",
 					SafariServices,

--- a/apps/extension/store-assets/apple/WHATS-NEW.md
+++ b/apps/extension/store-assets/apple/WHATS-NEW.md
@@ -17,6 +17,32 @@ user's voice (what changed for them), not the developer changelog.
 
 ---
 
+## 1.6.2
+
+Bug-fix release. The lead item is Firefox-only — a crash that left Movar doing
+nothing at all on Google there — but Safari users are coming from 1.6.1, which
+they may not have received yet, so its item is folded in below. The build-time
+egress guard that also landed in this version is invisible to users and is
+deliberately left out of the note.
+
+### Українська (uk)
+
+```
+Що нового у версії 1.6.2
+
+• У Firefox Мовар припиняв працювати в пошуку Google — не приховував російськомовні результати й не перемикав мову пошуку. Виправлено.
+• Виправлено рідкісний випадок, коли на вкладці мовчки припинялося приховування російськомовного вмісту — і не відновлювалося, доки ви не відкриєте сторінку заново. Тепер Мовар повертається до роботи сам.
+```
+
+### English (en)
+
+```
+What's new in 1.6.2
+
+• In Firefox, Movar stopped working on Google Search — it neither hid Russian-language results nor switched the search language. Fixed.
+• Fixed a rare case where hiding Russian-language content quietly stopped working on a tab and stayed off until you reopened the page. Movar now recovers on its own.
+```
+
 ## 1.6.1
 
 Single-fix release. The user-visible symptom was filtering that quietly stopped


### PR DESCRIPTION
Two changesets, both patch:

- **[#383](https://github.com/rejifald/movar/pull/383) — the Firefox content-script crash.** `searchParams.keys()` is not iterable in an Xray-wrapped sandbox, which threw out of the whole content-script bootstrap and left Movar doing **nothing at all** on Google in Firefox: no `hl`/`lr` rewrite (so Google served the Russian corpus) and no concealment. This is the reason to ship promptly.
- **[#379](https://github.com/rejifald/movar/pull/379) — the emitted-bundle network-egress guard.** Build-time only; nothing a user can observe.

## Hand-bumped (what `changeset version` cannot see)

- **Safari** `MARKETING_VERSION` 1.6.1 → 1.6.2 across all 8 build configurations, `CURRENT_PROJECT_VERSION` 1786375258 → **1786386205** (ASC requires a strictly increasing build number).
- **`store-assets/apple/WHATS-NEW.md`** — a 1.6.2 block in **both locales, Ukrainian leading**. It **folds the 1.6.1 item in**: Safari is submitted by hand and 1.6.1's App Store review has not completed, so Apple users may be coming straight from 1.6.0. The egress guard is deliberately left out of the note — a store release note is for what a user can notice.

## After merge

Publishing the **GitHub Release** is what ships this; a pushed tag ships nothing. Chrome remains blocked behind 1.6.0's in-review submission (`FAILED_PRECONDITION: You may not edit or publish an item that is in review`), so 1.6.2 is what should take that slot once the item frees up — it supersedes both 1.6.0 and 1.6.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)