### PR TITLE
fix: let the install guidance use the whole card on a phone

### DIFF
--- a/apps/extension/src/entrypoints/onboarding/App.tsx
+++ b/apps/extension/src/entrypoints/onboarding/App.tsx
@@ -158,15 +158,26 @@ function OnboardingBody() {
  *  post-install guidance stay one voice. */
 function ReassuranceCard() {
   const { t } = useI18n();
+  /*
+   * Same rail treatment as the step cards above, for the same reason and by
+   * the same mechanics: the glyph pairs with the title, and below `sm` the
+   * prose and the source link start at the card's own edge instead of behind
+   * a 36px indent — which, once the steps stopped indenting theirs, would
+   * have left this the one card on the page whose text doesn't reach it.
+   * `sm:row-end-3` spans the glyph across both rows so the wide layout keeps
+   * the geometry the visual baselines hold.
+   */
   return (
-    <aside className="border-border flex items-start gap-4 rounded-xl border p-5">
+    <aside className="border-border grid grid-cols-[auto_1fr] gap-x-4 gap-y-2 rounded-xl border p-5">
       <ShieldCheck
         size={iconSize.lg}
         aria-hidden="true"
-        className="text-accent-text mt-1 shrink-0"
+        className="text-accent-text row-start-1 mt-1 sm:row-end-3"
       />
-      <div className="flex min-w-0 flex-1 flex-col gap-2">
-        <h2 className="text-base font-semibold">{t.onboarding.reassuranceTitle}</h2>
+      <h2 className="col-start-2 row-start-1 text-base font-semibold">
+        {t.onboarding.reassuranceTitle}
+      </h2>
+      <div className="col-span-2 row-start-2 flex min-w-0 flex-col gap-2 sm:col-span-1 sm:col-start-2">
         <p className="text-ink-soft text-sm">{t.onboarding.reassurance}</p>
         <a
           href={SOURCE_URL}
@@ -201,15 +212,39 @@ function StepCard({ step, index, total, flow, browserLabel, permission }: Readon
   // point at no browser UI get `null`.
   const mockup = mockupFor(flow, step.kind);
 
+  /*
+   * The icon rail runs beside the step's heading, and from `sm` up beside the
+   * whole step; below it the body takes the card's full width. This page has a
+   * phone audience for exactly one reason — Firefox for Android is the only
+   * mobile browser that installs Movar, and it opens this page in a
+   * phone-width tab right after the install — and at that width the rail cost
+   * more than the 56px (40px tile + gap) it reserves. It left the step's prose
+   * and its `@movar/browser-ui` mockup 229px of a 285px card at 375px, and
+   * because a mockup will not compress below its own min-content width while
+   * the column that holds it can't shrink past it, the pin step's mockup ran
+   * 58px past the card's edge; at 320px the step overflowed the viewport and
+   * the page scrolled sideways. `min-w-0` is what lets the mockup compress
+   * instead, and the full-width row is what leaves it room to. Same treatment
+   * as the pre-install half of this guidance (apps/marketing
+   * InstallGuide.astro).
+   *
+   * Grid rather than that page's positioned badge because the rail's width is
+   * structural here (`auto` column + `gap-x-4`) instead of a padding that
+   * would have to restate 40px + 16px as an off-ladder 56px. `sm:row-end-3`
+   * spans the tile across both rows so it can never set the heading row's
+   * height, which keeps the wide layout — the 800px the visual baselines in
+   * `apps/e2e/src/offline/onboarding.visual.spec.ts` capture — pixel-for-pixel
+   * what it was.
+   */
   return (
-    <li className="border-border bg-surface-2 flex gap-4 rounded-xl border p-5">
+    <li className="border-border bg-surface-2 grid grid-cols-[auto_1fr] gap-x-4 gap-y-2 rounded-xl border p-5">
       <span
         aria-hidden="true"
-        className="bg-surface-3 text-accent-text flex h-10 w-10 shrink-0 items-center justify-center rounded-lg"
+        className="bg-surface-3 text-accent-text row-start-1 flex h-10 w-10 items-center justify-center rounded-lg sm:row-end-3"
       >
         <Icon className="h-5 w-5" />
       </span>
-      <div className="flex flex-col gap-2">
+      <div className="col-start-2 row-start-1 flex flex-col gap-2">
         {/* Not uppercased: the Ukrainian "з" (of) in "Крок 1 з 4" reads as the
             digit 3 when capitalised ("КРОК 1 З 4"). */}
         <p className="text-ink-faint text-xs font-medium tracking-wide">
@@ -217,6 +252,8 @@ function StepCard({ step, index, total, flow, browserLabel, permission }: Readon
           {step.optional === true ? ` · ${t.onboarding.optionalBadge}` : null}
         </p>
         <h2 className="text-base font-semibold">{title}</h2>
+      </div>
+      <div className="col-span-2 row-start-2 flex min-w-0 flex-col gap-2 sm:col-span-1 sm:col-start-2">
         <p className="text-ink-soft text-sm">{body}</p>
         {mockup === null ? null : <StepIllustration mockup={mockup} locale={locale} />}
         {step.permissionAware === true ? <PermissionLine permission={permission} /> : null}

--- a/apps/marketing/src/components/InstallGuide.astro
+++ b/apps/marketing/src/components/InstallGuide.astro
@@ -147,14 +147,29 @@ for (const { key, flow } of flows) {
                 const mockup =
                   kind && installFlow ? mockupFor(installFlow, kind) : null;
                 return (
-                  <li class="flex gap-4">
+                  /*
+                   * The step number keeps its rail beside the title, but only
+                   * the title: below `sm` the prose and the browser mockup
+                   * start at the card's own edge instead. The rail is 48px
+                   * and empty under the first line — 17% of the card at
+                   * 375px, spent on nothing — and it was indenting the
+                   * mockups too, drawing a Firefox doorhanger at 229px of a
+                   * 277px card.
+                   *
+                   * The badge is positioned rather than a flex rail so the
+                   * wide layout is pixel-for-pixel what it was: out of flow
+                   * it can't set the first line's height, and the indents
+                   * (`pl-12` on the title, `sm:pl-12` on the rest) are
+                   * exactly the 32px badge + 16px gap it replaces.
+                   */
+                  <li class="relative">
                     <span
                       aria-hidden="true"
-                      class="flex size-8 shrink-0 items-center justify-center rounded-full bg-accent-surface font-display text-sm font-bold text-accent-text">
+                      class="absolute left-0 top-0 flex size-8 items-center justify-center rounded-full bg-accent-surface font-display text-sm font-bold text-accent-text">
                       {index + 1}
                     </span>
-                    <div class="min-w-0 flex-1">
-                      <h3 class="font-semibold text-ink-strong">{step.title}</h3>
+                    <h3 class="pl-12 font-semibold text-ink-strong">{step.title}</h3>
+                    <div class="sm:pl-12">
                       <p class="mt-1 text-ink-soft">{step.body}</p>
                       {mockup ? (
                         <Fragment


### PR DESCRIPTION
Both halves of Movar's install guidance — the marketing site's `/install` steps and the extension's first-run onboarding — reserved a left rail for a step marker and kept it for the full height of every step. On a phone that rail is dead width, and it was indenting the `@movar/browser-ui` mockups along with the prose.

## What changed

**`apps/marketing` — `InstallGuide.astro`.** Each step was a `flex gap-4` row: a 32px number badge plus a 16px gap, so a 48px column ran the height of the step to hold one digit. At 375px that is 17% of the card, and the Firefox doorhanger drew at 229px inside a 277px card. The badge is now `absolute left-0 top-0` inside a `relative` `<li>`, the title carries `pl-12`, and the body wrapper carries `sm:pl-12` — the rail exists only beside the title's own line, and below `sm` the prose and the mockup start at the card's edge.

**`apps/extension` — the onboarding `StepCard` and `ReassuranceCard`.** These had no narrow-screen treatment at all, and the rail there cost more than its 56px: a mockup will not compress below its own min-content width, and the column holding it had no `min-w-0` to shrink past that — so at 375px the pin step's mockup ran **58px past the card's edge**, and at 320px the step overflowed the viewport and the page scrolled sideways (`scrollWidth` 387 against a 320px layout). Both cards are now a two-column grid: the glyph takes the `auto` column, the heading sits beside it, and the body — prose, mockup, permission line, source link — is its own row that spans both columns below `sm` and returns to column two at `sm`.

## Why it matters on this page

Firefox for Android is the only mobile browser that installs Movar, and it opens the onboarding page in a phone-width tab straight after the install. The marketing `/install` page routes Android visitors to exactly that browser, so both surfaces have a real phone audience.

## No baselines need regenerating

Both suites shoot above `sm`, and the wide geometry is unchanged — measured element by element, before and after:

| Surface | Viewport | Result |
| --- | --- | --- |
| `/install`, all four flows | 1280 (marketing visual baselines) | badge `0,0,32×32`; body `x=48 y=28.8 w=670`; mockups `x=48`; `<li>` heights `53.6 / 281 / 279.5 / 293.6` — identical |
| Onboarding step cards | 800 (`onboarding.visual.spec.ts`) | card `528×371.9 / 393.2`; tile `(21,21) 40×40`; label `(77,21)`; body `(77,77) w=430`; mockup `(77,137)` — identical |
| Onboarding reassurance card | 800 | aside `528×182`; glyph `(21,25)`; h2 `(57,21)`; prose `(57,53) w=450`; link `(57,141)` — identical |

`absolute` on the marketing badge and `sm:row-end-3` on the extension's glyphs are what keep this true: out of flow, or spanning both rows, neither marker can set the heading row's height.

## Verification

- **Narrow widths** — 375px and 320px, English and Ukrainian, light and dark: nothing extends past the viewport, `scrollWidth` equals the layout width, and every mockup fits its box. Prose and mockups go from 229px to the card's full 285px (375px) / 230px (320px). The marketing breakpoint flips cleanly at exactly 640.
- **Gates** — `astro check`, eslint, prettier, marketing unit tests, `pnpm check:readme`, `nx run marketing:audit` (build + Movar Audit over `dist/`), and the extension's 1471 tests across 86 files, plus its lint and typecheck. All green, including every lefthook pre-commit gate.

## Reviewer notes

- The marketing number stays a **sibling** of the `<h3>` rather than leading it inline. An inline badge rendered the same but put the digit into the heading's text content, which `aria-hidden` hides from screen readers and from nothing else.
- The extension uses grid where marketing uses a positioned badge: there the rail is 32px + 16px = `pl-12`, an on-ladder value; here it would be 40px + 16px = an off-ladder 56px, so the `auto` column expresses it structurally instead.
- **No new test.** Neither suite covers phone-width layout — marketing shoots at 1280, onboarding at 800 — so the overflow this fixes had no guard and still has none. Happy to add a narrow-viewport assertion to the offline suite if you want one.
- The `Components/Onboarding` Storybook story renders these mockups **unstyled**: `.storybook/preview.css` never imports `@movar/browser-ui/browser-ui.css`, so the illustration expands to ~4800px tall there. I injected the stylesheet at runtime to measure truthfully; a one-line `@import` would make the story honest, but it is not in this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)