### PR TITLE
fix(audit): take the served-language denominator from the population, not the sample

### DIFF
--- a/packages/audit/src/rules/switch.test.ts
+++ b/packages/audit/src/rules/switch.test.ts
@@ -8,6 +8,7 @@ import type {
   PickerOption,
   RedirectHop,
   TextNodeSample,
+  TextSampling,
 } from '../evidence';
 import type { RuleResult } from '../report';
 import type { Ruleset } from '../ruleset';
@@ -78,13 +79,23 @@ function targetPage(
   htmlLang: string | null,
   url = UK_PRODUCT,
   textNodes: readonly TextNodeSample[] = [],
+  textSampling?: TextSampling,
 ): PageEvidence {
   return makePage({
     id: 'page-uk',
     url,
     reach: 'declared-target',
-    document: makeDocument({ htmlLang, textNodes }),
+    document: makeDocument({
+      htmlLang,
+      textNodes,
+      ...(textSampling === undefined ? {} : { textSampling }),
+    }),
   });
+}
+
+/** What a collector writes when its sampling ceiling, not the page, ended the walk. */
+function capped(examined: number, sampled: number): TextSampling {
+  return { examined, sampled, cappedAt: sampled };
 }
 
 /** A 301 to the Ukrainian homepage, then a 302 straight back to the Russian page. */
