### PR TITLE
fix(safari): import Combine for HostStateModel's ObservableObject

### DIFF
--- a/.changeset/safari-combine-import.md
+++ b/.changeset/safari-combine-import.md
@@ -1,0 +1,11 @@
+---
+'@movar/extension': patch
+---
+
+Import Combine in the Safari host app's `HostState`, so both app targets archive again.
+
+`ObservableObject` and `@Published` are Combine's types. Some SDKs re-export them transitively through SwiftUI; the iOS/macOS 26 SDK does not, so `HostStateModel` failed to compile the moment a real Xcode saw it — `type 'HostStateModel' does not conform to protocol 'ObservableObject'`, plus `init(wrappedValue:) is not available due to missing import of defining module 'Combine'`. Both schemes failed to archive.
+
+A local `swiftc -typecheck` against the Command Line Tools SDK does not reproduce it, which is why this shipped: the native shell landed having been typechecked but never built, and the gap was known and recorded at the time. The import carries a comment saying exactly that, so nobody on a machine where it looks redundant tidies it back out.
+
+Only `HostState.swift` declares the conformance. `@ObservedObject` in `AboutView` and `MovarRootView` is SwiftUI's own property wrapper and needs nothing.

--- a/apps/extension/safari/Movar/Shared (App)/HostState.swift
+++ b/apps/extension/safari/Movar/Shared (App)/HostState.swift
@@ -5,6 +5,7 @@
 //  What the host knows about itself, and the one screen that branches on it.
 //
 
+import Combine
 import Foundation
 
 /// Which shell the app is running as. The native counterpart of `bridge.ts`'s
@@ -192,6 +193,14 @@ extension EnablementBanner {
 /// it publishes the same facts here that it pushes into the WebView's `show()`,
 /// including the macOS focus-regain refresh, so the native screen is a live view
 /// of the extension's state rather than a launch-time snapshot.
+/// `Combine` is imported explicitly above rather than leaned on through
+/// SwiftUI: `ObservableObject` and `@Published` are Combine's, and while some
+/// SDKs re-export them transitively, the iOS/macOS 26 SDK does not — Xcode
+/// fails this file with "does not conform to protocol 'ObservableObject'" and
+/// "init(wrappedValue:) is not available due to missing import of defining
+/// module 'Combine'". A local `swiftc -typecheck` against the Command Line
+/// Tools SDK does NOT reproduce it, so the import stays whether or not the
+/// machine you are on needs it.
 final class HostStateModel: ObservableObject {
     @Published var state: HostState?
 


### PR DESCRIPTION
**`main` currently fails to archive both Safari app schemes.** This is the one-line fix.

## What broke

[#512](https://github.com/rejifald/movar/pull/512) merged while its `build` check was red. That check was failing on:

```
HostState.swift:195: error: type 'HostStateModel' does not conform to protocol 'ObservableObject'
HostState.swift:196: error: initializer 'init(wrappedValue:)' is not available
                            due to missing import of defining module 'Combine'
** ARCHIVE FAILED **
```

`ObservableObject` and `@Published` are Combine's types. Some SDKs re-export them transitively through SwiftUI; the iOS/macOS 26 SDK does not.

## Why it wasn't caught before merge

The native shell in #512 was typechecked but **never built** — there's no Xcode on the machine it was written on, only Command Line Tools. `swiftc -typecheck` against the CLT SDK does **not** reproduce this, because that SDK re-exports Combine where Xcode 26's does not. That gap was recorded in the PR description at the time; this is it landing.

The added import carries a comment explaining precisely this, so nobody working on a machine where it looks redundant removes it again.

## Scope

Only `HostState.swift` declares the conformance. `@ObservedObject` in `AboutView` and `MovarRootView` is SwiftUI's own property wrapper and needs no import — verified by grepping every `Shared (App)` Swift file for Combine-dependent declarations.

## Verification

`swiftc -typecheck -swift-version 5 -target arm64-apple-macos11.0` over all seven `Shared (App)` files: exit 0.

**Still not built by a real Xcode** — same constraint as before. The failing CI `build` job on this PR is the actual check; watch it rather than trusting the local typecheck, since a passing local typecheck is exactly what let the bug through the first time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)