### PR TITLE
fix(safari): isolate platform failures, and document the submission workflow

### DIFF
--- a/docs/safari-deploy.md
+++ b/docs/safari-deploy.md
@@ -510,6 +510,69 @@ Store Connect, and attaches the notarized `.dmg` to the Release.
 
 ## Troubleshooting
 
+### A release step went green but nothing shipped ("silent success")
+
+**Read this first when a release "succeeded" and the artifact never appeared.**
+Two independent mechanisms in this pipeline report success while failing, and
+both were found the hard way — each one hid a real, already-rejected Apple
+submission behind a green check.
+
+#### 1. `altool` exits 0 even when it fails
+
+`xcrun altool --validate-app` / `--upload-app` return **exit status 0** on a
+rejected package. On 2026-08-11 a run reported SUCCESS while its own output
+said:
+
+```
+VERIFY FAILED with 1 error
+ERROR: Validation failed (409) This bundle is invalid. The value for key
+CFBundleVersion [9] … must contain a higher version than that of the
+previously uploaded version [1785959230].
+```
+
+Every altool call was decorative until this was fixed. **Never gate on
+altool's exit code.** `release.yml` and `safari-signing-rehearsal.yml` run it
+through an `altool_checked` helper that parses `--output-format json` and fails
+on a non-empty `product-errors` — treating unparseable output as failure too,
+because the absence of an error report is not evidence of success.
+
+> Keep altool's **stderr out of that JSON file**. It writes its progress and
+> its `VERIFY SUCCEEDED` banner to stderr, so `2>&1` corrupts the report and
+> the gate then fails a package that actually passed. Use `2>"$err"`, and print
+> both.
+
+#### 2. A pipe swallows a failing command
+
+GitHub Actions' **default** shell is `bash -e` with **no `pipefail`**, so in
+
+```yaml
+run: node scripts/apple-submit.mjs | tee -a "$GITHUB_STEP_SUMMARY"
+```
+
+the step's exit status is `tee`'s. A crashed script reads as a green run — this
+is exactly how a half-finished App Store submission (version created, build
+attached, then a 409) reported success.
+
+Naming the shell fixes it, because `shell: bash` runs
+`bash --noprofile --norc -eo pipefail`:
+
+```yaml
+shell: bash
+run: node scripts/apple-submit.mjs | tee -a "$GITHUB_STEP_SUMMARY"
+```
+
+Demonstrate the difference before trusting any change here:
+
+```sh
+bash --noprofile --norc -eo pipefail -c 'node -e "process.exit(3)" | tee /dev/null'; echo $?   # 3
+bash -e                              -c 'node -e "process.exit(3)" | tee /dev/null'; echo $?   # 0
+```
+
+**The general rule for this pipeline: an exit code is not evidence.** Anything
+that talks to Apple must be judged on what it reported, not on whether the
+process ended cleanly — and any `run:` step containing a pipe must declare
+`shell: bash`.
+
 ### Build hangs forever ("endlessly building")
 
 **Symptom.** Xcode sits on _Build_ / _Preparing_ indefinitely — no progress bar