@@ -217,8 +228,41 @@ describe('core/switch-no-effect', () => {
     expect(finding?.verdict).toBe('observation');
     expect(finding?.downgradedFrom).toBe('fail');
     expect(finding?.denominator).toEqual({ examined: 2, matched: 2 });
-    expect(finding?.summary).toMatch(/2 of 2 sampled text nodes classify as ru/);
+    expect(finding?.summary).toMatch(/2 of 2 text nodes classify as ru/);
     expect(result.verdict).toBe('pass');
+  });
+
+  /**
+   * The collector caps text sampling, so `textNodes` is a floor and
+   * `textSampling.examined` is the page. Publishing "2 of 2" about a 4000-node
+   * page states unanimity the audit never measured — the same overstatement,
+   * one layer up from the denominator that produced it.
+   */
+  it('publishes the examined population, not the sample, on a truncated target', () => {
+    const target = targetPage(null, UK_PRODUCT, SAMPLES, capped(4000, 2));
+    const result = resultFor(
+      RULE,
+      networkEvidence([sourcePage(), target]),
+      rulesetWith(alwaysClassifies('ru')),
+    );
+    const finding = result.findings[0];
+
+    expect(finding?.denominator).toEqual({ examined: 4000, matched: 2 });
+    expect(finding?.summary).toMatch(/2 of 4000 text nodes classify as ru/);
+  });
+
+  /** A bundle written before `schemaVersion` 3 still replays as it was published. */
+  it('falls back to the sample length on a bundle collected before the counts existed', () => {
+    const target = targetPage(null, UK_PRODUCT, SAMPLES);
+    expect(target.document.textSampling).toBeUndefined();
+
+    const result = resultFor(
+      RULE,
+      networkEvidence([sourcePage(), target]),
+      rulesetWith(alwaysClassifies('ru')),
+    );
+
+    expect(result.findings[0]?.denominator).toEqual({ examined: 2, matched: 2 });
   });
 
   it('never fires on a self-referential alternate — that is correct markup', () => {

--- a/packages/audit/src/rules/switch.ts
+++ b/packages/audit/src/rules/switch.ts
@@ -234,7 +234,7 @@ function noEffectSummary(
 ): string {
   if (determination.via === CLASSIFIED) {
     const { examined = 0, matched = 0 } = determination.denominator ?? {};
-    return `The ${source} page declares a ${target.language} version at ${target.href}, but that page declares no language of its own and ${matched} of ${examined} sampled text nodes classify as ${determination.language} — following the switch does not change the language.`;
+    return `The ${source} page declares a ${target.language} version at ${target.href}, but that page declares no language of its own and ${matched} of ${examined} text nodes classify as ${determination.language} — following the switch does not change the language.`;
   }
   return `The ${source} page declares a ${target.language} version at ${target.href}, but following that ${target.source} serves ${determination.language} again — the switch does not change the language.`;
 }

--- a/packages/audit/src/served-language.test.ts
+++ b/packages/audit/src/served-language.test.ts
@@ -1,0 +1,189 @@
+import { describe, expect, it } from 'vitest';
+import type { Classifier } from './classifier';
+import type { PageEvidence, TextNodeSample, TextSampling } from './evidence';
+import type { Determination } from './served-language';
+import {
+  classifiedPageLanguage,
+  declaredPageLanguage,
+  mergedDenominator,
+  servedLanguage,
+} from './served-language';
+import type { LanguageCode } from '@movar/lang-detect';
+import { makeDocument, makePage } from '../test/fixtures';
+
+/** Two candidates, so distinctiveness has something to be relative to. */
+const CANDIDATES: readonly LanguageCode[] = ['uk', 'ru'];
+
+/** The classifier seam, stubbed: no franc, no trigram tables, no surprises. */
+function alwaysClassifies(language: LanguageCode): Classifier {
+  return () => ({ language, margin: 4, rung: 1, discriminating: true });
+}
+
+/** Answers about one snippet and abstains on every other — `null` is "no evidence". */
+function classifiesOnly(text: string, language: LanguageCode): Classifier {
+  return (snippet) =>
+    snippet === text ? { language, margin: 4, rung: 1, discriminating: true } : null;
+}
+
+/** What a collector writes when its sampling ceiling, not the page, ended the walk. */
+function capped(examined: number, sampled: number): TextSampling {
+  return { examined, sampled, cappedAt: sampled };
+}
+
+function node(text: string): TextNodeSample {
+  return { nodePath: 'main > p', text, inheritedLang: null };
+}
+
+const SAMPLES: readonly TextNodeSample[] = [node('Доставка по всей стране'), node('Дрель ударная')];
+
+/**
+ * A page carrying no `<html lang>` — the only shape that reaches the
+ * classifier at all, since a declaration always wins.
+ */
+function undeclaredPage(
+  textNodes: readonly TextNodeSample[] = SAMPLES,
+  textSampling?: TextSampling,
+): PageEvidence {
+  return makePage({
+    document: makeDocument({
+      htmlLang: null,
+      textNodes,
+      ...(textSampling === undefined ? {} : { textSampling }),
+    }),
+  });
+}
+
+describe('classifiedPageLanguage', () => {
+  it('answers with the dominant language and says the classifier decided it', () => {
+    const determination = classifiedPageLanguage(
+      undeclaredPage(),
+      alwaysClassifies('ru'),
+      CANDIDATES,
+    );
+
+    expect(determination?.language).toBe('ru');
+    expect(determination?.via).toBe('classified');
+  });
+
+  it('refuses a candidate set it cannot discriminate within', () => {
+    expect(classifiedPageLanguage(undeclaredPage(), alwaysClassifies('ru'), ['ru'])).toBeNull();
+  });
+
+  it('has nothing to classify when the bundle carries no text nodes', () => {
+    expect(
+      classifiedPageLanguage(undeclaredPage([]), alwaysClassifies('ru'), CANDIDATES),
+    ).toBeNull();
+  });
+
+  it('answers null rather than guessing when the classifier abstained throughout', () => {
+    expect(classifiedPageLanguage(undeclaredPage(), () => null, CANDIDATES)).toBeNull();
+  });
+
+  /**
+   * `textNodes` is what fitted in the bundle; `textSampling.examined` is what
+   * the walker saw. Quoting the sample as the page understates M by the whole
+   * truncation and so inflates the share the finding publishes — in the
+   * direction of the accusation. This determination is the kernel's, shared by
+   * `core/switch-no-effect` and family C, so it is the widest blast radius the
+   * mistake has.
+   */
+  describe('the denominator', () => {
+    it('quotes the population the collector examined, not the sample it kept', () => {
+      const page = undeclaredPage(SAMPLES, capped(4000, 2));
+
+      const determination = classifiedPageLanguage(page, alwaysClassifies('ru'), CANDIDATES);
+
+      expect(determination?.denominator).toEqual({ examined: 4000, matched: 2 });
+    });
+
+    /** "2 of 4000" is the finding; "2 of 2" is the smear that page can't argue with. */
+    it('never lets a truncated page read as unanimous', () => {
+      const page = undeclaredPage(SAMPLES, capped(4000, 2));
+
+      const { examined = 0, matched = 0 } =
+        classifiedPageLanguage(page, alwaysClassifies('ru'), CANDIDATES)?.denominator ?? {};
+
+      expect(matched).toBeLessThan(examined);
+    });
+
+    /**
+     * A node the classifier abstained on is not an excluded node — it stays in
+     * the denominator. Exclusions never narrow M; that is what keeps the share
+     * honest rather than flattering to whichever verdict won.
+     */
+    it('keeps a node the classifier abstained on in the denominator', () => {
+      const page = undeclaredPage(SAMPLES, { examined: 2, sampled: 2 });
+
+      const determination = classifiedPageLanguage(
+        page,
+        classifiesOnly('Дрель ударная', 'ru'),
+        CANDIDATES,
+      );
+
+      expect(determination?.denominator).toEqual({ examined: 2, matched: 1 });
+    });
+
+    /**
+     * A stored `schemaVersion` 2 bundle carries no counts at all, so it falls
+     * back to the sample length it did quote — an old bundle replays with the
+     * denominator it was published with rather than with an empty one.
+     */
+    it('falls back to the sample length on a bundle collected before the counts existed', () => {
+      const page = undeclaredPage();
+      expect(page.document.textSampling).toBeUndefined();
+
+      const determination = classifiedPageLanguage(page, alwaysClassifies('ru'), CANDIDATES);
+
+      expect(determination?.denominator).toEqual({ examined: 2, matched: 2 });
+    });
+  });
+});
+
+describe('servedLanguage', () => {
+  it('lets the declaration win, and carries no denominator when it does', () => {
+    const page = makePage({ document: makeDocument({ htmlLang: 'uk', textNodes: [...SAMPLES] }) });
+
+    const determination = servedLanguage(page, alwaysClassifies('ru'), CANDIDATES);
+
+    expect(determination).toEqual({ language: 'uk', via: 'declared' });
+    expect(declaredPageLanguage(page)).toBe('uk');
+  });
+
+  it('hands the classifier fallback the population as its denominator', () => {
+    const page = undeclaredPage(SAMPLES, capped(4000, 2));
+
+    const determination = servedLanguage(page, alwaysClassifies('ru'), CANDIDATES);
+
+    expect(determination?.via).toBe('classified');
+    expect(determination?.denominator).toEqual({ examined: 4000, matched: 2 });
+  });
+});
+
+describe('mergedDenominator', () => {
+  /**
+   * The sum is where a per-page understatement stops being per-page: family C
+   * cites every leg of a serving comparison in one finding, so two truncated
+   * pages quoted at the cap would publish "4 of 3000" for a site with 8000
+   * examined nodes.
+   */
+  it('sums the populations, so a truncation cannot compound across pages', () => {
+    const legs: readonly Determination[] = [
+      classifiedPageLanguage(
+        undeclaredPage(SAMPLES, capped(4000, 2)),
+        alwaysClassifies('ru'),
+        CANDIDATES,
+      ),
+      classifiedPageLanguage(
+        undeclaredPage(SAMPLES, capped(4000, 2)),
+        alwaysClassifies('ru'),
+        CANDIDATES,
+      ),
+    ].flatMap((determination) => (determination === null ? [] : [determination]));
+
+    expect(mergedDenominator(legs)).toEqual({ examined: 8000, matched: 4 });
+  });
+
+  it('stays undefined when every determination came from a declaration', () => {
+    expect(mergedDenominator([{ language: 'uk', via: 'declared' }])).toBeUndefined();
+  });
+});

--- a/packages/audit/src/served-language.ts
+++ b/packages/audit/src/served-language.ts
@@ -18,6 +18,7 @@ import { declaredLanguageOf } from './bcp47';
 import type { Classifier } from './classifier';
 import type { PageEvidence } from './evidence';
 import type { Denominator, Via } from './finding';
+import { textNodeDenominator } from './text-samples';
 import type { LanguageCode } from '@movar/lang-detect';
 
 /** ≥2 of anything is what every differential question needs. */
@@ -48,6 +49,13 @@ export function declaredPageLanguage(page: PageEvidence): string | null {
  * Refuses to answer with fewer than two candidates: distinctiveness is
  * candidate-relative, so a one-language candidate set is not a classification —
  * it is a rubber stamp that returns whatever it was handed.
+ *
+ * The denominator comes from `textNodeDenominator`, never from
+ * `textNodes.length`: the sample is what fitted in the bundle, and quoting it
+ * as the page understates M on every truncated page — inflating the share, in
+ * the direction of the accusation. This is the kernel's copy of that
+ * denominator, so it compounds: `mergedDenominator` sums it across pages, and
+ * both `rules/switch.ts` and `rules/serving.ts` publish what it says.
  */
 export function classifiedPageLanguage(
   page: PageEvidence,
@@ -73,11 +81,7 @@ export function classifiedPageLanguage(
     matched = count;
   }
   if (dominant === null) return null;
-  return {
-    language: dominant,
-    via: CLASSIFIED,
-    denominator: { examined: samples.length, matched },
-  };
+  return { language: dominant, via: CLASSIFIED, denominator: textNodeDenominator(page, matched) };
 }
 
 /**


### PR DESCRIPTION
Half of #483 — the `served-language.ts` call site. The `ua.ts` half is deliberately
left out and is described under [What this does **not** fix](#what-this-does-not-fix).

## The defect

`classifiedPageLanguage` in `packages/audit/src/served-language.ts` built its own
`Denominator` instead of calling the shared helper:

```ts
const samples = page.document.textNodes;
…
denominator: { examined: samples.length, matched }
```

`textNodes` is a **sample**. The collector caps body sampling at
`MAX_TEXT_NODE_SAMPLES` (1500) and records what the walker actually saw in
`textSampling.examined` (`schemaVersion` 3, #475). So a truncated page quoted the
cap as if it were the page — understating `M` by the whole truncation and
inflating the share the finding publishes, in the direction of the accusation.

This is the third instance of the class `packages/audit/AGENTS.md` already records
(_"`textNodes` is a sample; `textSampling.examined` is the population"_), after
#478's volume comparison and the five call sites #438 migrated.

## Blast radius

Wider than the other two, because this one is **kernel** rather than a single
rule. `classifiedPageLanguage` is the classifier half of the hybrid seam, so it
feeds both families that read it:

- `core/switch-no-effect` (`rules/switch.ts`), which quotes the numbers in its summary
- family C's hybrid `core/serving-*` findings (`rules/serving.ts`), via `mergedDenominator`

And `mergedDenominator` **sums** these across determinations, so the understatement
compounds instead of staying per-page:

| | before | after |
| --- | --- | --- |
| one page, 4000 examined / 2 sampled | `2 of 2` | `2 of 4000` |
| two such pages, merged | `4 of 4` | `4 of 8000` |
| pre-v3 bundle, 2 sampled | `2 of 2` | `2 of 2` (unchanged) |

`2 of 2` is not a smear in the sense `finding.ts` warns about — it is worse. It
reads as a total, unanimous verdict on a page the audit looked at 0.05 % of.

## The fix

One line: `textNodeDenominator(page, matched)`, the helper the other callers
already use. Two properties worth checking in review:

- **Exclusions never narrow `examined`.** Nothing filters on the way to the
  denominator here — a node the classifier abstained on stays in `M` and only
  fails to raise `N`. That is what keeps the share honest rather than flattering
  to whichever verdict won.
- **Old bundles still replay.** A bundle written before `schemaVersion` 3 carries
  no counts, so it falls back to the sample length — exactly the denominator it
  was originally published with.

## Wording

`core/switch-no-effect` said _"N of M sampled text nodes"_. That was an accurate
label for the wrong denominator, and would be the wrong label for the right one:
in this repo "sampled text nodes" means the denominator **is** the sample, which
is why #438 dropped it from the five it migrated. All three existing
`textNodeDenominator` callers (`content-language.ts`, `page-declaration.ts`,
`inventory-hreflang.ts`) say plain "text nodes"; this one now does too.

`serving.ts` needed no change — it never quotes the counts inline. Its only
hybrid phrasing is `viaNote`'s _"served language read from sampled text"_, which
describes what the classifier read rather than what the denominator counts, and
stays true. `artifact.ts` renders the structured field as _"N of M examined"_,
also neutral.

## Tests

New `src/served-language.test.ts` (12 tests) pins the kernel contract directly,
since the module had no test file of its own: truncated page quotes the
population, abstention does not narrow it, a pre-v3 bundle falls back, and
`mergedDenominator` sums populations (8000, not 4).

Two rule-level regressions in `rules/switch.test.ts` on top, because the
**published summary** is what a site is confronted with, not the structured
field — a kernel-only test would pass while the sentence still said `2 of 2`.

Both use the `capped(examined, sampled)` helper pattern from `ua.test.ts`.

Reverting the one-line fix fails five of the new assertions; the pre-v3 and
abstention cases pass either way, which is the point of them.

## What this does not fix

- **The `ua.ts` half of #483.** `classifyDefaultLanguage` (`rules/ua.ts:511`)
  still returns `examined: nodes.length`, and narrows twice — the sample, then a
  blank-node `.filter()`. It lands harder than this one (`ua/state-language-not-default`
  is statute-cited and names a company), so it is getting its own change rather
  than riding along here. #483 stays open until it lands.
- **#435** — that `classifiedPageLanguage` classifies raw node text rather than
  routing through the shared `classifySamples` gates. Untouched here on purpose:
  it changes which nodes are classified, this changes only what they are counted
  against.

## Verification

- `pnpm --filter @movar/audit exec vitest run` — 26 files, 860 passed
- `pnpm --filter @movar/audit exec tsc --noEmit` — clean
- pre-commit (eslint, prettier, suppressions, typecheck, test) and pre-push
  (build, `metrics:audit`) both green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
