### PR TITLE
fix(release): give Safari the 1.8.0 version, and redeploy marketing when the files its pages read change

### DIFF
--- a/.github/workflows/deploy-marketing.yml
+++ b/.github/workflows/deploy-marketing.yml
@@ -8,6 +8,22 @@ on:
       - 'pnpm-lock.yaml'
       - 'pnpm-workspace.yaml'
       - '.github/workflows/deploy-marketing.yml'
+      # Two pages are built from files OUTSIDE apps/marketing, so a change to
+      # one of these rebuilds no page unless it is listed here. That is not
+      # hypothetical: v1.8.0's release commit touched only RELEASE-NOTES.md and
+      # never redeployed, leaving movar.fyi/changelog topped out at 1.7.0 while
+      # the App Store note appended to every store submission pointed readers
+      # at it (`withChangelogLink`).
+      #   changelog.astro  <- Changelog.astro reads RELEASE-NOTES.md at build
+      #                       time through scripts/lib/release-notes.mjs
+      #   Transparency     <- scripts/lib/promises.mts re-derives each verified
+      #                       promise from the extension it describes
+      - 'apps/extension/store-assets/RELEASE-NOTES.md'
+      - 'apps/extension/package.json'
+      - 'apps/extension/wxt.config.ts'
+      - 'scripts/lib/release-notes.mjs'
+      - 'scripts/lib/promises.mts'
+      - 'LICENSE'
   workflow_dispatch:
 
 permissions:

--- a/apps/extension/safari/Movar/Movar.xcodeproj/project.pbxproj
+++ b/apps/extension/safari/Movar/Movar.xcodeproj/project.pbxproj
@@ -814,7 +814,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1786386205;
+				CURRENT_PROJECT_VERSION = 1788087223;
 				DEVELOPMENT_TEAM = RQSR4UU3VB;
 				CODE_SIGN_ENTITLEMENTS = "iOS (Extension)/Movar Extension.entitlements";
 				REGISTER_APP_GROUPS = YES;
