### PR TITLE
fix(metrics): exclude generated dirs from the source-line count

### DIFF
--- a/.github/workflows/metrics-gate.yml
+++ b/.github/workflows/metrics-gate.yml
@@ -4,10 +4,12 @@ name: Metrics gate
 # maintainer explicitly accepts the regression. Three things are checked
 # (see scripts/metrics-gate.mts for the full rationale):
 #
-#   1. Coverage freshness — the committed `readme-metrics.snapshot.json` must
-#      match freshly-recomputed coverage. Keeps the README badge honest AND
-#      keeps `main`'s snapshot trustworthy as the regression baseline below, so
-#      we never have to run coverage on the base commit.
+#   1. Snapshot freshness — the committed `readme-metrics.snapshot.json` must
+#      match the freshly-recomputed coverage AND source-line count. Keeps the
+#      README badges honest AND keeps `main`'s snapshot trustworthy as the
+#      regression baseline below, so we never have to run coverage on the base
+#      commit. (LOC needs no extra step here: the `--refresh` below recomputes
+#      it unconditionally.)
 #   2. Coverage regression — recomputed coverage must not drop below the base
 #      commit's snapshot.
 #   3. Code-quality regression — `fallow audit --base <base>` must not introduce

--- a/docs/metrics-gate.md
+++ b/docs/metrics-gate.md
@@ -11,11 +11,11 @@ but can't notice when the snapshot itself drifts from reality. This gate does.
 Implemented in [`scripts/metrics-gate.mts`](../scripts/metrics-gate.mts), run by
 [`.github/workflows/metrics-gate.yml`](../.github/workflows/metrics-gate.yml) on
 every PR. It recomputes the dynamic metrics for the PR head and compares them
-three ways:
+four ways:
 
 | #   | Check                       | Fails when                                                                   | Overridable?                                  |
 | --- | --------------------------- | ---------------------------------------------------------------------------- | --------------------------------------------- |
-| 1   | **Coverage freshness**      | the committed `readme-metrics.snapshot.json` coverage ≠ recomputed coverage  | No — a wrong number is wrong, not a trade-off |
+| 1   | **Snapshot freshness**      | the committed `readme-metrics.snapshot.json` coverage or LOC ≠ recomputed    | No — a wrong number is wrong, not a trade-off |
 | 2   | **Coverage regression**     | recomputed line/branch coverage drops below the base commit's snapshot       | Yes (label)                                   |
 | 3   | **Code-quality regression** | `fallow audit --base <base>` finds new dead code, complexity, or duplication | Yes (label)                                   |
 | 4   | **Coverage floor**          | recomputed line/branch coverage drops below the absolute `COVERAGE_FLOOR`    | No — a waivable floor is the ratchet it stops |
@@ -23,6 +23,18 @@ three ways:
 Check 1 does double duty: enforcing it on every PR keeps `main`'s committed
 snapshot honest, which is what lets check 2 use that snapshot as the baseline
 instead of re-running coverage on the base commit.
+
+It covers the source-line count as well as coverage. LOC used to be only
+_rendered_ into the README badge and never gated, so it drifted freely: a snapshot
+refreshed after a build or lint counted the `.ts` files those tools generate
+(`apps/marketing/.astro/content.d.ts` and friends) and one refreshed on a clean
+checkout didn't, so the badge rounded to whichever the author happened to run.
+The generated directories are now excluded by `BUILD_DIRS` in
+[`scripts/gen-readme-metrics.mts`](../scripts/gen-readme-metrics.mts), which makes
+LOC a pure function of the source tree and therefore safe to pin — and pinning it
+costs the gate nothing, since the `--refresh` step already recomputes it. If LOC
+staleness ever fails on a PR that genuinely didn't change it, suspect a new
+generated directory missing from `BUILD_DIRS` rather than a bad snapshot.
 
 Check 4 is the backstop check 2 can't be: base-relative regression only catches
 a single large drop, so a run of sub-threshold PRs — or repeated use of the
@@ -40,8 +52,8 @@ the check flaky. Base-relative quality regressions are caught by `fallow audit`
 
 ## Fixing a red gate
 
