### PR TITLE
fix(marketing): grow the mobile hero headline off the section-heading floor

### DIFF
--- a/apps/marketing/src/components/Hero.astro
+++ b/apps/marketing/src/components/Hero.astro
@@ -33,15 +33,23 @@ const claims = [
  * The text column is a fixed width only from `md` up (380px, widening to
  * the 540px design width at `lg`); below `md` it's just the full stacked
  * width. Those fixed widths are why the h1 steps down by breakpoint rather
- * than scaling fluidly: «Налаштуйте інтернет» measures 504px at 48px in
- * Fixel Display (≈10.5px of width per 1px of font-size), so each step is
- * sized against the column it actually sits in, with headroom left over
- * for font-fallback variance —
- *   - base (stacked, ~327px column at a 375px viewport): 26px → ~273px (17% headroom)
+ * than scaling fluidly: each step is sized against the column it actually
+ * sits in, with headroom left for font-fallback variance —
+ *   - base (stacked): sized by rendering line 1 at each candidate size and
+ *     checking it stays on one line, rather than a linear width estimate —
+ *     375px (~327px column) isn't the tightest common phone width; 360px
+ *     (~312px column, a common Android width) is, and needs its own check.
+ *     29px is the largest value that still fits «Налаштуйте інтернет» on one
+ *     line at 360px, confirmed under the `ui-sans-serif` fallback stack too
+ *     (30px already wraps at 360px, in-font or fallback).
  *   - md (380px column):                                  30px → ~315px (17% headroom)
  *   - lg (540px column, the desktop design size):          48px → 504px (given, 7% headroom)
  * — leaving the shorter second line ("in your language." / "на рідну
  * мову.") no way to wrap into a third line at any of the three.
+ *
+ * Below ~340px (e.g. the 320px-wide iPhone SE 1st-gen) line 1 already wraps
+ * even at the original 26px — a pre-existing gap this doesn't newly cause
+ * and doesn't attempt to close.
  */}
 <section class="overflow-hidden bg-bg px-6 py-16 md:py-20">
   <div class="mx-auto flex max-w-5xl flex-col gap-10 md:flex-row md:items-start md:gap-8 lg:gap-16">

--- a/apps/marketing/src/styles/global.css
+++ b/apps/marketing/src/styles/global.css
@@ -110,7 +110,7 @@
   --fs-micro: 10px; /* the band's ordinals, story + guide micro-labels */
   --fs-band: 13.5px; /* the dark band's body and switch labels */
   --fs-lead: 17px; /* the reader CTA's standfirst */
-  --fs-hero-sm: 26px; /* hero headline below `sm:`, where the fluid ramp starts */
+  --fs-hero-sm: 29px; /* hero headline below `sm:`, where the fluid ramp starts */
   --lh-hero: 1.1; /* the hero headline's only line-height */
   --fs-code: 0.875em; /* inline `code`, relative to its host paragraph */
 


### PR DESCRIPTION
## Summary
- `--fs-hero-sm` (the hero headline's font-size below `md:`) was 26px — 4px below the largest mobile section h2 (30px, `text-3xl`) and only 2px above the smallest, so the hero read as no more prominent than an ordinary section heading on mobile.
- Raised to 29px: the largest value that still keeps the Ukrainian first line («Налаштуйте інтернет») on one line at 360px — the tighter real-world floor (a common Android width), not the 375px the original sizing comment used. Verified by rendering each candidate size and checking actual line-wrap, not linear width estimation.
- Confirmed safe for both locales, and under the `ui-sans-serif` font-fallback stack (in case the custom font hasn't loaded yet).
- `md:`/`lg:` sizes (30px/48px, the desktop design sizes) are untouched.

## Test plan
- [x] Verified in-browser at 320/360/375px (mobile) and 1280px (desktop), both locales (uk/en), light and dark — no wrap regression, clean two-line hero at every width ≥360px.
- [x] Confirmed 320px already wrapped even at the original 26px (pre-existing, not introduced by this change).
- [x] `pnpm --filter @movar/marketing lint` clean.
- [x] No visual-regression baseline touches this: the marketing e2e suite has no viewport below the 1280×720 desktop default, so it never exercises the `--fs-hero-sm` breakpoint.
- [x] Pre-push hooks (build × 4 projects, fallow metrics) passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)