### PR TITLE
fix(marketing): --header-h is two heights, and only one was declared

### DIFF
--- a/apps/marketing/src/styles/global.css
+++ b/apps/marketing/src/styles/global.css
@@ -39,9 +39,30 @@
  * header instead of racing it for the same 0px (the guide hub's group rail).
  * A hardcoded 64px there against a 73px header left a 9px seam of page
  * background between two blurred bars.
+ *
+ * It is TWO numbers, because the header is two heights. Below `sm:` the
+ * hamburger is the tallest thing in the row (`p-2` around a `size-6` icon =
+ * 40px); at `sm:` and up it is `sm:hidden` and the 28px brand icon governs.
+ * Add the row's `py-4` (32px) and the 1px bottom border: 73px, then 61px.
+ *
+ * Declaring only the mobile value re-created the very seam the paragraph above
+ * describes — and re-created it in the one state that always ships. The guide
+ * hub's rail is `hidden sm:block`, so it renders ONLY at the widths where 73px
+ * is wrong, parking 12px below a 61px header on every desktop screen. Measured,
+ * not inferred: header bottom 61px, rail top 73px, at 1280 scrolled.
+ *
+ * 40rem is Tailwind's `sm:` — the breakpoint the header itself switches on, and
+ * the one the guide hub's own media query already uses. Change one, change all
+ * three.
  */
 :root {
   --header-h: 73px;
+}
+
+@media (min-width: 40rem) {
+  :root {
+    --header-h: 61px;
+  }
 }
 
 html {


### PR DESCRIPTION
Found while building #535 — `measureHeaderBottom()` reads the real element, and
it disagreed with the variable.

## The header is two heights; the variable declared one

| width | height | why |
|---|---|---|
| < 640px | **73px** | the hamburger is the tallest thing in the row — `p-2` around a `size-6` icon = 40px |
| ≥ 640px | **61px** | that button is `sm:hidden`; the 28px brand icon governs |

Both plus the row's `py-4` (32px) and the 1px bottom border. `--header-h` carried
the mobile number unconditionally.

## Which re-created the seam its own comment describes killing

The comment above `--header-h` exists because *"a hardcoded 64px there against a
73px header left a 9px seam of page background between two blurred bars."* The
variable fixed that — and replaced it with a 12px one.

The sharp part is where. The guide hub's group rail is `hidden sm:block` and
parks at `top-(--header-h)`, so it renders **only** at the widths where 73px is
wrong. This was not an edge case; it was the only state that shipped.

Measured on `/uk/guide` at 1280, scrolled so both bars are stuck:

```
header bottom   61px
rail top        73px
seam            12px   ← page background between two blurred bars
```

Second effect, milder: `scroll-padding-top` resolved to 148px against 120px of
real chrome on the guide (61 + 59 rail), so anchor jumps overshot by 28px where
the comment intends 16px.

## After

Measured in a live page at both breakpoints, not derived:

| | declared | header | rail seam | scroll-padding |
|---|---|---|---|---|
| 375px | 73px | 73px | rail not rendered | 89px (73 + 16) |
| 1280px | 61px | 61px | **0px** | 136px (61 + 59 + 16) |

40rem is Tailwind's `sm:` — the breakpoint the header itself switches on, and the
one the guide hub's own media query already uses.

## No baseline churn, verified rather than assumed

The reasoning was that this cannot move a capture: `pinStickyForCapture` makes
`.sticky` static for screenshots, so `top` never applies, and the variable feeds
nothing else a scroll-0 static capture can see.

Rather than ship on that, the marketing visual suite was run in **compare** mode
in the pinned container — `E2E_BASELINE_TARGET=e2e:test:marketing` — giving
**105/105 with zero PNGs touched**. The diff is 21 lines of CSS and comment,
nothing else.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