-- **Stale coverage (exit 2):** run `pnpm metrics` and commit the updated
-  `scripts/readme-metrics.snapshot.json` (and `README.md`).
+- **Stale snapshot — coverage or LOC (exit 2):** run `pnpm metrics` and commit
+  the updated `scripts/readme-metrics.snapshot.json` (and `README.md`).
 - **Coverage regression (exit 1):** add tests, or accept it (below).
 - **`fallow audit` regression (exit 1):** remove the dead code / split the
   complex function / de-duplicate, or accept it (below). `pnpm metrics:audit`

--- a/scripts/gen-readme-metrics.mts
+++ b/scripts/gen-readme-metrics.mts
@@ -196,15 +196,38 @@ function coverageColor(pct: number): string {
 }
 
 // --- static collectors (committed sources only) -----------------------------
+/**
+ * Generated directories the source scan below must not descend into. Every one
+ * is gitignored tool output, and each can contain `.ts` — so counting them
+ * would make LOC depend on *what ran before* `pnpm metrics` rather than on the
+ * source tree. `apps/marketing/.astro` is the one that actually bit us:
+ * `astro sync` (which the marketing package's own `lint` script runs, as do
+ * `astro build` / `astro check`) writes a ~210-line `content.d.ts` there, so a
+ * refresh after `pnpm lint` reported ~210 lines more than a refresh on a clean
+ * checkout, and the README badge rounded to a different number depending on
+ * which one the author happened to run. Keep this in step with .gitignore: a
+ * generated dir missing here is a silently wrong metric, not a loud failure.
+ */
 const BUILD_DIRS = new Set([
   'node_modules',
   '.output',
   'dist',
   '.nx',
   '.wxt',
+  '.astro',
+  '.wrangler',
   'coverage',
   '.turbo',
+  'storybook-static',
+  'test-results',
+  'demo-results',
 ]);
+
+/** `BUILD_DIRS` plus the `playwright-report*` family — the e2e configs write
+ *  `playwright-report`, `-live`, and `-compare`, and .gitignore covers them
+ *  with a prefix glob, so match on the prefix rather than pinning each name. */
+const isBuildDir = (name: string): boolean =>
+  BUILD_DIRS.has(name) || name.startsWith('playwright-report');
 
 /** Test/spec/helper files, excluded from the source-line count. */
 const isTest = (name: string): boolean => /\.(test|spec|test-utils)\.tsx?$/.test(name);
