### PR TITLE
feat(release): link the full changelog from every store note

### DIFF
--- a/apps/extension/store-assets/RELEASE-NOTES.md
+++ b/apps/extension/store-assets/RELEASE-NOTES.md
@@ -30,6 +30,20 @@ so this is not a step you can forget, only one you can leave undone.
 Only the **fenced block** under each locale heading ships. Prose between the
 headings is editorial context for whoever writes the next one.
 
+**Don't write the changelog link into a block.** A store listing shows one
+version's note and nothing else, so `withChangelogLink` in
+[`scripts/lib/release-notes.mjs`](../../../scripts/lib/release-notes.mjs)
+appends a pointer to `movar.fyi/changelog` — the Ukrainian page for `uk`, the
+English one for `en` — as each store note is submitted. It happens at that
+boundary and not here because movar.fyi/changelog renders these same blocks and
+would link to itself, and because each store wants its own idiom: the App
+Store's "What's New" is plain text (spelled-out URL, not tappable), while AMO's
+release notes are sanitized HTML (a real anchor, which AMO rewrites through its
+outgoing-link bouncer). Both stores allow it — Apple's metadata rules bar other
+marketplaces and irrelevant content, not a link to your own site. Keep the
+budget in mind anyway: `pnpm check:release-notes` fails if a note plus its
+footer exceeds the App Store's 4000-character cap.
+
 ---
 
 ## 1.6.2

--- a/docs/safari-deploy.md
+++ b/docs/safari-deploy.md
@@ -199,7 +199,9 @@ It is idempotent at every level: an editable version is reused rather than
 duplicated, and a version already `WAITING_FOR_REVIEW` or `READY_FOR_SALE` is
 reported and left alone. Release notes come from
 [RELEASE-NOTES.md](../apps/extension/store-assets/RELEASE-NOTES.md) — only the
