### PR TITLE
fix(marketing): give every primary install CTA its own column on mobile

### DIFF
--- a/apps/marketing/src/components/Close.astro
+++ b/apps/marketing/src/components/Close.astro
@@ -18,6 +18,13 @@
  * id (same pattern as GuideCallout.astro / GuideChecklist.astro /
  * GuideChecker.astro).
  *
+ * It also takes the Hero's `width="stretch"`, for the same reason it can't
+ * take a different target: below `sm` both are the page's one action sitting
+ * alone in one stacked column, and a button sized by whatever the detected
+ * browser's label measures gave the same phone two install buttons of two
+ * different widths. Stretched, they agree with each other and with the
+ * column. From `sm` up both revert to label width.
+ *
  * The "why this keeps happening" deep-dive link used to sit here beside the
  * install CTA. It now closes the Stakes section instead: this row's one job
  * is to get people installing, and a second link competing with the CTA at
@@ -49,7 +56,7 @@ const t = strings[lang].close;
       {t.sectionTitle}
     </h2>
     <div class="flex flex-col items-start gap-4 md:shrink-0">
-      <DownloadButtons lang={lang} align="start" anchor={false} />
+      <DownloadButtons lang={lang} align="start" anchor={false} width="stretch" />
     </div>
   </div>
 </section>

--- a/apps/marketing/src/components/DownloadButtons.astro
+++ b/apps/marketing/src/components/DownloadButtons.astro
@@ -72,9 +72,38 @@ interface Props {
    * with forest text, and the "Soon" chip has to lighten with it.
    */
   tone?: 'accent' | 'inverse';
+  /**
+   * How wide the button is on narrow screens. `stretch` fills the column below
+   * `sm` and reverts to label width from `sm` up; `auto` is label width
+   * throughout.
+   *
+   * Every CTA that is a page's own primary action stretches — Hero.astro,
+   * Close.astro and InstallGuide.astro. On a phone each is the one action
+   * alone in one stacked column, and its width is whatever the detected
+   * browser's label happens to measure: 198px ("Встановити в Edge") to 292px
+   * (the Android label) inside the same 312px column at 360px. That gave the
+   * homepage two install buttons of two different widths, and gave the same
+   * button a different width per visitor, none of them lining up with
+   * anything. Filling the column settles them all on the edge the rules, the
+   * prose and the claims list already share.
+   *
+   * `align` is unaffected: it positions the button's contents, so a stretched
+   * `center` CTA (/install) still centres its label inside the filled button.
+   *
+   * Prose callers stay `auto` — the guide's callouts and the blog panel put
+   * the button inside a paragraph's measure, where a full-bleed bar reads as a
+   * banner rather than as a control.
+   */
+  width?: 'auto' | 'stretch';
 }
 
