### PR TITLE
fix(safari): refuse a mixed-appearance screenshot set, and say why Audit stays manual

### DIFF
--- a/apps/extension/safari/Movar/ScreenshotsUITests/ScreenshotTests.swift
+++ b/apps/extension/safari/Movar/ScreenshotsUITests/ScreenshotTests.swift
@@ -48,6 +48,23 @@ final class ScreenshotTests: XCTestCase {
 
     override func setUpWithError() throws {
         continueAfterFailure = false
+
+        // macOS turns itself dark in the evening, and the committed set is light.
+        // Capturing the other one produces a listing that is half and half — which
+        // is exactly what happened the first time this ran after sunset. There is
+        // no reliable way to pin an app's appearance from the outside:
+        // `-AppleInterfaceStyle` in NSArgumentDomain is ignored here (tried; the app
+        // came up dark regardless), so the honest move is to refuse rather than mix.
+        let wantDark = ProcessInfo.processInfo.environment["MOVAR_SHOT_APPEARANCE"] == "Dark"
+        let systemIsDark = UserDefaults.standard.string(forKey: "AppleInterfaceStyle") == "Dark"
+        let want = wantDark ? "dark" : "light"
+        let have = systemIsDark ? "dark" : "light"
+        try XCTSkipIf(
+            systemIsDark != wantDark,
+            "The system is in \(have) mode but this run wants \(want); capturing now would "
+                + "leave the listing with a mixed set. Switch the appearance in System "
+                + "Settings, or set MOVAR_SHOT_APPEARANCE=\(systemIsDark ? "Dark" : "Light").",
+        )
     }
 
     func testCaptureStoreScreenshots() throws {

--- a/apps/extension/scripts/capture-macos-screenshots.mts
+++ b/apps/extension/scripts/capture-macos-screenshots.mts
@@ -27,10 +27,18 @@
  * accepted — but anything else FAILS THE TEST rather than writing a file App
  * Store Connect would reject weeks later.
  *
- * WHAT IS STILL MANUAL. The Audit tab is captured before a run, so its detail
- * pane is empty. Filling it means actually fetching a site, and a screenshot
- * test that needs the network is a screenshot test that fails on a plane. Run
- * that scene by hand if the listing wants it.
+ * THE AUDIT SCENE IS PRE-RUN, and cannot be otherwise. Its report needs the
+ * network; the consent sheet the app raises first never enters the accessibility
+ * tree, so no test can click it; its confirm is a tinted row rather than a default
+ * button, so Return does not fire it; and `AuditModel` keeps runs in memory only,
+ * so one cannot be performed once and photographed later. Each of those is a
+ * deliberate decision in the app and none should be changed for a screenshot. A
+ * populated report has to be photographed by hand.
+ *
+ * APPEARANCE. The test refuses to run when the system appearance does not match
+ * the set being captured — macOS goes dark in the evening, and the first run after
+ * sunset produced a half-light, half-dark listing. Switch appearance in System
+ * Settings, or set MOVAR_SHOT_APPEARANCE=Dark.
  *
  * Uploading is manual too — `scripts/apple-submit.mjs` handles versions, notes,
  * compliance and submission, and no screenshots at all.
@@ -157,7 +165,11 @@ for (const locale of locales) {
   }
 
   if (written === 0) {
-    console.error(`✗ ${locale}: the run produced no attachments — did the test actually execute?`);
+    console.error(
+      `✗ ${locale}: the run produced no attachments. The usual cause is the appearance ` +
+        `guard skipping the test because the system is in the other mode — check the ` +
+        `xcodebuild output above for a skip, and see APPEARANCE in this file's header.`,
+    );
     process.exit(1);
   }
 }


### PR DESCRIPTION
Follow-up to #564, from trying to capture the Audit tab with a real report
behind it. The attempt did not succeed, and both things it turned up are worth
keeping.

## The Audit scene cannot be automated

Every reason is a deliberate decision in the app that should outlive this
attempt, so the headers now say so instead of the breezier "run that scene by
hand" they shipped with:

- The report needs the **network**, and a screenshot test that needs the network
  fails on a plane.
- The **consent sheet never enters the accessibility tree**. `app.sheets`
  matches nothing; its only trace is the application and window going
  `Disabled`. A test cannot click it.
- Its confirm is a **tinted row, not a default button**
  (`movarNeutralTint` in `PlatformSeams.swift`), so Return does not fire it.
  That is the right call — a network-consent dialog that triggers on a stray
  Return is a worse app, and it should not be changed to suit a screenshot.
- `AuditModel` is **"SESSION-SCOPED AND IN MEMORY, deliberately"** — a list of
  sites someone chose to investigate is not a neutral record — so a run cannot
  be performed once and photographed by a later launch.

Driving the click from outside the test fails too: XCUITest's own
`AutomationModeUI` overlay sits above the app for the duration and is not
something an automation tool can be granted.

## Appearance is now guarded

The reason this is a fix and not just a comment. macOS turns itself dark in the
evening, and the first run after sunset produced dark shots to sit beside the
light set committed in #564 — **silently**, because the count and the
dimensions were all correct. Worse, the stuck consent sheet also blocked the tab
switch, so `02-audit.png` and `03-settings.png` came out **byte-identical**. It
was only caught by opening one of the files.

There is no reliable way to pin an app's appearance from outside
(`-AppleInterfaceStyle` in `NSArgumentDomain` is ignored here — tried; the app
came up dark regardless), so the test now refuses rather than mixes:

```
Test skipped - The system is in dark mode but this run wants light; capturing now
would leave the listing with a mixed set. Switch the appearance in System Settings,
or set MOVAR_SHOT_APPEARANCE=Dark.
```

The runner points at that as the likely cause when a run yields no attachments.

## Reviewer notes

- **No screenshots change here.** The six committed in #564 are untouched and
  correct; the bad dark/duplicate set produced mid-investigation was discarded
  before it reached the branch.
- Verified live against a genuinely dark system — the skip above is real output,
  not a mock.
- `pnpm --filter @movar/extension typecheck` clean; the Swift parses; pre-push
  gate green (21 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)