-fenced blocks ship, not the editorial prose around them — and a locale with no
+fenced blocks ship, not the editorial prose around them — with a
+`movar.fyi/changelog` pointer appended per locale on the way out (the store
+shows one version's note; the site has the whole history). A locale with no
 note is a hard error naming the locale, because App Store Connect rejects a
 version whose localization has no "What's New".
 
@@ -340,7 +342,10 @@ succeeds locally.
    [`apps/extension/store-assets/RELEASE-NOTES.md`](../apps/extension/store-assets/RELEASE-NOTES.md)
    with this version's user-facing highlights in **Ukrainian and English**,
    distilled from [`apps/extension/CHANGELOG.md`](../apps/extension/CHANGELOG.md).
-   You'll paste each locale in the next step.
+   You'll paste each locale in the next step. Pasting by hand skips the
+   `movar.fyi/changelog` footer the automated path appends, so add it yourself:
+   `Повний журнал змін: https://movar.fyi/uk/changelog` for uk,
+   `Full changelog: https://movar.fyi/changelog` for en.
 
 8. **Submit for review.** Prefer the automated path — see
    [Submitting for review](#submitting-for-review-safari-submityml) below; it

--- a/scripts/amo-release-notes.mjs
+++ b/scripts/amo-release-notes.mjs
@@ -35,7 +35,7 @@ import { createHmac, randomUUID } from 'node:crypto';
 import { readFileSync } from 'node:fs';
 import { resolve, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { parseReleaseNotes, noteForLocale } from './lib/release-notes.mjs';
+import { parseReleaseNotes, noteForLocale, withChangelogLink } from './lib/release-notes.mjs';
 
 const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 const NOTES = 'apps/extension/store-assets/RELEASE-NOTES.md';
@@ -150,7 +150,11 @@ async function main() {
       console.error(`✗ No ${fileLocale} note for ${version} — cannot set AMO's ${amoLocale}.`);
       process.exit(1);
     }
-    releaseNotes[amoLocale] = note;
+    // AMO renders release notes as sanitized HTML (`sanitizeUserHTML`, which
+    // allows `a` and converts newlines with `nl2br` first), so the footer is a
+    // real anchor rather than a bare URL. AMO rewrites the href through its
+    // outgoing-link bouncer on display.
+    releaseNotes[amoLocale] = withChangelogLink(note, fileLocale, { format: 'html' });
   }
 
   console.log(`AMO release notes — ${addon} ${version} [${Object.keys(releaseNotes).join(', ')}]`);

--- a/scripts/apple-submit.mjs
+++ b/scripts/apple-submit.mjs
@@ -50,7 +50,7 @@ import { readFileSync } from 'node:fs';
 import { resolve, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { clientFromEnv, request, requireOk } from './lib/asc-api.mjs';
-import { parseReleaseNotes, noteForLocale } from './lib/release-notes.mjs';
+import { parseReleaseNotes, noteForLocale, withChangelogLink } from './lib/release-notes.mjs';
 
 const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 const env = (name, fallback = '') => (process.env[name] ?? '').trim() || fallback;
@@ -261,6 +261,9 @@ async function submitPlatform(token, { appId, platform, version, notes, buildNum
         `no "What's New" written for locale ${locale}. Add a "### … (${locale.split('-')[0]})" block under "## ${version}" in RELEASE-NOTES.md.`,
       );
     }
+    // "What's New" is plain text — no markup, and the URL is not tappable on
+    // the App Store — so the footer spells the address out in full.
+    const whatsNew = withChangelogLink(note, locale, { format: 'text' });
     await write(
       token,
       `set What's New for ${locale} (${note.split('\n')[0].slice(0, 40)}…)`,
@@ -271,7 +274,7 @@ async function submitPlatform(token, { appId, platform, version, notes, buildNum
           data: {
             type: 'appStoreVersionLocalizations',
             id: localization.id,
-            attributes: { whatsNew: note },
+            attributes: { whatsNew },
           },
         },
       },

--- a/scripts/check-release-notes.mjs
+++ b/scripts/check-release-notes.mjs
@@ -19,7 +19,7 @@
 import { readFileSync } from 'node:fs';
 import { resolve, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { parseReleaseNotes, noteForLocale } from './lib/release-notes.mjs';
+import { parseReleaseNotes, noteForLocale, withChangelogLink } from './lib/release-notes.mjs';
 
 const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 const NOTES = 'apps/extension/store-assets/RELEASE-NOTES.md';
@@ -29,6 +29,14 @@ const REQUIRED_LOCALES = ['uk', 'en'];
 
 /** Shorter than this is a stub, not a note. */
 const MIN_LENGTH = 20;
+
+/**
+ * App Store Connect caps "What's New" at 4000 characters per localization and
+ * rejects the write over it. Measured on the note as the store will actually
+ * receive it — `withChangelogLink` adds the movar.fyi/changelog footer at the
+ * submission boundary, so the budget has to include it.
+ */
+const MAX_LENGTH = 4000;
 
 const version =
   (process.env.VERSION ?? '').trim() ||
@@ -51,6 +59,13 @@ if (!forVersion) {
       problems.push(
         `the ${locale} note under "## ${version}" is empty or a stub (${note.trim().length} chars) — the scaffold was never filled in.`,
       );
+    } else {
+      const forStore = withChangelogLink(note.trim(), locale, { format: 'text' });
+      if (forStore.length > MAX_LENGTH) {
+        problems.push(
+          `the ${locale} note under "## ${version}" is ${forStore.length} chars once the changelog link is appended — App Store Connect caps "What's New" at ${MAX_LENGTH}. Trim it.`,
+        );
+      }
     }
   }
 }

--- a/scripts/lib/release-notes.mjs
+++ b/scripts/lib/release-notes.mjs
@@ -31,6 +31,9 @@
 // "What's New", and the other surfaces just render blank. A parser that quietly
 // returned nothing would surface as a metadata rejection far from the actual
 // cause, so every extraction failure here is explicit.
+//
+// It also composes the store-only "full changelog" footer — see
+// `withChangelogLink` below.
 
 /** Locale code as written in a `### Name (code)` heading. */
 const LOCALE_HEADING = /^###\s+.*\(([a-zA-Z-]+)\)\s*$/;
@@ -126,4 +129,69 @@ export function noteForLocale(notes, storeLocale) {
     if (locale.split('-')[0].toLowerCase() === language) return note;
   }
   return undefined;
+}
+
+/**
+ * The public changelog on movar.fyi, per locale. Mirrors
+ * `localeChangelogHref()` in apps/marketing/src/i18n.ts — en at the root,
+ * uk under `/uk/`. Deep-link the page rather than the home page: `/install`
+ * carries Chrome / Firefox / Edge store links, and App Store guideline 2.3.10
+ * ("no other mobile platforms or alternative app marketplaces in your
+ * metadata") is only unarguable if a reviewer following the link never lands
+ * on them.
+ *
+ * Keyed the same way notes are, so `noteForLocale` resolves `en-US` → `en`.
+ */
+const CHANGELOG_URLS = new Map([
+  ['uk', 'https://movar.fyi/uk/changelog'],
+  ['en', 'https://movar.fyi/changelog'],
+]);
+
+/** Link label, per locale. "журнал змін" matches the site's own wording. */
+const CHANGELOG_LABELS = new Map([
+  ['uk', 'Повний журнал змін'],
+  ['en', 'Full changelog'],
+]);
+
+/**
+ * Append "full changelog" pointer to a note bound for a store listing.
+ *
+ * A store note covers ONE version. Someone arriving on 1.7.0 after skipping
+ * three releases has no way, from the listing alone, to see what changed in
+ * the ones they missed — the store shows one block and the older text is
+ * either buried (AMO) or gone (App Store). movar.fyi/changelog is the whole
+ * history in the reader's language, so the stores link out to it.
+ *
+ * Applied at the store boundary rather than written into the fenced block in
+ * RELEASE-NOTES.md, for two reasons: the marketing changelog renders those
+ * same blocks and would end up linking to itself, and each surface needs its
+ * own idiom — App Store's "What's New" is plain text, while AMO's release
+ * notes are sanitized HTML (`sanitizeUserHTML`, whose allowlist includes `a`,
+ * with newlines converted by `nl2br` first).
+ *
+ * Both stores permit this: Apple's metadata rules bar other marketplaces and
+ * irrelevant content, not a link to your own site, and its 3.1.1 external-link
+ * ban is about purchase mechanisms, which Movar has none of. AMO renders the
+ * anchor through Mozilla's outgoing-link bouncer.
+ *
+ * An unknown locale degrades to the bare note instead of throwing. The note is
+ * load-bearing — App Store Connect rejects a localization without one — and
+ * the footer is not, so a locale we have no label for must not be able to
+ * block a release.
+ *
+ * @param {string} note          the note as written in RELEASE-NOTES.md
+ * @param {string} storeLocale   'uk', 'en-US', …
+ * @param {{ format: 'text' | 'html' }} options
+ * @returns {string}
+ */
+export function withChangelogLink(note, storeLocale, { format }) {
+  const url = noteForLocale(CHANGELOG_URLS, storeLocale);
+  const label = noteForLocale(CHANGELOG_LABELS, storeLocale);
+  if (!url || !label) return note;
+  // Idempotent: a note that already spells out the URL by hand keeps whatever
+  // wording the author chose rather than getting a second copy underneath.
+  if (note.includes(url)) return note;
+
+  const footer = format === 'html' ? `<a href="${url}">${label}</a>` : `${label}: ${url}`;
+  return `${note.trimEnd()}\n\n${footer}`;
 }

--- a/scripts/lib/release-notes.test.mjs
+++ b/scripts/lib/release-notes.test.mjs
@@ -17,7 +17,7 @@
 import { readFileSync } from 'node:fs';
 import { resolve, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { parseReleaseNotes, noteForLocale } from './release-notes.mjs';
+import { parseReleaseNotes, noteForLocale, withChangelogLink } from './release-notes.mjs';
 
 const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..');
 let failed = 0;
@@ -118,6 +118,42 @@ eq(
   'an unwritten locale reports missing rather than guessing',
   noteForLocale(notes, 'de-DE'),
   undefined,
+);
+
+// --- the store-only changelog footer --------------------------------------
+// The stores show one version's note and nothing else, so they link out to the
+// full history. Applied at the store boundary, NOT in RELEASE-NOTES.md, so the
+// marketing changelog that renders the same blocks never links to itself.
+const ukNote = 'Що нового у версії 1.6.2\n\n• Пункт один';
+eq(
+  'uk gets the Ukrainian page as plain text',
+  withChangelogLink(ukNote, 'uk', { format: 'text' }),
+  `${ukNote}\n\nПовний журнал змін: https://movar.fyi/uk/changelog`,
+);
+eq(
+  "the App Store's en-US resolves to the en page",
+  withChangelogLink('Note', 'en-US', { format: 'text' }),
+  'Note\n\nFull changelog: https://movar.fyi/changelog',
+);
+eq(
+  'html format emits an anchor for AMO',
+  withChangelogLink('Note', 'en', { format: 'html' }),
+  'Note\n\n<a href="https://movar.fyi/changelog">Full changelog</a>',
+);
+truthy(
+  'the uk footer never points at the English page',
+  !withChangelogLink(ukNote, 'uk', { format: 'text' }).includes('movar.fyi/changelog'),
+  'uk note linked to the en changelog',
+);
+eq(
+  'a hand-written link is not duplicated',
+  withChangelogLink('Note https://movar.fyi/changelog', 'en', { format: 'text' }),
+  'Note https://movar.fyi/changelog',
+);
+eq(
+  'an unknown locale degrades to the bare note rather than failing the release',
+  withChangelogLink('Note', 'de-DE', { format: 'text' }),
+  'Note',
 );
 
 // --- the live file --------------------------------------------------------


### PR DESCRIPTION
A store listing shows one version's note and nothing else. Someone landing on 1.7.0 after skipping three releases has no way, from the listing alone, to see what they missed — the older text is buried on AMO and gone on the App Store. `movar.fyi/changelog` is the whole history in the reader's language, so the store notes now point at it.

## Rules check, first

Both stores that *have* a notes field permit a link to your own site:

| Store | Notes field | Verdict |
| --- | --- | --- |
| App Store (iOS + macOS) | `whatsNew`, plain text, 4000 chars | **Allowed.** 2.3.12 only requires that changes be described; 2.3.10 bars other mobile platforms / alternative app marketplaces and irrelevant content — a link to our own changelog is neither; 3.1.1's external-link ban targets purchasing mechanisms, which Movar has none of. |
| Firefox AMO | `release_notes`, per-version, translated | **Allowed, renders as a real link.** AMO pipes release notes through [`sanitizeUserHTML`](https://github.com/mozilla/addons-frontend/blob/master/src/amo/utils/index.js), whose allowlist leads with `a` (`allowLinks` defaults true; `AddonVersionCard` doesn't disable it) after `nl2br`. Confirmed against uBlock Origin's stored notes — `<a href=…>` anchors, rewritten through Mozilla's outgoing-link bouncer. |
| Chrome Web Store | none | Nothing to add. |
| Edge | none user-facing | Its per-version text is "Notes for certification" — reviewer-only, fed from `CHANGELOG.md`. Untouched. |

It deep-links `/changelog` rather than the home page, so a reviewer following it never lands on `/install` and its Chrome / Firefox / Edge store links. That keeps 2.3.10 unarguable.

## What changed

`withChangelogLink` composes the footer **at the store boundary**, not in `RELEASE-NOTES.md`. Two reasons: `Changelog.astro` renders those same fenced blocks and would link to itself, and each store wants its own idiom.

- `scripts/apple-submit.mjs` — `Повний журнал змін: https://movar.fyi/uk/changelog` (plain text; the field has no markup and the URL isn't tappable, so it's spelled out). `en-US` resolves to the `en` URL through the existing subtag resolver.
- `scripts/amo-release-notes.mjs` — `<a href="https://movar.fyi/uk/changelog">Повний журнал змін</a>`.

Deliberately left out: the **GitHub Release body** (not a marketplace, and it already sits beside the repo's own `CHANGELOG.md`) and **movar.fyi/changelog** itself (the destination). Swept every consumer of the parser to confirm those are the only two.

An unknown locale degrades to the bare note instead of throwing. App Store Connect rejects a localization with no "What's New", so the note is load-bearing and a missing footer label must never be able to block a release. Appending is idempotent if someone hand-writes the URL.

Since this makes every note longer, `check:release-notes` now also fails when a note plus its footer exceeds the App Store's 4000-char cap for `whatsNew`, measured on the text the store actually receives. 1.6.2 composes to 417 chars (uk) / 367 (en).

## Verification

`pnpm test:release-notes` — 21 assertions, 6 new covering both formats, `en-US` → `en` resolution, the uk page never leaking into the en note, idempotence, and the unknown-locale degradation. `pnpm check:release-notes` green. Composed output eyeballed for all four store/locale pairs.

Note: AMO release notes have never actually been set on a real release — `release_notes` reads `null` for 1.6.1/1.6.2 because `amo-release-notes.mjs` landed in #389, after 1.6.2 shipped. The next release is the first to exercise that path, so the rendered version-history entry is worth an eyeball then.

🤖 Generated with [Claude Code](https://claude.com/claude-code)