-const { lang = 'en', align = 'center', anchor = true, tone = 'accent' } = Astro.props;
+const {
+  lang = 'en',
+  align = 'center',
+  anchor = true,
+  tone = 'accent',
+  width = 'auto',
+} = Astro.props;
 
 const TONE = {
   accent: {
@@ -88,6 +117,15 @@ const TONE = {
     soon: 'rounded-md bg-forest-900/15 px-2 py-1 text-ui-xs font-medium uppercase tracking-label text-forest-900',
   },
 } as const;
+
+/* Applied to the wrapper as well as the button: the wrapper is a flex item of
+ * the caller's row, so without a width of its own it shrinks to the label and
+ * the button has nothing to fill. */
+const WIDTH = {
+  auto: '',
+  stretch: 'w-full sm:w-auto',
+} as const;
+
 const t = strings[lang].download;
 const guideHref = localeInstallHref(lang);
 ---
@@ -95,7 +133,11 @@ const guideHref = localeInstallHref(lang);
 <div
   data-cta-root
   id={anchor ? 'download' : undefined}
-  class:list={['flex flex-col gap-4', align === 'start' ? 'items-start' : 'items-center']}
+  class:list={[
+    'flex flex-col gap-4',
+    align === 'start' ? 'items-start' : 'items-center',
+    WIDTH[width],
+  ]}
 >
   <a
     data-cta
@@ -113,6 +155,7 @@ const guideHref = localeInstallHref(lang);
     class:list={[
       'group inline-flex cursor-pointer items-center justify-center gap-2 rounded-xl border px-6 py-3 text-sm font-semibold transition',
       TONE[tone].button,
+      WIDTH[width],
     ]}
   >
     <span data-cta-label>{t.addGeneric}</span>

--- a/apps/marketing/src/components/Hero.astro
+++ b/apps/marketing/src/components/Hero.astro
@@ -67,8 +67,32 @@ const claims = [
         {t.subhead}
       </p>
 
-      <div class="mt-9 flex flex-wrap items-center gap-x-5 gap-y-3">
-        <DownloadButtons lang={lang} align="start" />
+      {/*
+       * Below `sm` the CTA and the guide link are an explicit column, not a
+       * row left to wrap. Wrapping decided this per visitor, because the pair's
+       * width is the browser label's width: in a 360px viewport's 312px column
+       * the Ukrainian labels (198-292px, plus a 112px link) never fit on one
+       * line, while the English ones (152-192px, plus a 94px link) always do —
+       * so the same hero was a row for some readers and a column for others.
+       *
+       * Worse, it changed under the reader mid-load: SSR renders the neutral
+       * "Add Movar to your browser" (249px, which wraps), and the CTA's script
+       * then swaps in "Add to Chrome" (172px, which doesn't), collapsing the
+       * block by a line and pulling everything below it up. A column can't do
+       * that — its height is the same before and after detection.
+       *
+       * `gap-5` also gives the link a step away from the button instead of the
+       * wrap's 12px, where it read as the button's caption — and on Android as
+       * a caption of the note that lands between them.
+       *
+       * From `sm` up this reproduces the previous row exactly (`gap-5` and
+       * `sm:gap-x-5` are the same 20px), so the 1280px visual baselines are
+       * untouched.
+       */}
+      <div
+        class="mt-9 flex flex-col items-start gap-5 sm:flex-row sm:flex-wrap sm:items-center sm:gap-x-5 sm:gap-y-3"
+      >
+        <DownloadButtons lang={lang} align="start" width="stretch" />
         <a href={installHref} class="text-sm font-medium text-accent-text hover:underline">
           {installLabel} →
         </a>

--- a/apps/marketing/src/components/InstallGuide.astro
+++ b/apps/marketing/src/components/InstallGuide.astro
@@ -89,8 +89,13 @@ for (const { key, flow } of flows) {
     </h1>
     <p class="mt-6 text-lg text-ink-soft">{t.intro}</p>
 
+    {/* `width="stretch"` matches the homepage's two CTAs: below `sm` this is
+        the page's one action alone in one column, and sizing it by the
+        detected browser's label left it a different width per visitor. The
+        label stays centred inside the filled button — `align` positions the
+        button's contents, not the button. */}
     <div class="mt-8">
-      <DownloadButtons lang={lang} />
+      <DownloadButtons lang={lang} width="stretch" />
     </div>
 
     {/* Browser selector — only the chosen browser's steps show (JS). */}


### PR DESCRIPTION
## What

On mobile, the three page-primary install CTAs — hero, closing CTA, `/install` — now fill their column, and the hero's CTA + "how to install" link are an explicit column instead of a `flex-wrap` row.

## Why

The install button's width **is** the detected browser's label width, so the mobile layout of every page carrying one varied by visitor. At 360px the hero's column is 312px; the button measures 198px (`Встановити в Edge`) to 292px (the Android label). Three consequences, all measured in the browser:

**1. Row-vs-column was decided by locale and browser.** The hero's CTA and its guide link sat in a wrapping row:

| | button | + link, fits 312px? |
|---|---|---|
| uk — every state | 198–292px (link 112px) | never |
| en — detected browser | 152–192px (link 94px) | always |
| en — SSR / GitHub / Android | 225–285px | never |

So the same hero was a row for an English Chrome user and a column for every Ukrainian one.

**2. It changed under the reader mid-load.** SSR renders the neutral `Add Movar to your browser` (249px → wraps); the CTA's script then swaps in `Add to Chrome` (172px → doesn't), collapsing the block by a line and pulling the claims list, the rule and the drum upward. A column holds one height across detection.

**3. The homepage showed two install buttons at two different widths** on the same phone — hero and closing CTA — neither aligned to anything.

## How

- **`DownloadButtons.astro`** gains `width?: 'auto' | 'stretch'`. `stretch` applies `w-full sm:w-auto` to both the wrapper and the button (the wrapper is a flex item of the caller's row, so without a width of its own it shrinks to the label and the button has nothing to fill).
- **`Hero.astro`**: the row becomes `flex-col items-start gap-5` below `sm`. The `gap-5` matters — the wrap left the link 12px under the button, close enough to read as its caption, and on Android as a caption of the note that lands between them.
- **`Close.astro`** and **`InstallGuide.astro`** take `width="stretch"`. `align` is unaffected: it positions the button's *contents*, so `/install`'s `align="center"` CTA still centres its label inside the filled button.
- Prose callers (`GuideCallout`, `GuideChecker`, `GuideChecklist`, `ReaderCta`) keep `auto` — inside a paragraph's measure a full-bleed bar reads as a banner rather than a control.

## For the reviewer

**No visual baselines need regenerating.** `playwright.marketing.config.ts` sets no viewport, so the baselines run at Playwright's default 1280. Every change is scoped below `sm`, and the `sm:` half reproduces the previous layout exactly (`gap-5` and `sm:gap-x-5` are both 20px; `sm:w-auto` restores label width). Measured at 1280 after the change:

| CTA | before | after |
|---|---|---|
| hero | `x=128 w=217`, link `x=365`, same line | identical |
| closing | `x=935 w=217` | identical |
| `/install` | `w=217`, centred in the 768px article | identical |

Built `dist` confirms the scope: 4 stretch classes per homepage (2 CTAs × wrapper+button), 2 per `/install`, 0 on `/for-ukrainian` and every prose caller.

**Known trade-off:** between 480–639px (large phone landscape, small tablet portrait) the buttons are now ~550px bars. Tightening that needs a breakpoint below `sm`, and `packages/theme/src/tokens.ts` declares its breakpoint set closed — so that's a token decision, not a class tweak. Flagging rather than deciding.

**Checks:** `pnpm --filter @movar/marketing lint` and `build` green (46 pages); pre-commit `astro check` clean over 101 files; pre-push build + metrics audit green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)