### PR TITLE
fix(safari): stop the submit workflow reporting green on a crash

### DIFF
--- a/.github/workflows/safari-submit.yml
+++ b/.github/workflows/safari-submit.yml
@@ -86,6 +86,11 @@ jobs:
           PLATFORMS: ${{ inputs.platforms }}
           BUILD_NUMBER: ${{ inputs.build_number }}
           DRY_RUN: '1'
+        # `shell: bash` is NOT cosmetic: the default shell is `bash -e` with
+        # NO pipefail, so `node … | tee` reports tee's exit status and a
+        # crashed script reads as a green run. Naming the shell gets
+        # `-eo pipefail`.
+        shell: bash
         run: node scripts/apple-submit.mjs | tee -a "$GITHUB_STEP_SUMMARY"
 
   apply:
@@ -116,4 +121,9 @@ jobs:
           # Only `submit` sets SUBMIT=1; `prepare` stops before the
           # irreversible step, leaving a version you can still edit by hand.
           SUBMIT: ${{ inputs.mode == 'submit' && '1' || '0' }}
+        # `shell: bash` is NOT cosmetic: the default shell is `bash -e` with
+        # NO pipefail, so `node … | tee` reports tee's exit status and a
+        # crashed script reads as a green run. Naming the shell gets
+        # `-eo pipefail`.
+        shell: bash
         run: node scripts/apple-submit.mjs | tee -a "$GITHUB_STEP_SUMMARY"

--- a/scripts/apple-submit.mjs
+++ b/scripts/apple-submit.mjs
@@ -145,6 +145,37 @@ async function waitForBuild(token, appId, platform, version, buildNumber, timeou
   }
 }
 
+/**
+ * Answer export compliance once, tolerating the fact that Apple refuses to let
+ * it be answered twice.
+ */
+async function declareExportCompliance(token, build) {
+  const current = build.attributes?.usesNonExemptEncryption;
+  if (current === false || current === true) {
+    log(`  export compliance already answered (usesNonExemptEncryption=${current})`);
+    return;
+  }
+  if (DRY_RUN) {
+    log('  [dry-run] would declare no non-exempt encryption');
+    return;
+  }
+  const res = await request(token, `/v1/builds/${build.id}`, {
+    method: 'PATCH',
+    body: {
+      data: { type: 'builds', id: build.id, attributes: { usesNonExemptEncryption: false } },
+    },
+  });
+  if (res.status >= 200 && res.status < 300) {
+    log('  declare no non-exempt encryption');
+    return;
+  }
+  if (res.status === 409 && /already set/i.test(res.detail)) {
+    log('  export compliance was already answered on this build');
+    return;
+  }
+  throw new Error(`declaring export compliance failed: ${res.status} ${res.detail}`);
+}
+
 async function submitPlatform(token, { appId, platform, version, notes, buildNumber, timeoutMin }) {
   step(`${platform} — ${version}`);
 
@@ -198,15 +229,18 @@ async function submitPlatform(token, { appId, platform, version, notes, buildNum
       { method: 'PATCH', body: { data: { type: 'builds', id: build.id } } },
     );
 
-    // Export compliance. Answering it here is what stops the version sitting
-    // in WAITING_FOR_EXPORT_COMPLIANCE forever. Movar ships no encryption of
-    // its own beyond standard HTTPS, which is exempt.
-    await write(token, 'declare no non-exempt encryption', `/v1/builds/${build.id}`, {
-      method: 'PATCH',
-      body: {
-        data: { type: 'builds', id: build.id, attributes: { usesNonExemptEncryption: false } },
-      },
-    });
+    // Export compliance. Answering it is what stops the version sitting in
+    // WAITING_FOR_EXPORT_COMPLIANCE forever. Movar ships no encryption of its
+    // own beyond standard HTTPS, which is exempt.
+    //
+    // Apple treats this as write-once: re-sending it returns
+    // `409 ENTITY_ERROR.ATTRIBUTE.INVALID: You cannot update when the value is
+    // already set`. The value is often already there — the build carries
+    // ITSAppUsesNonExemptEncryption from its Info.plist — so a rerun of this
+    // otherwise-idempotent script would die on a build that is already fine.
+    // Skip when it is set, and still tolerate the 409 in case the list
+    // response omitted the attribute.
+    await declareExportCompliance(token, build);
   }
 
   // --- release notes, per localization -------------------------------------


### PR DESCRIPTION
The first real `prepare` run created the iOS version and attached the build, then **died — and the workflow reported SUCCESS.** Two separate faults.

## The crash reads as green

```yaml
run: node scripts/apple-submit.mjs | tee -a "$GITHUB_STEP_SUMMARY"
```

GitHub's default shell is `bash -e` with **no** `pipefail`, so the step's exit status is `tee`'s, not the script's. Naming `shell: bash` gets `-eo pipefail`.

Verified rather than assumed:

```
bash --noprofile --norc -eo pipefail -c 'node -e "process.exit(3)" | tee /dev/null'  → exit 3
bash -e                              -c 'node -e "process.exit(3)" | tee /dev/null'  → exit 0
```

This is the **same defect class as altool's unreliable exit code**, which this work had already fixed once — reintroduced by my own pipe, in the workflow that performs the single most irreversible action in the repo.

## Export compliance is write-once

```
PATCH /v1/builds/… → 409 ENTITY_ERROR.ATTRIBUTE.INVALID: You cannot update when the value is already set
```

The value is frequently already set, because the build carries `ITSAppUsesNonExemptEncryption` from its Info.plist. That made a rerun of an otherwise-idempotent script fail on a build that was already correct. Now it skips when the attribute is set, and still tolerates that specific 409 in case a list response omits it.

## State this leaves behind

The partial run created the **iOS 1.6.2 version** and attached build `1786451798`. Nothing was submitted and no reviewer saw it. The script reuses an existing editable version, so re-running `prepare` picks up from there and completes macOS plus both sets of release notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)