@@ -828,7 +828,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.7.0;
+				MARKETING_VERSION = 1.8.0;
 				OTHER_LDFLAGS = (
 					"-framework",
 					SafariServices,
@@ -850,7 +850,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1786386205;
+				CURRENT_PROJECT_VERSION = 1788087223;
 				DEVELOPMENT_TEAM = RQSR4UU3VB;
 				CODE_SIGN_ENTITLEMENTS = "iOS (Extension)/Movar Extension.entitlements";
 				REGISTER_APP_GROUPS = YES;
@@ -864,7 +864,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.7.0;
+				MARKETING_VERSION = 1.8.0;
 				OTHER_LDFLAGS = (
 					"-framework",
 					SafariServices,
@@ -889,7 +889,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1786386205;
+				CURRENT_PROJECT_VERSION = 1788087223;
 				DEVELOPMENT_TEAM = RQSR4UU3VB;
 				CODE_SIGN_ENTITLEMENTS = "iOS (App)/Movar.entitlements";
 				REGISTER_APP_GROUPS = YES;
@@ -906,7 +906,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.7.0;
+				MARKETING_VERSION = 1.8.0;
 				OTHER_LDFLAGS = (
 					"-framework",
 					SafariServices,
@@ -932,7 +932,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1786386205;
+				CURRENT_PROJECT_VERSION = 1788087223;
 				DEVELOPMENT_TEAM = RQSR4UU3VB;
 				CODE_SIGN_ENTITLEMENTS = "iOS (App)/Movar.entitlements";
 				REGISTER_APP_GROUPS = YES;
@@ -949,7 +949,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.7.0;
+				MARKETING_VERSION = 1.8.0;
 				OTHER_LDFLAGS = (
 					"-framework",
 					SafariServices,
@@ -974,7 +974,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1786386205;
+				CURRENT_PROJECT_VERSION = 1788087223;
 				DEVELOPMENT_TEAM = RQSR4UU3VB;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -991,7 +991,7 @@
 					"@executable_path/../../../../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 11.0;
-				MARKETING_VERSION = 1.7.0;
+				MARKETING_VERSION = 1.8.0;
 				OTHER_LDFLAGS = (
 					"-framework",
 					SafariServices,
@@ -1012,7 +1012,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1786386205;
+				CURRENT_PROJECT_VERSION = 1788087223;
 				DEVELOPMENT_TEAM = RQSR4UU3VB;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -1029,7 +1029,7 @@
 					"@executable_path/../../../../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 11.0;
-				MARKETING_VERSION = 1.7.0;
+				MARKETING_VERSION = 1.8.0;
 				OTHER_LDFLAGS = (
 					"-framework",
 					SafariServices,
@@ -1052,7 +1052,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1786386205;
+				CURRENT_PROJECT_VERSION = 1788087223;
 				DEVELOPMENT_TEAM = RQSR4UU3VB;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -1069,7 +1069,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 11.0;
-				MARKETING_VERSION = 1.7.0;
+				MARKETING_VERSION = 1.8.0;
 				OTHER_LDFLAGS = (
 					"-framework",
 					SafariServices,
@@ -1095,7 +1095,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1786386205;
+				CURRENT_PROJECT_VERSION = 1788087223;
 				DEVELOPMENT_TEAM = RQSR4UU3VB;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -1112,7 +1112,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 11.0;
-				MARKETING_VERSION = 1.7.0;
+				MARKETING_VERSION = 1.8.0;
 				OTHER_LDFLAGS = (
 					"-framework",
 					SafariServices,


### PR DESCRIPTION
Two gaps found while walking the v1.8.0 App Store submission path end to end.
Both are release-blocking in the sense that they are wrong at the moment of
submission, and neither is caught by any existing guard.

## Safari was left on 1.7.0

`pnpm version:packages` bumps `apps/extension/package.json`, but Safari is not
on Changesets — its `MARKETING_VERSION` and build number are a hand step in the
release ritual (`apps/extension/AGENTS.md`, `docs/release-credentials.md`).
#554 did every other part of that ritual and left the Xcode project on 1.7.0.

Nothing caught it because nothing compares the two versions, and the release
path hides it: `release.yml` passes `MARKETING_VERSION=$VERSION` on the
xcodebuild command line, so a CI archive is correct whatever the project file
says. The drift only bites on the documented fallback — a local archive through
Xcode Organizer — which would have produced a 1.8.0 release labelled 1.7.0,
colliding with the build already uploaded under that version.

The build number was staler still: `1786386205` dates to the v1.6.2 cut (#384),
because #526 bumped only the marketing version. Both are now set across all
eight build configurations. Verified with `xcodebuild -showBuildSettings`, not
just by reading the file.

## movar.fyi/changelog would have been stale in the store note

`Deploy Marketing` fires on `apps/marketing/**`, but two pages are built from
files outside that tree, so touching one of them rebuilds nothing:

- `changelog.astro` renders `apps/extension/store-assets/RELEASE-NOTES.md`,
  read at build time through `scripts/lib/release-notes.mjs`.
- `Transparency.astro` re-derives each verified promise from the extension via
  `scripts/lib/promises.mts`, which reads `LICENSE`, `wxt.config.ts` and
  `apps/extension/package.json`.

v1.8.0 is what that cost. Its release commit touched `RELEASE-NOTES.md` and
nothing under `apps/marketing/`, so the filter never matched and
movar.fyi/changelog has sat at 1.7.0 since — while `withChangelogLink`
(`apple-submit.mjs:266`, `amo-release-notes.mjs:157`) appends a pointer to that
page to every App Store and AMO note. Submitting 1.8.0 first would have told
users to read about the release somewhere it does not appear.

Because `.github/workflows/deploy-marketing.yml` is itself in its own path
filter, merging this PR is what redeploys the site and closes the gap.

`apps/extension/src/**` is deliberately NOT listed. The promise scan does read
it, so a claim there can still go stale, but listing it would redeploy the
marketing site on essentially every extension commit — worth its own decision
rather than smuggling it in here.

## Verification

- `xcodebuild -showBuildSettings -scheme "Movar (iOS)"` resolves
  `MARKETING_VERSION = 1.8.0` / `CURRENT_PROJECT_VERSION = 1788087223`.
- `plutil -lint` clean on the project file; workflow YAML parses.
- `safari-submit.yml` in `plan` mode against 1.8.0 is green: credentials
  authenticate, both locales parse, and it reports "would create version 1.8.0"
  for IOS and MAC_OS — i.e. no stale 1.7.0 version record is in the way.
- Pre-push gate green (21 passed). Two earlier runs failed in the
  `serviceWorker` fixture's 5s storage seed under load 70-100 from unrelated
  work on the same machine; the same suite passed in 47s once the machine was
  quiet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)