### PR TITLE
feat(extension): point the footer version stamp at the changelog

### DIFF
--- a/.changeset/version-stamp-links-to-changelog.md
+++ b/.changeset/version-stamp-links-to-changelog.md
@@ -1,0 +1,17 @@
+---
+'@movar/brand': patch
+'@movar/i18n': patch
+'@movar/extension': patch
+---
+
+Make the version stamp in the popup and options footers a link to the public changelog, anchored at the version the user is actually running.
+
+The stamp was inert text on both surfaces. It is the only place in the UI that names a release, so it is where someone goes after noticing the number changed — and it went nowhere. The store listings are no answer either: Chrome has no release-notes field at all, and the Firefox and App Store listings only ever show the newest version's notes. `movar.fyi/changelog` renders `apps/extension/store-assets/RELEASE-NOTES.md` — the same file those listings read — so it is the one surface that holds the whole history, in both languages.
+
+`changelogUrl(locale, version)` (`apps/extension/src/lib/changelog-url.ts`) builds `https://movar.fyi/changelog#v1.6.2`, or `/uk/changelog` when the resolved UI locale is Ukrainian, mirroring the site's own `localeChangelogHref`. The anchor is emitted only for a real semver: the static-serve preview renders `version = 'preview'` (no `browser.runtime.getManifest()`), and an anchor for that would resolve to nothing, so it opens the top of the page — the newest release — instead. Each release in `Changelog.astro` now carries the matching `id`, plus `scroll-mt-24`; the site's header is sticky and measures 73px, so without the offset a jump would land the release underneath it.
+
+Both footers render one shared `VersionLink`, so the two surfaces cannot drift into linking differently. Resting appearance is unchanged — same type ramp, no underline — and it opens in a new tab (`noopener`), since navigating in place would throw away the popup the user is standing in. The new `versionLink` catalogue string starts with the visible stamp (`v1.6.2 — what's new`) so the accessible name contains the visible label, as WCAG 2.5.3 requires.
+
+`@movar/brand` gains `SITE_URL` — the origin only. The `/uk` prefix is the marketing site's own routing concern, and that package is constants without logic, so callers compose the path they need.
+
+Not covered here: the Safari host app's About tab shows the same stamp as plain text. Its WKWebView runs under `default-src 'self'`, so external links route through the native bridge, and the `open-url` case does not exist in `ViewController.swift` yet — the existing "Source code" button is already a no-op on device. Linking the stamp there needs that native pass first.