--- a/docs/safari-deploy.md
+++ b/docs/safari-deploy.md
@@ -158,6 +158,65 @@ a correctly signed `.ipa` with `SDK version issue … must be built with the iOS
 pin silently goes stale and fails at the last step of a release. Raise
 `MIN_XCODE_MAJOR` in all three files together when Apple raises the minimum.
 
+## Submitting for review — `safari-submit.yml`
+
+`altool --upload-app` only _delivers a build_. Creating the version, attaching
+the build, writing "What's New" per localization, answering export compliance
+and submitting used to be hand-work in the App Store Connect UI. The
+[Review Submissions API](https://developer.apple.com/documentation/appstoreconnectapi)
+covers all of it, so
+[safari-submit.yml](../.github/workflows/safari-submit.yml) +
+[apple-submit.mjs](../scripts/apple-submit.mjs) finish the job — for a build
+uploaded by CI _or_ by Organizer.
+
+It is a separate workflow from `release-safari` on purpose: Apple's build
+processing takes minutes to tens of minutes, and waiting for that on the macOS
+runner would burn 10x-priced minutes doing nothing. This is pure HTTP, so it
+runs on Linux, and it is re-runnable without rebuilding or re-uploading.
+
+Three modes, mirroring the release job's "reversible first, irreversible last"
+rule. Every run prints a read-only **plan** first, needing no approval; any
+write is behind the same `production` gate as the store jobs.
+
+| `mode`    | Does                                                                     | Reversible                          |
+| --------- | ------------------------------------------------------------------------ | ----------------------------------- |
+| `plan`    | reads only — resolves app, build, version, localizations, submissions    | n/a                                 |
+| `prepare` | create/reuse the version, attach the build, set notes, export compliance | yes — editable, no reviewer sees it |
+| `submit`  | also submits for review                                                  | **no**                              |
+
+```sh
+# See what would happen — safe, no approval needed.
+gh workflow run safari-submit.yml --ref main -f mode=plan -f version=1.6.2
+
+# Fill everything in without submitting.
+gh workflow run safari-submit.yml --ref main -f mode=prepare -f version=1.6.2
+
+# Submit. One platform at a time — see the warning below.
+gh workflow run safari-submit.yml --ref main -f mode=submit -f version=1.6.2 -f platforms=MAC_OS
+```
+
+It is idempotent at every level: an editable version is reused rather than
+duplicated, and a version already `WAITING_FOR_REVIEW` or `READY_FOR_SALE` is
+reported and left alone. Release notes come from
+[WHATS-NEW.md](../apps/extension/store-assets/apple/WHATS-NEW.md) — only the
+fenced blocks ship, not the editorial prose around them — and a locale with no
+note is a hard error naming the locale, because App Store Connect rejects a
+version whose localization has no "What's New".
+
+> **Submit one platform at a time when they differ in risk.** iOS and macOS are
+> submitted independently, and a metadata problem on one no longer abandons the
+> other — but they are still separate decisions. macOS has shipped before; iOS
+> had never been through review until 1.6.2, so its first submission can draw
+> questions a macOS update never gets.
+
+> ⚠️ **The `production` gate approves per ENVIRONMENT, not per job.** Every
+> store job in `release.yml` declares the same `production` environment, and a
+> run's `pending_deployments` returns a **single** entry — so "approve only
+> `release-safari`" is not expressible in the UI: one click releases Chrome,
+> Firefox and Edge too. To ship one store alone, disable the others (`if: false`)
+> on a throwaway branch and never merge it. This is how v1.6.2 reached Safari
+> without re-submitting the version the other three had already shipped.
+
 ## Local App Store submission (Xcode Organizer)
 
 _Fallback only. As of 2026-08-11 `release-safari` handles both platforms; keep
@@ -283,10 +342,12 @@ succeeds locally.
    distilled from [`apps/extension/CHANGELOG.md`](../apps/extension/CHANGELOG.md).
    You'll paste each locale in the next step.
 
-8. **Submit for review in App Store Connect.** For the new version on **each**
-   platform: attach the just-uploaded build (it appears after processing), paste
-   the **What's New** notes from step 7 into each localization, answer
-   export-compliance, and **Submit for Review**.
+8. **Submit for review.** Prefer the automated path — see
+   [Submitting for review](#submitting-for-review-safari-submityml) below; it
+   works whether the build was uploaded by CI or by Organizer. By hand instead:
+   for the new version on **each** platform, attach the just-uploaded build (it
+   appears after processing), paste the **What's New** notes from step 7 into
+   each localization, answer export-compliance, and **Submit for Review**.
 
 9. **After approval** — the marketing download links already point at the app-id
    URL shared by iOS + macOS

--- a/scripts/apple-submit.mjs
+++ b/scripts/apple-submit.mjs
@@ -383,28 +383,48 @@ async function main() {
   }
   log(`app: ${app.attributes.name} (${app.id})`);
 
+  // Platforms are isolated from one another. They fail for genuinely different
+  // reasons — iOS's first-ever submission can lack listing metadata macOS has
+  // had for releases — and letting the first failure abandon the rest would
+  // mean an iOS metadata gap silently withholding a macOS release that was
+  // ready. Collect every outcome, report them all, then fail if any did.
   const results = [];
   for (const platform of platforms) {
-    results.push(
-      await submitPlatform(token, {
-        appId: app.id,
-        platform,
-        version,
-        notes,
-        buildNumber,
-        timeoutMin,
-      }),
-    );
+    try {
+      results.push(
+        await submitPlatform(token, {
+          appId: app.id,
+          platform,
+          version,
+          notes,
+          buildNumber,
+          timeoutMin,
+        }),
+      );
+    } catch (cause) {
+      console.error(`  ✗ ${platform}: ${cause.message}`);
+      results.push({ platform, error: cause.message });
+    }
   }
 
   step('Summary');
   for (const r of results) {
-    const what = r.submitted
-      ? 'SUBMITTED FOR REVIEW'
-      : r.prepared
-        ? 'prepared, not submitted'
-        : `skipped (${r.skipped})`;
+    const what = r.error
+      ? `FAILED — ${r.error}`
+      : r.submitted
+        ? 'SUBMITTED FOR REVIEW'
+        : r.prepared
+          ? 'prepared, not submitted'
+          : `skipped (${r.skipped})`;
     log(`  ${r.platform}: ${what}`);
+  }
+
+  const failures = results.filter((r) => r.error);
+  if (failures.length) {
+    console.error(
+      `\n${failures.length} of ${results.length} platform(s) failed: ${failures.map((f) => f.platform).join(', ')}`,
+    );
+    process.exit(1);
   }
 }
 


### PR DESCRIPTION
Two things the 1.6.2 submission exposed, now that both platforms are `WAITING_FOR_REVIEW`.

## A failure on one platform abandoned the other

`apple-submit.mjs` looped over platforms with no error isolation, so the first exception aborted the run. That matters because the platforms fail for genuinely different reasons — iOS's first-ever submission can lack listing metadata macOS has had for releases — meaning an iOS metadata gap could silently withhold a macOS release that was ready.

During the 1.6.2 submission the workaround was dispatching each platform separately. Now each platform is caught individually, every outcome is reported, and the run exits non-zero at the end if any failed.

## The docs never mentioned `safari-submit.yml`

They still described attaching the build, pasting release notes and hitting **Submit for Review** as hand-work in App Store Connect — so a reader today would do by hand what is now automated. Adds a section covering the three modes and their reversibility, plus the two traps found the hard way during this release:

- **The `production` gate approves per ENVIRONMENT, not per job.** A run's `pending_deployments` returns a single entry, so "approve only `release-safari`" isn't expressible — one click releases Chrome, Firefox and Edge too. Shipping one store alone needs a throwaway branch with the others disabled.
- **Submit platforms separately when they differ in risk**, which is now a preference rather than a necessity.

## Verified

v1.6.2 is with Apple on both platforms — confirmed by a read-only `plan` run, which correctly refused to touch either:

```
▸ IOS — 1.6.2      version 1.6.2 is already WAITING_FOR_REVIEW — nothing to do, leaving it alone.
▸ MAC_OS — 1.6.2   version 1.6.2 is already WAITING_FOR_REVIEW — nothing to do, leaving it alone.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)