### PR TITLE
fix(metrics): gate loc and suppressions against a live scan

### DIFF
--- a/docs/metrics-gate.md
+++ b/docs/metrics-gate.md
@@ -13,12 +13,13 @@ Implemented in [`scripts/metrics-gate.mts`](../scripts/metrics-gate.mts), run by
 every PR. It recomputes the dynamic metrics for the PR head and compares them
 three ways:
 
-| #   | Check                       | Fails when                                                                   | Overridable?                                  |
-| --- | --------------------------- | ---------------------------------------------------------------------------- | --------------------------------------------- |
-| 1   | **Coverage freshness**      | the committed `readme-metrics.snapshot.json` coverage ≠ recomputed coverage  | No — a wrong number is wrong, not a trade-off |
-| 2   | **Coverage regression**     | recomputed line/branch coverage drops below the base commit's snapshot       | Yes (label)                                   |
-| 3   | **Code-quality regression** | `fallow audit --base <base>` finds new dead code, complexity, or duplication | Yes (label)                                   |
-| 4   | **Coverage floor**          | recomputed line/branch coverage drops below the absolute `COVERAGE_FLOOR`    | No — a waivable floor is the ratchet it stops |
+| #   | Check                       | Fails when                                                                                        | Overridable?                                  |
+| --- | --------------------------- | ------------------------------------------------------------------------------------------------- | --------------------------------------------- |
+| 1   | **Coverage freshness**      | the committed `readme-metrics.snapshot.json` coverage ≠ recomputed coverage                       | No — a wrong number is wrong, not a trade-off |
+| 2   | **Coverage regression**     | recomputed line/branch coverage drops below the base commit's snapshot                            | Yes (label)                                   |
+| 3   | **Code-quality regression** | `fallow audit --base <base>` finds new dead code, complexity, or duplication                      | Yes (label)                                   |
+| 4   | **Coverage floor**          | recomputed line/branch coverage drops below the absolute `COVERAGE_FLOOR`                         | No — a waivable floor is the ratchet it stops |
+| 5   | **Source freshness**        | the committed `loc` drifts past `LOC_TOLERANCE`, or a suppression count differs, from a live scan | No — same reason as 1                         |
 
 Check 1 does double duty: enforcing it on every PR keeps `main`'s committed
 snapshot honest, which is what lets check 2 use that snapshot as the baseline
@@ -33,6 +34,19 @@ is a hard minimum that the `accept-metrics-regression` label does **not** bypass
 Raise it deliberately as real coverage climbs (commit the new numbers); never
 lower it to make a red gate pass. A breach exits with code `3`.
 
+Check 5 closes the gap check 1 left. Coverage is snapshotted because
+recomputing it costs a full test run; `loc` and the suppression counts come from
+a filesystem walk that takes milliseconds, so they were un-checked out of habit
+rather than cost — and an unchecked `loc` is a number the README states _about
+the project_ that nothing had ever compared to the project. It is deliberately
+asymmetric. `loc` gets a ±`LOC_TOLERANCE` (500) band because it moves on nearly
+every TypeScript PR, and an exact pin would force the remedy after every review
+fixup that touches one line; the README renders it as `~61k`, so precision past
+that is precision nobody reads. Suppression counts are matched **exactly**,
+because each one is a deliberate decision to silence a linter and this number is
+the only thing that makes adding one visible — a tolerance there would be a
+budget for accumulating them quietly. A breach exits with code `4`.
+
 The absolute fallow **health score** is intentionally _not_ gated — it folds in
 git churn and drifts commit-to-commit independent of the diff, which would make
 the check flaky. Base-relative quality regressions are caught by `fallow audit`
@@ -42,6 +56,12 @@ the check flaky. Base-relative quality regressions are caught by `fallow audit`
 
 - **Stale coverage (exit 2):** run `pnpm metrics` and commit the updated
   `scripts/readme-metrics.snapshot.json` (and `README.md`).
+- **Stale source metrics (exit 4):** run `pnpm gen:readme --refresh-source` and
+  commit the updated snapshot (and `README.md`). Unlike exit 2 this needs no
+  coverage or fallow run — it rescans the tree and re-pins only `loc` and the
+  suppression counts, in well under a second. If the failure names a
+  _suppression_ count you did not intend to change, that is the check working:
+  find the `eslint-disable` / `fallow-ignore` the diff added.
 - **Coverage regression (exit 1):** add tests, or accept it (below).
 - **`fallow audit` regression (exit 1):** remove the dead code / split the
   complex function / de-duplicate, or accept it (below). `pnpm metrics:audit`