@@ -219,7 +242,7 @@ function scanSourceStats(): { loc: number; eslint: number; fallow: number } {
   const walk = (dir: string): void => {
     for (const entry of readdirSync(dir, { withFileTypes: true })) {
       if (entry.isDirectory()) {
-        if (!BUILD_DIRS.has(entry.name)) walk(nodePath.resolve(dir, entry.name));
+        if (!isBuildDir(entry.name)) walk(nodePath.resolve(dir, entry.name));
       } else if (/\.tsx?$/.test(entry.name)) {
         const text = readFileSync(nodePath.resolve(dir, entry.name), 'utf8');
         eslint += (text.match(/eslint-disable/g) ?? []).length;

--- a/scripts/metrics-gate.mts
+++ b/scripts/metrics-gate.mts
@@ -11,15 +11,21 @@
  * reality — `check:readme` reads the same committed file to both render and
  * verify, so a PR that quietly lowers coverage keeps a stale-but-consistent
  * badge and stays green. This gate closes that hole by recomputing the real
- * numbers in CI and comparing them three ways:
+ * numbers in CI and comparing them four ways:
  *
- *   1. FRESHNESS (coverage): the recomputed coverage must equal what the PR
- *      committed in the snapshot. A mismatch means the committed snapshot is
- *      stale or hand-edited — the author must run `pnpm metrics` and commit.
- *      Not acknowledgeable: a wrong number isn't a "regression", it's wrong.
- *      Enforcing this on every PR is also what keeps `main`'s snapshot honest,
- *      so it can serve as the regression BASELINE below without re-running
- *      coverage on the base commit.
+ *   1. FRESHNESS (coverage + LOC): the recomputed coverage and source-line count
+ *      must equal what the PR committed in the snapshot. A mismatch means the
+ *      committed snapshot is stale or hand-edited — the author must run
+ *      `pnpm metrics` and commit. Not acknowledgeable: a wrong number isn't a
+ *      "regression", it's wrong. Enforcing this on every PR is also what keeps
+ *      `main`'s snapshot honest, so it can serve as the regression BASELINE
+ *      below without re-running coverage on the base commit.
+ *      LOC is pinned here — not merely rendered — because it is a pure function
+ *      of the source tree and costs the gate nothing extra (the workflow already
+ *      runs `--refresh`, which recomputes it unconditionally). Unpinned, it
+ *      silently drifted by hundreds of lines between snapshots and rendered a
+ *      visibly wrong README badge; the determinism it relies on is BUILD_DIRS in
+ *      gen-readme-metrics.mts, so keep that list current with .gitignore.
  *
  *   2. REGRESSION (coverage): the recomputed coverage must not drop below the
  *      base commit's snapshot (`git show <base>:…snapshot.json`).
@@ -87,6 +93,7 @@ interface Coverage {
 }
 interface Snapshot {
   coverage?: Coverage;
+  loc?: number;
 }
 
 function readSnapshot(path: string, label: string): Snapshot {
@@ -142,7 +149,17 @@ if (!recomputed.coverage) {
 }
 const fresh = recomputed.coverage;
 
-// --- 1. Freshness: committed coverage must match the recomputed truth --------
+// --- 1. Freshness: the committed snapshot must match the recomputed truth ----
+// Both stale values are fixed by the same `pnpm metrics` run, so they're
+// collected and reported together rather than one failure per push.
+if (recomputed.loc == null) {
+  throw new Error(
+    '[metrics-gate] recomputed snapshot has no loc — did `pnpm gen:readme --refresh` run first?',
+  );
+}
+const freshLoc = recomputed.loc;
+
+const staleness: string[] = [];
 const committedCov = committed.coverage;
 const coverageStale =
   !committedCov ||
@@ -152,10 +169,32 @@ if (coverageStale) {
   const was = committedCov
     ? `${committedCov.lines}% lines / ${committedCov.branches}% branches`
     : '(absent)';
-  console.error('✗ Committed coverage is stale or inaccurate.');
-  console.error(`    committed: ${was}`);
-  console.error(`    recomputed: ${fresh.lines}% lines / ${fresh.branches}% branches`);
+  staleness.push(
+    `coverage — committed ${was}, recomputed ${fresh.lines}% lines / ${fresh.branches}% branches`,
+  );
+}
+// Unlike coverage, LOC is an exact integer read straight off the source tree —
+// no test run, no rounding, so no epsilon and no room for honest disagreement.
+// It only ever diverges when the committed number is stale, hand-edited, or
+// scanned over a tree that had generated `.ts` in it (see BUILD_DIRS).
+const locStale = committed.loc !== freshLoc;
+if (locStale) {
+  staleness.push(
+    `lines of code — committed ${committed.loc ?? '(absent)'}, recomputed ${freshLoc}`,
+  );
+}
+if (staleness.length > 0) {
+  console.error('✗ The committed metrics snapshot is stale or inaccurate:');
+  for (const item of staleness) console.error(`    ${item}`);
   console.error(`  Run \`pnpm metrics\` and commit ${snapshotRel} (+ README.md), then push.`);
+  if (locStale) {
+    console.error(
+      '  If the LOC number is reproducible for you but not here, a generated directory is leaking',
+    );
+    console.error(
+      '  into the source scan — add it to BUILD_DIRS in scripts/gen-readme-metrics.mts.',
+    );
+  }
   process.exit(2);
 }
 

--- a/scripts/metrics-gate.test.mts
+++ b/scripts/metrics-gate.test.mts
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 /**
- * Regression test for the metrics-gate absolute coverage floor (issue #114).
+ * Regression tests for the two non-waivable metrics-gate checks: the absolute
+ * coverage floor (issue #114) and snapshot freshness.
  *
  * The repo has no vitest project globbing root `scripts/`, so this is a small
  * spawn-based runner (same pattern as the other script tests). It drives
@@ -10,6 +11,9 @@
  *   1. coverage below the floor  -> exit 3 (the floor), even WITH the accept
  *      label set — the floor is non-waivable.
  *   2. coverage above the floor, fresh, no regression/audit -> exit 0.
+ *   3. a committed LOC that disagrees with the recomputed one -> exit 2
+ *      (staleness), also with the accept label set — freshness is likewise
+ *      non-waivable.
  *
  * BASE_SHA is a bogus sha on purpose: the gate handles a missing base snapshot
  * gracefully (skips the base-relative regression check), isolating the floor.
@@ -26,20 +30,26 @@ const here = nodePath.dirname(fileURLToPath(import.meta.url));
 const gateScript = nodePath.join(here, 'metrics-gate.mts');
 const tmp = mkdtempSync(nodePath.join(tmpdir(), 'movar-metrics-gate-'));
 
-function snapshot(coverage: { lines: number; branches: number }): string {
+/** The gate compares committed LOC against recomputed LOC, so the absolute
+ *  value is irrelevant to every assertion below — only whether the two agree. */
+const LOC = 60_917;
+
+function snapshot(coverage: { lines: number; branches: number }, loc: number): string {
   const p = nodePath.join(tmp, `snap-${coverage.lines}-${coverage.branches}-${Math.random()}.json`);
-  writeFileSync(p, JSON.stringify({ coverage }));
+  writeFileSync(p, JSON.stringify({ coverage, loc }));
   return p;
 }
 
 /** Run the gate with a given recomputed + committed coverage (kept equal so the
- *  freshness check passes and we isolate the floor) and optional accept label. */
+ *  freshness check passes and we isolate the floor) and optional accept label.
+ *  `committedLoc` defaults to the recomputed value; override it to make the
+ *  committed snapshot stale. */
 function runGate(
   coverage: { lines: number; branches: number },
-  opts: { acceptLabel?: boolean } = {},
+  opts: { acceptLabel?: boolean; committedLoc?: number } = {},
 ): number {
-  const recomputed = snapshot(coverage);
-  const committed = snapshot(coverage); // equal -> fresh
+  const recomputed = snapshot(coverage, LOC);
+  const committed = snapshot(coverage, opts.committedLoc ?? LOC); // equal -> fresh
   const result = spawnSync('npx', ['--no-install', 'tsx', gateScript], {
     env: {
       ...process.env,
@@ -78,10 +88,24 @@ expectExit(
 // regression (bogus base + AUDIT_OUTCOME=success) -> pass.
 expectExit('above floor, fresh, no regression passes', runGate({ lines: 92.7, branches: 85.6 }), 0);
 
+console.log('==> metrics-gate LOC freshness');
+
+// A committed LOC that disagrees with the recomputed one is stale (exit 2) —
+// this is the check that would have caught generated `.astro` type files
+// inflating the count. Like coverage freshness, the accept label must not
+// rescue it: the number is simply wrong, not a trade-off.
+const fresh = { lines: 92.7, branches: 85.6 };
+expectExit('stale committed LOC fails with exit 2', runGate(fresh, { committedLoc: LOC + 210 }), 2);
+expectExit(
+  'stale committed LOC still fails (exit 2) even WITH the accept label',
+  runGate(fresh, { committedLoc: LOC + 210, acceptLabel: true }),
+  2,
+);
+
 rmSync(tmp, { recursive: true, force: true });
 
 if (failed > 0) {
-  console.error(`✗ metrics-gate floor test FAILED (${failed} case(s))`);
+  console.error(`✗ metrics-gate test FAILED (${failed} case(s))`);
   process.exit(1);
 }
-console.log('✓ metrics-gate floor test passed');
+console.log('✓ metrics-gate floor + freshness tests passed');


### PR DESCRIPTION
## What

`scanSourceStats()` in `scripts/gen-readme-metrics.mts` skipped build directories
by name, but not `apps/marketing/.astro`. `astro sync` — which the marketing
package's own `lint` script runs, as do `astro build` and `astro check` — writes
a ~208-line `content.d.ts` and a `types.d.ts` there. Both end in `.ts` and
neither looks like a test, so both were counted as source.

So `loc` depended on whether a build or a lint had run before `pnpm metrics`,
not on the source tree:

| | `loc` | README badge |
| --- | --- | --- |
| before, `.astro` present | 61127 | `61.1k` |
| after, `.astro` present | 60917 | `60.9k` |
| after, clean checkout | 60917 | `60.9k` |

That is why historical snapshots drifted unpredictably (+206 at #406, +469 at
#424, +176 at #427) and why the badge recently rendered `56.9k` where the true
source count was `56.7k`.

## Changes

**`BUILD_DIRS` gains the generated dirs that can hold `.ts`** — `.astro`,
`.wrangler`, `storybook-static`, `test-results`, `demo-results`. The
`playwright-report*` family (`playwright-report`, `-live`, `-compare`, all
written by the e2e configs) is matched by prefix via a new `isBuildDir()` helper,
since `.gitignore` covers them with a glob and an exact-name `Set` can't. Checked
that no tracked file lives under any of those names, so nothing real is skipped.

**The metrics gate now pins `loc` alongside coverage.** It is a pure function of
the source tree once the generated dirs are excluded, and the gate's `--refresh`
step already recomputes it, so the check costs nothing — leaving it unpinned is
why the drift went unnoticed for so long. It is folded into the existing
freshness check: exit 2, non-waivable, with coverage and LOC reported together so
one `pnpm metrics` run fixes both. The failure message names `BUILD_DIRS` as the
likely culprit when the number is reproducible locally but not in CI.

The two halves are coupled: without the `.astro` exclusion, pinning `loc` would
have failed the gate for anyone who ran `pnpm lint` before `pnpm metrics`.

Docs (`docs/metrics-gate.md`) and the workflow header updated to match. The gate
test gains two cases — stale LOC fails with exit 2, and still fails with the
`accept-metrics-regression` label — alongside the three existing floor cases.

## For the reviewer

- **No snapshot or README change.** This branch's committed `loc` of 60917 was
  already the clean value, so the fix locks it in rather than correcting it.
- **I ran `gen:readme --refresh`, not the full `pnpm metrics`.** The heavy half
  (fallow, coverage, the content-bundle guard) cannot move any number here — the
  diff touches only `scripts/`, `docs/`, and `.github/` — and refreshing `health`
  would have added churn the docs themselves describe as drifting commit-to-commit
  with git history. Happy to run the full refresh if you'd rather.
- **Verified empirically**, not just by reading: ran `astro sync` to generate the
  real 208 lines, re-ran the refresh, and got a byte-identical snapshot and
  README. Also swept a checkout carrying `.astro`, `playwright-report`, and
  `test-results` — zero gitignored directories contribute source lines, and it
  agrees with a clean worktree exactly.
- **No changeset**, since this ships no package code — it is build tooling, CI
  config, and docs. Say the word if you want one anyway.
- `packages/audit/**` is untouched, as requested. Worth knowing separately:
  `pnpm install` in a fresh worktree flips `packages/audit/src/collect/cli.ts`
  from mode 644 to 755 (pnpm chmod'ing a `bin` target). I reverted it here, but it
  will keep reappearing until the file is committed as 755.
- **Unrelated snag hit while pushing**, noted in case it bites you too: the
  `pre-push` e2e step failed every popup/options spec in this fresh worktree
  because `extension:build:e2e` is `"cache": true` with no `outputs` declared, so
  nx replayed a cache hit without materialising `apps/extension/.output/`.
  `nx run extension:build:e2e --skip-nx-cache` fixed it and the suite went 21/21.
  Same gap on `extension:build`, `diagnostics:build`, and `marketing:build`.
  Tracked separately — not touched here.
- **These new test cases do not run in CI.** `pnpm test:metrics-gate` — like
  `test:promises`, `test:release-notes`, `test:action-pins`, and `test:edge-poll`
  — is not referenced by any workflow or by `lefthook.yml`. Pre-existing gap,
  tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