--- a/apps/e2e/src/offline/options.spec.ts
+++ b/apps/e2e/src/offline/options.spec.ts
@@ -92,8 +92,16 @@ test.describe('extension options', () => {
     await expect(footer.getByRole('combobox', { name: 'Language' })).toBeVisible();
     // Version comes from browser.runtime.getManifest().version; matching a
     // semver shape rules out the App.tsx fallback string 'preview' that
-    // would appear if chrome.runtime were unavailable.
-    await expect(footer.getByText(/^v\d+\.\d+\.\d+/)).toBeVisible();
+    // would appear if chrome.runtime were unavailable. It's a link to the
+    // public changelog anchored at that version — and `changelogUrl` only
+    // emits the `#v…` fragment for a real release, so asserting the anchored
+    // href re-proves the manifest read from the other side.
+    const versionLink = footer.getByRole('link', { name: /^v\d+\.\d+\.\d+.* — what's new$/ });
+    await expect(versionLink).toBeVisible();
+    await expect(versionLink).toHaveAttribute(
+      'href',
+      /^https:\/\/movar\.fyi\/changelog#v\d+\.\d+\.\d+/,
+    );
     // Feedback link uses the shared FEEDBACK_URL constant. Asserting on the
     // localised text ('Send feedback') proves the i18n catalogue resolved
     // and the link is reachable by keyboard users.

--- a/apps/e2e/src/offline/popup.spec.ts
+++ b/apps/e2e/src/offline/popup.spec.ts
@@ -149,7 +149,14 @@ test.describe('extension popup', () => {
       // sourced from package.json and pinned at build time. We import the
       // version here to assert exact equality, so version bumps are caught
       // as a test change rather than a passing assertion on a loose regex.
-      await expect(footer.getByText(`v${version}`)).toBeVisible();
+      //
+      // The stamp is a link to the public changelog, anchored at the running
+      // version (lib/changelog-url.ts). Asserting the href — not just the text
+      // — is what proves the anchor tracks the manifest version rather than
+      // silently pointing at the top of the page.
+      const versionLink = footer.getByRole('link', { name: `v${version} — what's new` });
+      await expect(versionLink).toBeVisible();
+      await expect(versionLink).toHaveAttribute('href', `https://movar.fyi/changelog#v${version}`);
       // The old UI-language <select> is gone (the popup follows the
       // preferred-language order). The footer instead carries the contextual
       // "report an issue" link — always shown; mailto built in report-mailto.ts.

--- a/apps/extension/AGENTS.md
+++ b/apps/extension/AGENTS.md
@@ -118,6 +118,8 @@ src/
     events.ts             — logCorrection: structured correction-event emitter
     host-match.ts         — hostMatchesAllowlist
     page-text.ts          — sampleVisibleText
+    changelog-url.ts      — movar.fyi/changelog URL for a locale, anchored at a released version
+    version-link.tsx      — the popup/options footer version stamp, linked to that changelog
     mount-app.tsx         — shared React root mount helper
     error-boundary.tsx    — top-level React error boundary
     test-setup.ts         — global jsdom reset + curtain/tooltip teardown

--- a/apps/extension/src/entrypoints/options/App.tsx
+++ b/apps/extension/src/entrypoints/options/App.tsx
@@ -6,6 +6,7 @@ import { defaultSettings } from '@movar/settings';
 import type { MovarSettings, UiLanguage } from '@movar/settings';
 import { iconSize } from '@movar/theme';
 import { getSettings, setSettings as persistSettings } from '../../lib/settings';
+import { VersionLink } from '../../lib/version-link';
 import { I18nProvider, useI18n } from '@movar/i18n';
 import {
   AllowlistSection,
@@ -59,7 +60,7 @@ interface OptionsBodyProps {
 
 /** Split out so `useI18n()` resolves under the provider above. */
 function OptionsBody({ settings, onChange, onChangeUiLanguage }: Readonly<OptionsBodyProps>) {
-  const { t } = useI18n();
+  const { t, locale } = useI18n();
 
   return (
     // No outer card: Chrome's `chrome://extensions/?options=…` modal already
@@ -103,7 +104,7 @@ function OptionsBody({ settings, onChange, onChangeUiLanguage }: Readonly<Option
           </a>
           <div className="flex items-center gap-3">
             <SourceLink label={t.sourceCode} />
-            <span className="text-ui-micro font-mono tracking-wide">v{version}</span>
+            <VersionLink version={version} locale={locale} label={t.versionLink} />
             <LanguageSelector
               value={settings.uiLanguage}
               onChange={onChangeUiLanguage}

--- a/apps/extension/src/entrypoints/popup/App.tsx
+++ b/apps/extension/src/entrypoints/popup/App.tsx
@@ -10,6 +10,7 @@ import { cn } from '@movar/ui';
 import type { PauseState } from '../../lib/pause';
 import type { HiddenSummary } from '../../lib/messaging';
 import { hostMatchesAllowlist } from '../../lib/host-match';
+import { VersionLink } from '../../lib/version-link';
 import { StatusHeader, resolveHero } from './StatusHeader';
 import type { HeroState } from './StatusHeader';
 import { HiddenPanel } from './HiddenPanel';
@@ -324,7 +325,7 @@ function PopupFooter({
         </button>
       </div>
       <div className="mt-2 flex items-center justify-between">
-        <span className="text-ui-micro font-mono tracking-wide">v{version}</span>
+        <VersionLink version={version} locale={locale} label={t.versionLink} />
         {/* Replaces the old UI-language picker — the popup now follows the
             user's preferred-language order. Always shown; on a non-web tab
             `reportUrl` is null and the mailto omits the page line. */}

--- a/apps/extension/src/lib/changelog-url.test.ts
+++ b/apps/extension/src/lib/changelog-url.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+import { changelogUrl } from './changelog-url';
+
+describe('changelogUrl', () => {
+  it('anchors a released version on the English changelog', () => {
+    expect(changelogUrl('en', '1.6.2')).toBe('https://movar.fyi/changelog#v1.6.2');
+  });
+
+  it("uses the site's /uk prefix for Ukrainian", () => {
+    expect(changelogUrl('uk', '1.6.2')).toBe('https://movar.fyi/uk/changelog#v1.6.2');
+  });
+
+  it('keeps a pre-release suffix in the anchor', () => {
+    expect(changelogUrl('en', '1.7.0-beta.1')).toBe('https://movar.fyi/changelog#v1.7.0-beta.1');
+  });
+
+  // The static-serve preview renders `version = 'preview'` (no `getManifest()`).
+  // An anchor for it would resolve to nothing, so the link opens the top of the
+  // page — the newest release — instead.
+  it.each(['preview', '', '1.6', 'v1.6.2'])('drops the anchor for %o', (version) => {
+    expect(changelogUrl('en', version)).toBe('https://movar.fyi/changelog');
+  });
+});

--- a/apps/extension/src/lib/changelog-url.ts
+++ b/apps/extension/src/lib/changelog-url.ts
@@ -1,0 +1,35 @@
+/*
+ * Where the footer's version stamp points: the public changelog on movar.fyi,
+ * deep-linked to the version the user is actually running.
+ *
+ * The stamp used to be inert text — a user who noticed a new version number had
+ * nowhere to go to find out what changed. `movar.fyi/changelog` renders
+ * `apps/extension/store-assets/RELEASE-NOTES.md` (the same file the store
+ * listings read), so this link lands on the one set of release notes rather
+ * than a store page that only ever shows the latest.
+ *
+ * Locale mirrors `localeChangelogHref()` in `apps/marketing/src/i18n.ts` — the
+ * site's `/uk` prefix is duplicated here rather than imported because the
+ * extension does not depend on the Astro app. Two lines, one shape; if the
+ * site's routing ever changes, both move together.
+ */
+import { SITE_URL } from '@movar/brand';
+import type { ResolvedLocale } from '@movar/i18n';
+
+/** A released version — `1.6.2`, optionally with a pre-release suffix. Anything
+ *  else (notably the `'preview'` fallback the static-serve preview renders when
+ *  `getManifest()` is unavailable) has no anchor on the page. */
+const RELEASED_VERSION = /^\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?$/;
+
+/**
+ * The changelog URL for `locale`, anchored at `version` when that version is a
+ * real release. The anchor matches the `id` each release carries in
+ * `apps/marketing/src/components/Changelog.astro` (`v` + the version) — an
+ * unreleased or unknown version simply opens the top of the page, which is the
+ * newest release, rather than a fragment that resolves to nothing.
+ */
+export function changelogUrl(locale: ResolvedLocale, version: string): string {
+  const path = locale === 'uk' ? '/uk/changelog' : '/changelog';
+  const anchor = RELEASED_VERSION.test(version) ? `#v${version}` : '';
+  return `${SITE_URL}${path}${anchor}`;
+}

--- a/apps/extension/src/lib/version-link.test.tsx
+++ b/apps/extension/src/lib/version-link.test.tsx
@@ -1,0 +1,33 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { messagesEn, messagesUk } from '@movar/i18n';
+import { VersionLink } from './version-link';
+
+describe('VersionLink', () => {
+  it('stamps `v<version>` and links to the anchored changelog', () => {
+    render(<VersionLink version="1.6.2" locale="en" label={messagesEn.versionLink} />);
+
+    const link = screen.getByRole('link', { name: "v1.6.2 — what's new" });
+    expect(link.getAttribute('href')).toBe('https://movar.fyi/changelog#v1.6.2');
+    expect(link.textContent).toBe('v1.6.2');
+  });
+
+  it('follows the UI locale to the Ukrainian changelog', () => {
+    render(<VersionLink version="1.6.2" locale="uk" label={messagesUk.versionLink} />);
+
+    const link = screen.getByRole('link', { name: 'v1.6.2 — що нового' });
+    expect(link.getAttribute('href')).toBe('https://movar.fyi/uk/changelog#v1.6.2');
+  });
+
+  // WCAG 2.5.3: the visible text is the whole label, so the accessible name
+  // must contain it — a speech-input user says what they see. The regex anchors
+  // that the name STARTS with the stamp, which is the contract `versionLink`
+  // documents for both catalogues.
+  it('opens in a new tab, and its accessible name starts with the visible stamp', () => {
+    render(<VersionLink version="1.6.2" locale="en" label={messagesEn.versionLink} />);
+
+    const link = screen.getByRole('link', { name: /^v1\.6\.2/ });
+    expect(link.getAttribute('target')).toBe('_blank');
+    expect(link.getAttribute('rel')).toContain('noopener');
+  });
+});

--- a/apps/extension/src/lib/version-link.tsx
+++ b/apps/extension/src/lib/version-link.tsx
@@ -1,0 +1,45 @@
+/*
+ * The footer version stamp, shared by the popup and the options page.
+ *
+ * Both footers used to render the same inert `<span>v1.6.2</span>`. It's the one
+ * place in the UI that names a release, so it's where a user goes looking for
+ * what changed — this makes it the link to `movar.fyi/changelog`, anchored at
+ * the running version (see `changelog-url.ts`). Shared rather than duplicated so
+ * the two surfaces can't drift into linking differently.
+ *
+ * Resting appearance is unchanged from the old span (same type ramp, no
+ * underline) — it reads as a stamp until hovered or focused.
+ */
+import type { JSX } from 'react';
+import type { ResolvedLocale } from '@movar/i18n';
+import { changelogUrl } from './changelog-url';
+
+interface VersionLinkProps {
+  /** Manifest version, without the `v` prefix (`1.6.2`). */
+  version: string;
+  /** Resolved UI locale — picks the changelog's language on the site. */
+  locale: ResolvedLocale;
+  /** `t.versionLink`: takes the rendered stamp, returns the accessible name. */
+  label: (stamp: string) => string;
+}
+
+export function VersionLink({ version, locale, label }: Readonly<VersionLinkProps>): JSX.Element {
+  const stamp = `v${version}`;
+  const name = label(stamp);
+  return (
+    <a
+      href={changelogUrl(locale, version)}
+      // The popup is a transient window and the options page is a regular tab;
+      // in both, navigating in place would throw away the surface the user is
+      // standing on. `noopener` keeps the changelog from reaching back through
+      // `window.opener`.
+      target="_blank"
+      rel="noopener noreferrer"
+      title={name}
+      aria-label={name}
+      className="hover:text-ink-strong text-ui-micro font-mono tracking-wide transition-colors"
+    >
+      {stamp}
+    </a>
+  );
+}

--- a/apps/marketing/src/components/Changelog.astro
+++ b/apps/marketing/src/components/Changelog.astro
@@ -69,8 +69,14 @@ function shape(note: string): { title: string | null; lines: string[] } {
     {
       releases.map(({ version, note }) => {
         const shaped = note ? shape(note) : null;
+        /* The `id` below is the deep-link target for the extension's footer
+         * version stamp, which links here anchored at the version the visitor
+         * is actually running (apps/extension/src/lib/changelog-url.ts builds
+         * the same `v` + version fragment). `scroll-mt-24` (96px) clears the
+         * sticky header — measured at 73px — when the browser jumps to the
+         * anchor; without it the release lands underneath the header. */
         return (
-          <li class="border-t border-hairline pt-6">
+          <li id={`v${version}`} class="scroll-mt-24 border-t border-hairline pt-6">
             <h2 class="type-heading text-ink-strong">
               <span class="text-ink-muted">{t.versionLabel}</span> {version}
             </h2>

--- a/packages/brand/AGENTS.md
+++ b/packages/brand/AGENTS.md
@@ -6,8 +6,9 @@
 
 Exports the brand/contact constants shared between the extension and the
 marketing site: `SUPPORT_EMAIL`, `FEEDBACK_URL` (derived from `SUPPORT_EMAIL`),
-`SOURCE_URL` (the public MIT-licensed repo), and the three social destinations
-(`DISCORD_URL`, `INSTAGRAM_URL`, `FACEBOOK_URL`). Nothing else.
+`SOURCE_URL` (the public MIT-licensed repo), `SITE_URL` (the marketing site's
+origin), and the three social destinations (`DISCORD_URL`, `INSTAGRAM_URL`,
+`FACEBOOK_URL`). Nothing else.
 
 ## Boundaries & invariants
 
@@ -31,6 +32,7 @@ Single entry point `src/index.ts`:
 | `SUPPORT_EMAIL` | `support@movar.fyi`                                    |
 | `FEEDBACK_URL`  | `mailto:` built from `SUPPORT_EMAIL`                   |
 | `SOURCE_URL`    | `https://github.com/rejifald/movar`                    |
+| `SITE_URL`      | `https://movar.fyi` — origin only; callers add paths   |
 | `DISCORD_URL`   | Community server — **must be a never-expiring invite** |
 | `INSTAGRAM_URL` | `instagram.com/movar.fyi`                              |
 | `FACEBOOK_URL`  | Numeric profile URL — the page has no vanity handle    |

--- a/packages/brand/src/index.ts
+++ b/packages/brand/src/index.ts
@@ -15,6 +15,17 @@ export const FEEDBACK_URL = `mailto:${SUPPORT_EMAIL}?subject=Movar%20feedback`;
 export const SOURCE_URL = 'https://github.com/rejifald/movar';
 
 /**
+ * Movar's marketing site — origin only, no trailing slash.
+ *
+ * Deliberately not a set of per-page URLs: the site is bilingual and its `/uk`
+ * prefix is the site's own routing concern (`localeChangelogHref` and friends
+ * in `apps/marketing/src/i18n.ts`). Consumers outside the site compose the path
+ * they need on top of this origin — e.g. the extension's footer version link,
+ * `apps/extension/src/lib/changelog-url.ts`.
+ */
+export const SITE_URL = 'https://movar.fyi';
+
+/**
  * Movar's Discord server — the community channel, alongside `FEEDBACK_URL` for
  * anything that needs a private reply.
  *

--- a/packages/i18n/src/messages-en.ts
+++ b/packages/i18n/src/messages-en.ts
@@ -134,6 +134,12 @@ export interface Messages {
    *  in a new tab. Paired with a code glyph. Wording mirrors the marketing
    *  footer's "Source code". */
   sourceCode: string;
+  /** Accessible name (and tooltip) for the footer's version stamp on both the
+   *  popup and the options page, which links out to `movar.fyi/changelog`
+   *  anchored at the running version. Takes the stamp exactly as rendered
+   *  (`v1.6.2`) and must start with it: the visible text is the whole label, so
+   *  WCAG 2.5.3 (label in name) requires the accessible name to contain it. */
+  versionLink: (stamp: string) => string;
   /** Popup-only "report an issue" affordance. Unlike `feedback` (a bare mailto
    *  on both surfaces), this one is contextual: on an http(s) page the popup
    *  prefills that page's URL + the extension version into the body; on a
@@ -382,6 +388,7 @@ export const messagesEn: Messages = {
   settings: 'Settings',
   feedback: 'Send feedback',
   sourceCode: 'Source code',
+  versionLink: (stamp) => `${stamp} — what's new`,
   report: {
     link: 'Report an issue',
     subject: (host) => (host == null ? 'Movar — issue' : `Movar — issue on ${host}`),

--- a/packages/i18n/src/messages-uk.ts
+++ b/packages/i18n/src/messages-uk.ts
@@ -118,6 +118,7 @@ export const messagesUk: Messages = {
   settings: 'Налаштування',
   feedback: 'Надіслати відгук',
   sourceCode: 'Вихідний код',
+  versionLink: (stamp) => `${stamp} — що нового`,
   report: {
     link: 'Повідомити про проблему',
     subject: (host) => (host == null ? 'Мовар — проблема' : `Мовар — проблема на ${host}`),


### PR DESCRIPTION
## What

The version stamp in the popup and options footers is now a link to `movar.fyi/changelog`, anchored at the version the user is actually running.

## Why

The stamp was inert text on both surfaces. It's the only place in the UI that names a release, so it's where someone goes after noticing the number changed — and it went nowhere. The store listings are no answer either: Chrome has no release-notes field at all, and the Firefox and App Store listings only ever show the newest version's notes. `movar.fyi/changelog` renders `apps/extension/store-assets/RELEASE-NOTES.md` — the same file those listings read — so it's the one surface holding the whole history, in both languages.

## How

- **`apps/extension/src/lib/changelog-url.ts`** — `changelogUrl(locale, version)` builds `https://movar.fyi/changelog#v1.6.2`, or `/uk/changelog` when the resolved UI locale is Ukrainian, mirroring the site's own `localeChangelogHref`. The anchor is emitted **only for a real semver**: the static-serve preview renders `version = 'preview'` (no `browser.runtime.getManifest()`), and an anchor for that would resolve to nothing, so it opens the top of the page — the newest release — instead.
- **`apps/extension/src/lib/version-link.tsx`** — one shared `VersionLink` for both footers, so they can't drift into linking differently. Resting appearance is unchanged (same type ramp, no underline); opens in a new tab with `noopener`, since navigating in place would throw away the popup the user is standing in.
- **`apps/marketing/src/components/Changelog.astro`** — each release now carries the matching `id`, plus `scroll-mt-24`. The site header is sticky and measures 73px, so without the offset the jump lands the release underneath it.
- **`@movar/brand`** gains `SITE_URL` — the origin only. The `/uk` prefix is the marketing site's own routing concern, and that package is constants-without-logic, so callers compose the path.
- **`@movar/i18n`** gains `versionLink`, which starts with the visible stamp (`v1.6.2 — what's new` / `— що нового`) so the accessible name contains the visible label, as WCAG 2.5.3 requires.

## For the reviewer

**The Safari host app is deliberately not included.** Its About tab shows the same stamp as plain text — the third instance of this class. It's blocked, not overlooked: the WKWebView runs under `default-src 'self'`, so external links route through the native bridge, and the `open-url` case doesn't exist in `ViewController.swift` yet. The existing "Source code" button there is already a documented no-op on device, so a changelog button today would just be a second dead control. Filed as follow-up work that starts with the native pass.

## Verification

- Full pre-push suite green: build (extension + marketing + safari-host-app), 20 offline e2e tests, `fallow audit`, README metrics parity — no snapshot drift.
- 1446 extension unit tests (10 new, covering `changelogUrl` and `VersionLink`), 119 i18n tests.
- The e2e footer assertions in `popup.spec.ts` / `options.spec.ts` now check the `href`, not just the text — that's what proves the anchor tracks the manifest version rather than silently pointing at the top of the page.
- Marketing build output confirmed to carry the `id`s in both locales and the emitted `scroll-margin-top` rule; the sticky header's 73px was measured in a rendered page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)