--- a/scripts/gen-readme-metrics.mts
+++ b/scripts/gen-readme-metrics.mts
@@ -5,6 +5,7 @@
  *   pnpm gen:readme                              # rewrite the block from source + snapshot
  *   tsx scripts/gen-readme-metrics.mts --check   # exit 1 if the block would change OR a promise is broken
  *   tsx scripts/gen-readme-metrics.mts --refresh # refresh dynamic metrics from .metrics/ + coverage/, then rewrite
+ *   tsx scripts/gen-readme-metrics.mts --refresh-source # re-pin loc + suppressions from a live scan only, then rewrite
  *
  * The README's `## Metrics` section carries a generated block between
  * `<!-- METRICS:START … -->` / `<!-- METRICS:END -->` markers: a row with the
@@ -107,6 +108,26 @@ function capitalize(value: string): string {
 // --- dynamic snapshot (committed; refreshed from gitignored fallow/coverage) -
 function readSnapshot(): Snapshot {
   return JSON.parse(readFileSync(snapshotPath, 'utf8')) as Snapshot;
+}
+
+/**
+ * Refresh only the two values a live scan can produce on its own: `loc` and
+ * `suppressions`. Everything else is kept exactly as committed.
+ *
+ * This exists so the gate's source-freshness check has a remedy proportional to
+ * the failure. Full `--refresh` is downstream of `pnpm metrics`, which re-runs
+ * fallow and the whole coverage suite — minutes — and a contributor who moved
+ * one TypeScript line should not have to pay that to re-pin a line count. The
+ * scan itself is milliseconds; nothing here reads `.metrics/` or `coverage/`,
+ * so it is also the one refresh that is correct to run on a tree where those
+ * are stale or absent.
+ */
+function refreshSourceSnapshot(): Snapshot {
+  const snapshot = readSnapshot();
+  const stats = scanSourceStats(repoRoot);
+  snapshot.loc = stats.loc;
+  snapshot.suppressions = { eslint: stats.eslint, fallow: stats.fallow };
+  return snapshot;
 }
 
 /**
@@ -444,13 +465,24 @@ function spliceRegion(readme: string, start: string, end: string, block: string)
 }
 
 // --- main -------------------------------------------------------------------
-const mode = process.argv.includes('--refresh')
-  ? 'refresh'
-  : process.argv.includes('--check')
-    ? 'check'
-    : 'write';
+// `--refresh-source` is tested before `--refresh` on purpose: the former
+// contains the latter as a substring only under `includes` on the raw argv
+// array, which compares whole elements — but the ordering also states the
+// intent, that the narrower flag wins if both are somehow passed.
+const mode = process.argv.includes('--refresh-source')
+  ? 'refresh-source'
+  : process.argv.includes('--refresh')
+    ? 'refresh'
+    : process.argv.includes('--check')
+      ? 'check'
+      : 'write';
 
-const snapshot = mode === 'refresh' ? refreshSnapshot() : readSnapshot();
+const snapshot =
+  mode === 'refresh'
+    ? refreshSnapshot()
+    : mode === 'refresh-source'
+      ? refreshSourceSnapshot()
+      : readSnapshot();
 
 // Load the marketing strings via tsx's .ts loader (the Astro build passes its
 // vite-imported strings.en instead). i18n.ts has no runtime side effects, so
@@ -466,7 +498,12 @@ const metrics = collectMetrics(snapshot, promises);
 const readme = readFileSync(readmePath, 'utf8');
 let next = spliceRegion(readme, BADGES_START, BADGES_END, renderBadgeRow(metrics));
 next = spliceRegion(next, METRICS_START, METRICS_END, renderReport(metrics));
-const refreshed = mode === 'refresh' ? ' (snapshot refreshed)' : '';
+const refreshed =
+  mode === 'refresh'
+    ? ' (snapshot refreshed)'
+    : mode === 'refresh-source'
+      ? ' (loc + suppressions re-pinned)'
+      : '';
 const broken = promises.filter((p) => !p.kept);
 
 if (mode === 'check') {

--- a/scripts/lib/source-stats.mts
+++ b/scripts/lib/source-stats.mts
@@ -28,10 +28,15 @@ export const SOURCE_GROUPS = ['apps', 'packages'] as const;
  *  `nx run marketing:typecheck` runs it on every commit, so most working trees
  *  carry ~210 lines of them that CI's fresh checkout does not.
  *
- *  This list fails open — a generated directory that isn't named here is
- *  counted as source, silently, because `loc` is snapshotted rather than
- *  recomputed by any guard. That is what the live-tree assertion in
- *  `source-stats.test.mts` exists to catch, so add new entries there in mind. */
+ *  This list still fails open in the sense that matters — a generated directory
+ *  that isn't named here is walked into, and its files are counted as source.
+ *  Two things catch that now, and they catch different halves: the live-tree
+ *  assertion in `source-stats.test.mts` fails the moment such a directory holds
+ *  a `.ts` file in *someone's* tree, and the freshness check in
+ *  `metrics-gate.mts` fails when the committed `loc` drifts from a live scan by
+ *  more than its tolerance. Neither notices a generated directory that is
+ *  simply never present on CI, which is why entries are added here on the
+ *  evidence of `.gitignore` rather than on the evidence of a failure. */
 export const BUILD_DIRS = new Set([
   'node_modules',
   '.output',
@@ -41,7 +46,30 @@ export const BUILD_DIRS = new Set([
   '.astro',
   'coverage',
   '.turbo',
+  'test-results',
+  'playwright-report',
+  'storybook-static',
+  'demo-results',
+  '.wrangler',
 ]);
+
+/**
+ * Generated directories whose name carries a run-specific suffix, matched by
+ * prefix rather than by name.
+ *
+ * `.gitignore` spells this `playwright-report*`, and the naive translation of
+ * that glob — `name.startsWith('playwright-report')` — also swallows a
+ * hand-written `playwright-reporter/`, hiding real source from the count
+ * permanently and silently. The trailing `-` is the whole difference: it covers
+ * the suffixed report dirs (`-live`, `-compare`) and nothing a package would
+ * plausibly be called.
+ */
+export const BUILD_DIR_PREFIXES = ['playwright-report-'];
+
+/** Whether the walk should refuse to descend into a directory of this name. */
+export function isBuildDir(name: string): boolean {
+  return BUILD_DIRS.has(name) || BUILD_DIR_PREFIXES.some((prefix) => name.startsWith(prefix));
+}
 
 /** Test/spec/helper files, excluded from the source-line count. */
 export const isTest = (name: string): boolean => /\.(test|spec|test-utils)\.tsx?$/.test(name);
@@ -55,7 +83,7 @@ export function sourceFiles(repoRoot: string): string[] {
     for (const entry of readdirSync(dir, { withFileTypes: true })) {
       const full = nodePath.resolve(dir, entry.name);
       if (entry.isDirectory()) {
-        if (!BUILD_DIRS.has(entry.name)) walk(full);
+        if (!isBuildDir(entry.name)) walk(full);
       } else if (/\.tsx?$/.test(entry.name)) {
         found.push(nodePath.relative(repoRoot, full).split(nodePath.sep).join('/'));
       }

--- a/scripts/metrics-gate.mts
+++ b/scripts/metrics-gate.mts
@@ -36,9 +36,20 @@
  *      ratchet it exists to stop. Raise it deliberately (with coverage) as the
  *      real numbers climb; never lower it to make a red gate pass.
  *
+ *   5. FRESHNESS (source): the committed `loc` must sit within `LOC_TOLERANCE`
+ *      of a live scan of the tree, and the committed suppression counts must
+ *      match one exactly. Coverage (1) is snapshotted because recomputing it
+ *      costs a full test run; these two come from a filesystem walk that takes
+ *      milliseconds, so nothing but habit was keeping them un-checked — and an
+ *      unchecked `loc` is a number the README states about the project that no
+ *      guard has ever compared to the project. Not overridable, for the same
+ *      reason as the floor. The remedy is `pnpm gen:readme --refresh-source`,
+ *      which re-pins exactly these two values without re-running any tool.
+ *
  * A regression (2 or 3) fails the gate UNLESS the PR carries the
  * `accept-metrics-regression` label (`HAS_ACCEPT_LABEL=true`) — the human
- * override. The floor (4) and freshness (1) are never overridable. The label is meant to be applied only by a maintainer; a companion
+ * override. The floor (4) and both freshness checks (1, 5) are never
+ * overridable. The label is meant to be applied only by a maintainer; a companion
  * workflow (`metrics-override-guard.yml`) strips it when a bot account applies
  * it, so automation cannot wave its own regression through. (That guard can
  * only act on *identity*; if agents run under a maintainer's own account it is
@@ -50,9 +61,11 @@
  * `fallow audit` (3) instead, which is built for exactly that comparison.
  *
  * Exit codes: 0 = pass (or acknowledged), 1 = unacknowledged regression,
- * 2 = stale/invalid snapshot (freshness), 3 = below the absolute coverage floor
- * (never overridable). The workflow treats any non-zero as a failed required
- * check.
+ * 2 = stale/invalid snapshot (coverage freshness), 3 = below the absolute
+ * coverage floor (never overridable), 4 = stale source metrics (never
+ * overridable). The workflow treats any non-zero as a failed required check.
+ * 4 is distinct from 2 because the remedies differ by minutes: 2 needs
+ * `pnpm metrics` (a full coverage run), 4 needs only `--refresh-source`.
  */
 import { readFileSync } from 'node:fs';
 import { execFileSync } from 'node:child_process';
@@ -81,12 +94,33 @@ const EPS = 0.05;
 // purpose. Raise these numbers (never lower them) as real coverage climbs.
 const COVERAGE_FLOOR = { lines: 91.7, branches: 84.6 };
 
+/**
+ * How far the committed `loc` may drift from a live scan before check 5 fails.
+ *
+ * A band rather than an exact match, and the asymmetry with the suppression
+ * counts below is the point. `loc` moves on nearly every PR that touches
+ * TypeScript, so pinning it exactly would make the remedy mandatory on review
+ * fixups that change one line — and the README renders it as `~61k`, so
+ * precision past this is precision nobody reads. The band is what buys the
+ * check the right to be non-waivable.
+ *
+ * A suppression count is different in kind: each one is a deliberate decision
+ * to silence a linter, and this number is the only thing that makes adding one
+ * visible. A tolerance there would be a budget for accumulating them quietly,
+ * which is the failure the count exists to prevent — so those match exactly.
+ */
+const LOC_TOLERANCE = 500;
+
 interface Coverage {
   lines: number;
   branches: number;
 }
 interface Snapshot {
   coverage?: Coverage;
+  /** Source lines under `apps/` + `packages/`, tests excluded (check 5). */
+  loc?: number;
+  /** Inline linter suppressions, counted across every scanned file (check 5). */
+  suppressions?: { eslint: number; fallow: number };
 }
 
 function readSnapshot(path: string, label: string): Snapshot {
@@ -157,6 +191,52 @@ if (coverageStale) {
   console.error(`    recomputed: ${fresh.lines}% lines / ${fresh.branches}% branches`);
   console.error(`  Run \`pnpm metrics\` and commit ${snapshotRel} (+ README.md), then push.`);
   process.exit(2);
+}
+
+// --- 5. Freshness: committed loc + suppressions must track a live scan -------
+// `recomputed` came from `--refresh`, which walks the tree, so its `loc` and
+// `suppressions` ARE the live scan; nothing extra is run here. Checked before
+// the floor only so a contributor who is stale on both hears about the cheap
+// remedy first.
+const sourceStale: string[] = [];
+if (recomputed.loc === undefined) {
+  throw new Error(
+    '[metrics-gate] recomputed snapshot has no loc — did `pnpm gen:readme --refresh` run first?',
+  );
+}
+if (committed.loc === undefined) {
+  sourceStale.push(`committed loc is absent (recomputed ${recomputed.loc})`);
+} else if (Math.abs(committed.loc - recomputed.loc) > LOC_TOLERANCE) {
+  sourceStale.push(
+    `committed loc ${committed.loc} drifts from the live scan ${recomputed.loc} by ` +
+      `${Math.abs(committed.loc - recomputed.loc)} lines (tolerance ${LOC_TOLERANCE})`,
+  );
+}
+if (recomputed.suppressions === undefined) {
+  throw new Error(
+    '[metrics-gate] recomputed snapshot has no suppressions — did `pnpm gen:readme --refresh` run first?',
+  );
+}
+if (committed.suppressions === undefined) {
+  sourceStale.push('committed suppression counts are absent');
+} else {
+  for (const kind of ['eslint', 'fallow'] as const) {
+    if (committed.suppressions[kind] !== recomputed.suppressions[kind]) {
+      sourceStale.push(
+        `committed ${kind} suppressions ${committed.suppressions[kind]} ≠ ` +
+          `live scan ${recomputed.suppressions[kind]}`,
+      );
+    }
+  }
+}
+if (sourceStale.length > 0) {
+  console.error('✗ Committed source metrics are stale (this is NOT waivable):');
+  for (const line of sourceStale) console.error(`    ${line}`);
+  console.error('  Run `pnpm gen:readme --refresh-source` and commit');
+  console.error(`  ${snapshotRel} (+ README.md), then push. It rescans the tree and re-pins`);
+  console.error('  only these two values — no coverage run, no fallow run, well under a second.');
+  console.error('  (See docs/metrics-gate.md; the tolerance lives in LOC_TOLERANCE.)');
+  process.exit(4);
 }
 
 // --- 4. Floor: recomputed coverage must clear the absolute minimum -----------

--- a/scripts/metrics-gate.test.mts
+++ b/scripts/metrics-gate.test.mts
@@ -26,9 +26,17 @@ const here = nodePath.dirname(fileURLToPath(import.meta.url));
 const gateScript = nodePath.join(here, 'metrics-gate.mts');
 const tmp = mkdtempSync(nodePath.join(tmpdir(), 'movar-metrics-gate-'));
 
-function snapshot(coverage: { lines: number; branches: number }): string {
+/** The source half of a snapshot. Defaults are shared by both sides of a run,
+ *  so check 5 passes and the coverage cases stay isolated from it. */
+interface Source {
+  loc: number;
+  suppressions: { eslint: number; fallow: number };
+}
+const SOURCE: Source = { loc: 61783, suppressions: { eslint: 46, fallow: 23 } };
+
+function snapshot(coverage: { lines: number; branches: number }, source: Source = SOURCE): string {
   const p = nodePath.join(tmp, `snap-${coverage.lines}-${coverage.branches}-${Math.random()}.json`);
-  writeFileSync(p, JSON.stringify({ coverage }));
+  writeFileSync(p, JSON.stringify({ coverage, ...source }));
   return p;
 }
 
@@ -36,10 +44,12 @@ function snapshot(coverage: { lines: number; branches: number }): string {
  *  freshness check passes and we isolate the floor) and optional accept label. */
 function runGate(
   coverage: { lines: number; branches: number },
-  opts: { acceptLabel?: boolean } = {},
+  opts: { acceptLabel?: boolean; committedSource?: Source } = {},
 ): number {
   const recomputed = snapshot(coverage);
-  const committed = snapshot(coverage); // equal -> fresh
+  // Equal coverage -> fresh. `committedSource` skews only the source half, so a
+  // check-5 case cannot accidentally trip the coverage checks.
+  const committed = snapshot(coverage, opts.committedSource ?? SOURCE);
   const result = spawnSync('npx', ['--no-install', 'tsx', gateScript], {
     env: {
       ...process.env,
@@ -77,6 +87,48 @@ expectExit(
 // A snapshot at the current real numbers clears the floor, is fresh, and has no
 // regression (bogus base + AUDIT_OUTCOME=success) -> pass.
 expectExit('above floor, fresh, no regression passes', runGate({ lines: 92.7, branches: 85.6 }), 0);
+
+console.log('==> metrics-gate source freshness (check 5)');
+
+const GREEN = { lines: 92.7, branches: 85.6 };
+
+// LOC_TOLERANCE is 500. Drift inside the band is what the band is for: a PR that
+// moves a few hundred lines must not be made to re-run anything.
+expectExit(
+  'loc drift inside the tolerance passes',
+  runGate(GREEN, { committedSource: { ...SOURCE, loc: SOURCE.loc - 499 } }),
+  0,
+);
+expectExit(
+  'loc drift past the tolerance fails with exit 4',
+  runGate(GREEN, { committedSource: { ...SOURCE, loc: SOURCE.loc - 501 } }),
+  4,
+);
+// Non-waivable, exactly like the floor: the label must not rescue it.
+expectExit(
+  'loc drift past the tolerance still fails WITH the accept label',
+  runGate(GREEN, {
+    acceptLabel: true,
+    committedSource: { ...SOURCE, loc: SOURCE.loc - 501 },
+  }),
+  4,
+);
+// Suppressions are gated exactly, so one silently-added disable is caught where
+// the same delta in `loc` would sit well inside the band.
+expectExit(
+  'a single extra eslint suppression fails with exit 4',
+  runGate(GREEN, {
+    committedSource: { ...SOURCE, suppressions: { eslint: 45, fallow: 23 } },
+  }),
+  4,
+);
+expectExit(
+  'a single extra fallow suppression fails with exit 4',
+  runGate(GREEN, {
+    committedSource: { ...SOURCE, suppressions: { eslint: 46, fallow: 22 } },
+  }),
+  4,
+);
 
 rmSync(tmp, { recursive: true, force: true });
 


### PR DESCRIPTION
Combines the two halves of #488 and #489 that survived review, rebuilt on `scripts/lib/source-stats.mts` (#506) rather than lifted from either branch. **Supersedes both.**

## Why

`loc` is a number the README states about the project that nothing had ever compared to the project. `check:readme` reads the same committed snapshot to both render and verify, so a stale or hand-edited `loc` renders a consistent badge and stays green forever. Coverage is snapshotted because recomputing it costs a full test run; `loc` and the suppression counts come from a filesystem walk measured in milliseconds, so they were un-checked out of habit rather than cost.

## Check 5, and why it is asymmetric

It compares both values against the live scan `--refresh` already performs, so it costs no CI time.

| | gated | why |
|---|---|---|
| `loc` | ±500 band | Moves on nearly every TypeScript PR. An exact pin would force the remedy after every review fixup that touches one line, and the README renders `~61k` — precision past the band is precision nobody reads. The band is what buys the check the right to be non-waivable. |
| suppressions | **exact** | Each one is a deliberate decision to silence a linter, and this count is the only thing that makes adding one visible. A tolerance would be a budget for accumulating them quietly. |

**Exit 4**, not a reuse of 2, because the remedies differ by minutes: 2 needs `pnpm metrics` (a full coverage run), 4 needs only the new `gen:readme --refresh-source`, which re-pins these two values from a rescan in ~0.5s and reads neither `.metrics/` nor `coverage/`.

## The skip-list

Adds the five gitignored directories it was missing — `test-results`, `playwright-report`, `storybook-static`, `demo-results`, `.wrangler`. These matter more now that `loc` is gated: an unlisted generated dir is *counted as source*, so the first tree to grow a `.ts` under one would fail this check on a PR that has nothing to do with it.

`playwright-report` is matched by name **plus a separate `playwright-report-` prefix list**, never `startsWith('playwright-report')`. That naive translation of the `.gitignore` glob — which is what #488 proposed — also swallows a hand-written `playwright-reporter/`, hiding real source permanently and silently. The trailing `-` covers the suffixed report dirs (`-live`, `-compare`) and nothing a package would plausibly be called.

## Verified

- **8/8 gate cases**, including that the accept label does **not** rescue exit 4, and that a single added suppression is caught where the same delta in `loc` sits well inside the band.
- **End to end against the real tree**: gate passes (`96.7% lines / 90.8% branches`); with a 900-line stale `loc` it exits 4 naming the drift and the one-command remedy.
- Source-scan guard still reports **612 files, none git-ignored**; `loc` unchanged at **61783** — the new entries are defensive today, which is the point.
- `pnpm test:scripts` (all six guards), `pnpm check:readme` (4/4), `pnpm lint:root`, prettier — all clean.

## Not included

#489 also bundled a `fallow-targets` change suppressing `docs/REFACTORING-QUEUE.md` timestamp churn. It is a real papercut — `pnpm metrics` dirties that file every run — but it is an independent change, and bundling it was the scope objection raised against #489. Worth its own PR.

Closes #488
Closes #489